### PR TITLE
fix: remove redundant https:// in publish command

### DIFF
--- a/src/langbot_plugin/cli/commands/publish.py
+++ b/src/langbot_plugin/cli/commands/publish.py
@@ -50,7 +50,7 @@ def publish_plugin(plugin_path: str, changelog: str, access_token: str) -> None:
                 print(f"!!! Failed to publish plugin: {result['msg']}")
                 return
             
-            print(f"✅ Plugin published successfully. You can check it on https://{SERVER_URL}/market")
+            print(f"✅ Plugin published successfully. You can check it on {SERVER_URL}/market")
             return
     except Exception as e:
         print(f"!!! Failed to publish plugin: {e}")


### PR DESCRIPTION
Removed unnecessary "https://" prefix from the SERVER_URL in the publish command output, ensuring the correct URL is displayed when a plugin is published successfully.

(太好了，又shui了个pr)