### PR TITLE
feat: add i18n support for CLI output

### DIFF
--- a/src/langbot_plugin/cli/__init__.py
+++ b/src/langbot_plugin/cli/__init__.py
@@ -9,6 +9,7 @@ from langbot_plugin.cli.commands.buildplugin import build_plugin_process
 from langbot_plugin.cli.commands.login import login_process
 from langbot_plugin.cli.commands.logout import logout_process
 from langbot_plugin.cli.commands.publish import publish_process
+from langbot_plugin.cli.i18n import cli_print, t
 
 """
 Usage:
@@ -107,7 +108,7 @@ def main():
         case "help":
             parser.print_help()
         case "ver":
-            print(f"LangBot Plugin CLI v{__version__}")
+            cli_print("version_info", __version__)
         case "login":
             login_process()
         case "logout":
@@ -117,7 +118,7 @@ def main():
         case "comp":
             generate_component_process(args.component_type)
         case "run":
-            print("Running plugin in current directory")
+            cli_print("running_plugin")
             run_plugin_process(args.stdio)
         case "build":
             build_plugin_process(args.output)
@@ -126,7 +127,7 @@ def main():
         case "rt":
             runtime_app.main(args)
         case _:
-            print(f"Unknown command: {args.command}")
+            cli_print("unknown_command", args.command)
             sys.exit(1)
 
 

--- a/src/langbot_plugin/cli/__main__.py
+++ b/src/langbot_plugin/cli/__main__.py
@@ -1,0 +1,4 @@
+from langbot_plugin.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/langbot_plugin/cli/commands/buildplugin.py
+++ b/src/langbot_plugin/cli/commands/buildplugin.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List
 
 from langbot_plugin.utils.discover.engine import ComponentDiscoveryEngine
+from langbot_plugin.cli.i18n import cli_print
 
 
 def parse_gitignore(gitignore_path: str) -> List[str]:
@@ -68,10 +69,10 @@ def should_ignore(path: str, gitignore_patterns: List[str]) -> bool:
 
 def build_plugin_process(output_dir: str) -> str:
     if not os.path.exists("manifest.yaml"):
-        print("Plugin manifest not found")
+        cli_print("manifest_not_found")
         return
 
-    print(f"Building plugin to {output_dir}...")
+    cli_print("building_plugin", output_dir)
 
     # Create output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)
@@ -106,7 +107,7 @@ def build_plugin_process(output_dir: str) -> str:
                 relative_dir_path = os.path.relpath(dir_path, ".")
                 if should_ignore(relative_dir_path, gitignore_patterns):
                     dirs_to_remove.append(d)
-                    print(f"  - Skipping ignored directory: {relative_dir_path}")
+                    cli_print("skipping_ignored_dir", relative_dir_path)
             
             # Remove ignored directories
             for d in dirs_to_remove:
@@ -118,20 +119,20 @@ def build_plugin_process(output_dir: str) -> str:
                 
                 # Skip if file should be ignored
                 if should_ignore(relative_path, gitignore_patterns):
-                    print(f"  - Skipping ignored file: {relative_path}")
+                    cli_print("skipping_ignored_file", relative_path)
                     continue
                 
                 # Skip if file is in always_exclude
                 if any(fnmatch.fnmatch(file, pattern) for pattern in always_exclude):
-                    print(f"  - Skipping excluded file: {relative_path}")
+                    cli_print("skipping_excluded_file", relative_path)
                     continue
                 
                 # Add file to zip
                 try:
                     zipf.write(file_path, relative_path)
-                    print(f"  - Added: {relative_path}")
+                    cli_print("file_added", relative_path)
                 except Exception as e:
-                    print(f"  - Error adding {relative_path}: {e}")
+                    cli_print("file_add_error", relative_path, e)
 
-    print(f"Plugin built successfully: {zipfile_path}")
+    cli_print("plugin_built", zipfile_path)
     return zipfile_path

--- a/src/langbot_plugin/cli/commands/gencomponent.py
+++ b/src/langbot_plugin/cli/commands/gencomponent.py
@@ -7,24 +7,24 @@ import yaml
 from langbot_plugin.cli.gen.renderer import component_types, render_template
 from langbot_plugin.cli.utils.form import input_form_values
 from langbot_plugin.cli.gen.renderer import simple_render
+from langbot_plugin.cli.i18n import cli_print, t
 
 
 def generate_component_process(component_type: str) -> None:
     if not os.path.exists("manifest.yaml"):
-        print("!! Please run this command in the root directory of the plugin.")
-        print("!! 请在插件的根目录下运行此命令。")
+        print("!! " + t("run_in_plugin_root"))
         return
 
     component_type_obj = None
 
     for component_type_obj in component_types:
         if component_type_obj.type_name == component_type:
-            print(f"Generating component {component_type_obj.type_name}...")
+            cli_print("generating_component", component_type_obj.type_name)
             component_type_obj = component_type_obj
             break
     else:
-        print(f"!! Component type {component_type} not found.")
-        print("!! Please use one of the following component types:")
+        print("!! " + t("component_not_found", component_type))
+        print("!! " + t("available_components"))
         for component_type_obj in component_types:
             print(f"!! - {component_type_obj.type_name}")
         return
@@ -82,5 +82,4 @@ def generate_component_process(component_type: str) -> None:
     with open("manifest.yaml", "w", encoding="utf-8") as f:
         yaml.dump(manifest, f, allow_unicode=True, sort_keys=False)
 
-    print(f"Component {component_type_obj.type_name} generated successfully.")
-    print(f"组件 {component_type_obj.type_name} 生成成功。")
+    cli_print("component_generated", component_type_obj.type_name)

--- a/src/langbot_plugin/cli/commands/initplugin.py
+++ b/src/langbot_plugin/cli/commands/initplugin.py
@@ -7,6 +7,7 @@ import subprocess
 
 from langbot_plugin.cli.gen.renderer import render_template, init_plugin_files
 from langbot_plugin.cli.utils.form import input_form_values, NAME_REGEXP
+from langbot_plugin.cli.i18n import cli_print, t
 
 # Check if Git is installed
 def is_git_available() -> bool:
@@ -34,12 +35,10 @@ def init_git_repo(plugin_dir: str) -> None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
-        print(f"Initialized Git repository in {plugin_dir}")
-        print(f"初始化 Git 仓库 {plugin_dir}")
+        cli_print("git_repo_initialized", plugin_dir)
 
     except subprocess.CalledProcessError as e:
-        print(f"Warning: Failed to initialize Git repository: {e.stderr}")
-        print(f"警告：初始化 Git 仓库失败：{e.stderr}")
+        cli_print("git_init_warning", e.stderr)
 
 
 form_fields = [
@@ -73,8 +72,7 @@ def init_plugin_process(
     plugin_name: str,
 ) -> None:
     if plugin_name == "":
-        print("未指定插件名称，将在当前目录生成插件内容")
-        print("No plugin name specified, generating content in current directory")
+        cli_print("no_plugin_name")
         plugin_dir = os.getcwd()
         plugin_dir_name = os.path.basename(plugin_dir)
     else:
@@ -83,11 +81,8 @@ def init_plugin_process(
         plugin_dir_name = plugin_name
 
     if not re.match(NAME_REGEXP, plugin_dir_name):
-        print(f"!! Invalid plugin name: {plugin_dir_name}")
-        print(
-            "!! Please use a valid name, which only contains letters, numbers, underscores and hyphens."
-        )
-        print("!! 请使用一个有效的名称，只能包含字母、数字、下划线和连字符。")
+        print("!! " + t("invalid_plugin_name", plugin_dir_name))
+        print("!! " + t("invalid_name_format"))
         return
 
     # check if directory exists and is not empty
@@ -95,15 +90,13 @@ def init_plugin_process(
         # list directory contents (excluding hidden files)
         dir_contents = [f for f in os.listdir(plugin_dir) if not f.startswith('.')]
         if dir_contents: 
-            print(f"!! 目录 {plugin_dir} 不为空，请使用其他名称或清空目录")
-            print(f"!! Directory {plugin_dir} is not empty, use a different name or empty it")
+            print("!! " + t("directory_not_empty", plugin_dir))
             return
     else:
         # only create directory if a plugin name is specified and the directory does not exist
         os.makedirs(plugin_dir, exist_ok=True)
 
-    print(f"Creating plugin {plugin_dir_name}, anything you input can be modified later.")
-    print(f"创建插件 {plugin_dir_name}，任何输入都可以在之后修改。")
+    cli_print("creating_plugin", plugin_dir_name)
 
     values = {
         "plugin_name": plugin_dir_name,
@@ -119,8 +112,7 @@ def init_plugin_process(
     values["plugin_attr"] = values["plugin_name"].replace("-", "").replace("_", "")
     values["plugin_label"] = values["plugin_name"].replace("-", " ").replace("_", " ")
 
-    print(f"Creating files in {values['plugin_name']}...")
-    print(f"在 {values['plugin_name']} 中创建文件...")
+    cli_print("creating_files", values['plugin_name'])
 
     assets_dir = os.path.join(plugin_dir, "assets")
     os.makedirs(assets_dir, exist_ok=True)
@@ -136,8 +128,6 @@ def init_plugin_process(
         # init_git_repo(values["plugin_name"])
         init_git_repo(plugin_dir)
     else:
-        print("Git not found, skipping Git repository initialization.")
-        print("请确保 Git 已安装并在 PATH 中可用，跳过 Git 仓库初始化。")
+        cli_print("git_not_found")
 
-    print(f"插件 {plugin_dir_name} 创建成功（目录：{plugin_dir}）")
-    print(f"Plugin {plugin_dir_name} created successfully (directory: {plugin_dir})")
+    cli_print("plugin_created", plugin_dir_name, plugin_dir)

--- a/src/langbot_plugin/cli/commands/logout.py
+++ b/src/langbot_plugin/cli/commands/logout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from langbot_plugin.cli.i18n import cli_print
 
 
 def logout_process() -> None:
@@ -18,10 +19,10 @@ def logout_process() -> None:
         
         if config_file.exists():
             config_file.unlink()
-            print("✅ Logout successful!")
-            print(f"Configuration file removed: {config_file}")
+            cli_print("logout_successful")
+            cli_print("config_file_removed", config_file)
         else:
-            print("Already logged out - no configuration file found")
+            cli_print("already_logged_out")
             
     except Exception as e:
-        print(f"Error occurred during logout: {e}")
+        cli_print("logout_error", e)

--- a/src/langbot_plugin/cli/commands/publish.py
+++ b/src/langbot_plugin/cli/commands/publish.py
@@ -6,12 +6,10 @@ import httpx
 from langbot_plugin.cli.commands.login import check_login_status, get_access_token
 from langbot_plugin.cli.commands.buildplugin import build_plugin_process
 from langbot_plugin.cli.utils.cloudsv import get_cloud_service_url
+from langbot_plugin.cli.i18n import cli_print, t
 
 SERVER_URL = get_cloud_service_url()
 
-NOT_LOGIN_TIPS = """
-Not logged in, please login first with `lbp login`
-"""
 
 TMP_DIR = 'dist/tmp'
 
@@ -47,13 +45,13 @@ def publish_plugin(plugin_path: str, changelog: str, access_token: str) -> None:
 
             result = response.json()
             if result['code'] != 0:
-                print(f"!!! Failed to publish plugin: {result['msg']}")
+                cli_print("publish_failed", result['msg'])
                 return
             
-            print(f"✅ Plugin published successfully. You can check it on {SERVER_URL}/market")
+            cli_print("publish_successful", SERVER_URL)
             return
     except Exception as e:
-        print(f"!!! Failed to publish plugin: {e}")
+        cli_print("publish_failed", e)
         return
 
 
@@ -62,12 +60,12 @@ def publish_process() -> None:
     Implement LangBot CLI publish process
     """
     if not check_login_status():
-        print(NOT_LOGIN_TIPS)
+        cli_print("not_logged_in")
         return
     
     access_token = get_access_token()
     if not access_token:
-        print(NOT_LOGIN_TIPS)
+        cli_print("not_logged_in")
         return
     
     # build plugin

--- a/src/langbot_plugin/cli/commands/runplugin.py
+++ b/src/langbot_plugin/cli/commands/runplugin.py
@@ -6,6 +6,7 @@ import dotenv
 
 from langbot_plugin.utils.discover.engine import ComponentDiscoveryEngine
 from langbot_plugin.cli.run.controller import PluginRuntimeController
+from langbot_plugin.cli.i18n import cli_print
 
 
 async def arun_plugin_process(stdio: bool = False) -> None:
@@ -15,7 +16,7 @@ async def arun_plugin_process(stdio: bool = False) -> None:
     discovery_engine = ComponentDiscoveryEngine()
 
     if not os.path.exists("manifest.yaml"):
-        print("Plugin manifest not found")
+        cli_print("manifest_not_found")
         return
 
     plugin_manifest = discovery_engine.load_component_manifest(
@@ -25,7 +26,7 @@ async def arun_plugin_process(stdio: bool = False) -> None:
     )
 
     if plugin_manifest is None:
-        print("Plugin manifest not found")
+        cli_print("manifest_not_found")
         return
 
     ws_debug_url = ""
@@ -33,7 +34,7 @@ async def arun_plugin_process(stdio: bool = False) -> None:
     if not stdio:
         ws_debug_url = os.getenv("DEBUG_RUNTIME_WS_URL", "")
         if ws_debug_url == "":
-            print("DEBUG_RUNTIME_WS_URL is not set in .env file")
+            cli_print("debug_url_not_set")
             return
 
     # discover components
@@ -63,8 +64,8 @@ def run_plugin_process(stdio: bool = False) -> None:
     try:
         asyncio.run(arun_plugin_process(stdio))
     except asyncio.CancelledError:
-        print("Plugin process cancelled")
+        cli_print("plugin_process_cancelled")
         return
     except KeyboardInterrupt:
-        print("Keyboard interrupt, exiting...")
+        cli_print("keyboard_interrupt")
         return

--- a/src/langbot_plugin/cli/i18n.py
+++ b/src/langbot_plugin/cli/i18n.py
@@ -36,8 +36,10 @@ class I18nManager:
             locale_lower = locale_str.lower()
             if 'zh' in locale_lower and ('cn' in locale_lower or 'hans' in locale_lower):
                 return 'zh_Hans'
-            elif 'zh' in locale_lower and ('tw' in locale_lower or 'hk' in locale_lower or 'mo' in locale_lower):
+            elif 'zh' in locale_lower and ('tw' in locale_lower or 'hk' in locale_lower or 'mo' in locale_lower or 'hant' in locale_lower):
                 return 'zh_Hant'
+            elif locale_lower.startswith('ja') or 'japan' in locale_lower:
+                return 'ja_JP'
             elif locale_lower.startswith('en'):
                 return 'en_US'
         

--- a/src/langbot_plugin/cli/i18n.py
+++ b/src/langbot_plugin/cli/i18n.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import locale
+import os
+from typing import Dict, Any
+
+from .locales import get_locale_messages, SUPPORTED_LOCALES
+
+
+class I18nManager:
+    """国际化管理器 / Internationalization Manager"""
+    
+    def __init__(self):
+        self._current_locale = self._detect_locale()
+        self._messages = get_locale_messages(self._current_locale)
+    
+    def _detect_locale(self) -> str:
+        """检测系统语言环境 / Detect system locale"""
+        # 检查环境变量
+        lang = os.environ.get('LANG', '')
+        lc_all = os.environ.get('LC_ALL', '')
+        lc_messages = os.environ.get('LC_MESSAGES', '')
+        
+        # 优先级：LC_ALL > LC_MESSAGES > LANG
+        locale_str = lc_all or lc_messages or lang
+        
+        # 如果环境变量没有设置，使用系统locale
+        if not locale_str:
+            try:
+                locale_str = locale.getlocale()[0] or locale.getdefaultlocale()[0] or ''
+            except:
+                locale_str = ''
+        
+        # 根据locale字符串判断语言
+        if locale_str:
+            locale_lower = locale_str.lower()
+            if 'zh' in locale_lower and ('cn' in locale_lower or 'hans' in locale_lower):
+                return 'zh_Hans'
+            elif 'zh' in locale_lower and ('tw' in locale_lower or 'hk' in locale_lower or 'mo' in locale_lower):
+                return 'zh_Hant'
+            elif locale_lower.startswith('en'):
+                return 'en_US'
+        
+        # 默认返回英文
+        return 'en_US'
+    
+    def get_message(self, key: str, *args) -> str:
+        """获取本地化消息 / Get localized message"""
+        message = self._messages.get(key, key)
+        
+        if args:
+            try:
+                return message.format(*args)
+            except:
+                return message
+        return message
+    
+    def set_locale(self, locale: str) -> None:
+        """设置语言环境 / Set locale"""
+        if locale in SUPPORTED_LOCALES:
+            self._current_locale = locale
+            self._messages = get_locale_messages(locale)
+    
+    def get_current_locale(self) -> str:
+        """获取当前语言环境 / Get current locale"""
+        return self._current_locale
+
+
+# 全局i18n管理器实例
+_i18n_manager = I18nManager()
+
+
+def t(key: str, *args) -> str:
+    """翻译函数快捷方式 / Translation function shortcut"""
+    return _i18n_manager.get_message(key, *args)
+
+
+def set_locale(locale: str) -> None:
+    """设置语言环境快捷方式 / Set locale shortcut"""
+    _i18n_manager.set_locale(locale)
+
+
+def get_current_locale() -> str:
+    """获取当前语言环境快捷方式 / Get current locale shortcut"""
+    return _i18n_manager.get_current_locale()
+
+
+def cli_print(key: str, *args) -> None:
+    """CLI打印函数，只输出单一语言 / CLI print function, outputs single language only"""
+    print(t(key, *args))

--- a/src/langbot_plugin/cli/locales/__init__.py
+++ b/src/langbot_plugin/cli/locales/__init__.py
@@ -1,0 +1,12 @@
+"""Localization support for LangBot Plugin CLI"""
+
+from . import en_US, zh_Hans
+
+SUPPORTED_LOCALES = {
+    'en_US': en_US.messages,
+    'zh_Hans': zh_Hans.messages,
+}
+
+def get_locale_messages(locale: str) -> dict:
+    """Get messages for a specific locale"""
+    return SUPPORTED_LOCALES.get(locale, SUPPORTED_LOCALES['en_US'])

--- a/src/langbot_plugin/cli/locales/__init__.py
+++ b/src/langbot_plugin/cli/locales/__init__.py
@@ -1,10 +1,12 @@
 """Localization support for LangBot Plugin CLI"""
 
-from . import en_US, zh_Hans
+from . import en_US, zh_Hans, zh_Hant, ja_JP
 
 SUPPORTED_LOCALES = {
     'en_US': en_US.messages,
     'zh_Hans': zh_Hans.messages,
+    'zh_Hant': zh_Hant.messages,
+    'ja_JP': ja_JP.messages,
 }
 
 def get_locale_messages(locale: str) -> dict:

--- a/src/langbot_plugin/cli/locales/en_US.py
+++ b/src/langbot_plugin/cli/locales/en_US.py
@@ -1,0 +1,79 @@
+"""English (US) translations for LangBot Plugin CLI"""
+
+messages = {
+    # General messages
+    'version_info': 'LangBot Plugin CLI v{}',
+    'unknown_command': 'Unknown command: {}',
+    'running_plugin': 'Running plugin in current directory',
+    
+    # Plugin initialization
+    'no_plugin_name': 'No plugin name specified, generating content in current directory',
+    'invalid_plugin_name': 'Invalid plugin name: {}',
+    'invalid_name_format': 'Please use a valid name, which only contains letters, numbers, underscores and hyphens.',
+    'directory_not_empty': 'Directory {} is not empty, use a different name or empty it',
+    'creating_plugin': 'Creating plugin {}, anything you input can be modified later.',
+    'creating_files': 'Creating files in {}...',
+    'git_repo_initialized': 'Initialized Git repository in {}',
+    'git_init_warning': 'Warning: Failed to initialize Git repository: {}',
+    'git_not_found': 'Git not found, skipping Git repository initialization.',
+    'plugin_created': 'Plugin {} created successfully (directory: {})',
+    
+    # Component generation
+    'run_in_plugin_root': 'Please run this command in the root directory of the plugin.',
+    'generating_component': 'Generating component {}...',
+    'component_not_found': 'Component type {} not found.',
+    'available_components': 'Please use one of the following component types:',
+    'component_generated': 'Component {} generated successfully.',
+    
+    # Build
+    'manifest_not_found': 'Plugin manifest not found',
+    'building_plugin': 'Building plugin to {}...',
+    'skipping_ignored_dir': '  - Skipping ignored directory: {}',
+    'skipping_ignored_file': '  - Skipping ignored file: {}',
+    'skipping_excluded_file': '  - Skipping excluded file: {}',
+    'file_added': '  - Added: {}',
+    'file_add_error': '  - Error adding {}: {}',
+    'plugin_built': 'Plugin built successfully: {}',
+    
+    # Login
+    'starting_login': 'Starting LangBot CLI login process...',
+    'generating_device_code': 'Generating device code...',
+    'device_code_failed': 'Failed to generate device code: {}',
+    'copy_user_code': 'Please copy the user code and complete verification in your browser:',
+    'user_code_label': 'User Code: {}',
+    'verification_url_label': 'Verification URL: {}',
+    'code_expires_label': 'Device code expires in: {} seconds',
+    'waiting_verification': 'Waiting for verification...',
+    'login_timeout': 'Login timeout or failed, please try again',
+    'login_successful': '✅ Login successful!',
+    'token_saved': 'Access token saved to: {}',
+    'token_type_label': 'Token type: {}',
+    'expires_in_label': 'Expires in: {} seconds',
+    'login_cancelled': 'Login cancelled',
+    'login_error': 'Error occurred during login: {}',
+    'network_request_failed': 'Network request failed: {}',
+    'token_get_failed': 'Failed to get token: {}',
+    'token_check_failed': 'Failed to check token status: {}',
+    'token_refresh_failed': 'Failed to refresh token: {}',
+    
+    # Form
+    'invalid_format_error': 'Invalid plugin author, please use a valid name, which only contains letters, numbers, underscores and hyphens.',
+    'plugin_author': 'Plugin author',
+    'plugin_description': 'Plugin description',
+    
+    # Runtime
+    'plugin_process_cancelled': 'Plugin process cancelled',
+    'keyboard_interrupt': 'Keyboard interrupt, exiting...',
+    'debug_url_not_set': 'DEBUG_RUNTIME_WS_URL is not set in .env file',
+    
+    # Logout
+    'logout_successful': '✅ Logout successful!',
+    'config_file_removed': 'Configuration file removed: {}',
+    'already_logged_out': 'Already logged out - no configuration file found',
+    'logout_error': 'Error occurred during logout: {}',
+    
+    # Publish
+    'not_logged_in': 'Not logged in, please login first with `lbp login`',
+    'publish_failed': '!!! Failed to publish plugin: {}',
+    'publish_successful': '✅ Plugin published successfully. You can check it on {}/market',
+}

--- a/src/langbot_plugin/cli/locales/ja_JP.py
+++ b/src/langbot_plugin/cli/locales/ja_JP.py
@@ -1,0 +1,79 @@
+"""日本語翻訳 for LangBot Plugin CLI"""
+
+messages = {
+    # 一般メッセージ
+    'version_info': 'LangBot Plugin CLI v{}',
+    'unknown_command': '不明なコマンド：{}',
+    'running_plugin': '現在のディレクトリでプラグインを実行中',
+    
+    # プラグイン初期化
+    'no_plugin_name': 'プラグイン名が指定されていません。現在のディレクトリにプラグインコンテンツを生成します',
+    'invalid_plugin_name': '無効なプラグイン名：{}',
+    'invalid_name_format': '有効な名前を使用してください。文字、数字、アンダースコア、ハイフンのみ使用できます。',
+    'directory_not_empty': 'ディレクトリ {} は空ではありません。別の名前を使用するか、ディレクトリを空にしてください',
+    'creating_plugin': 'プラグイン {} を作成中です。入力内容は後で変更できます。',
+    'creating_files': '{} にファイルを作成中...',
+    'git_repo_initialized': 'Git リポジトリを {} に初期化しました',
+    'git_init_warning': '警告：Git リポジトリの初期化に失敗しました：{}',
+    'git_not_found': 'Git が見つかりません。Git リポジトリの初期化をスキップします。',
+    'plugin_created': 'プラグイン {} の作成が完了しました（ディレクトリ：{}）',
+    
+    # コンポーネント生成
+    'run_in_plugin_root': 'プラグインのルートディレクトリでこのコマンドを実行してください。',
+    'generating_component': 'コンポーネント {} を生成中...',
+    'component_not_found': 'コンポーネントタイプ {} が見つかりません。',
+    'available_components': '以下のコンポーネントタイプのいずれかを使用してください：',
+    'component_generated': 'コンポーネント {} の生成が完了しました。',
+    
+    # ビルド
+    'manifest_not_found': 'プラグインマニフェストが見つかりません',
+    'building_plugin': 'プラグインを {} にビルド中...',
+    'skipping_ignored_dir': '  - 無視されたディレクトリをスキップ：{}',
+    'skipping_ignored_file': '  - 無視されたファイルをスキップ：{}',
+    'skipping_excluded_file': '  - 除外されたファイルをスキップ：{}',
+    'file_added': '  - 追加済み：{}',
+    'file_add_error': '  - ファイル {} の追加エラー：{}',
+    'plugin_built': 'プラグインビルドが完了しました：{}',
+    
+    # ログイン
+    'starting_login': 'LangBot CLI ログイン処理を開始中...',
+    'generating_device_code': 'デバイスコードを生成中...',
+    'device_code_failed': 'デバイスコードの生成に失敗しました：{}',
+    'copy_user_code': 'ユーザーコードをコピーしてブラウザで認証を完了してください：',
+    'user_code_label': 'ユーザーコード：{}',
+    'verification_url_label': '認証URL：{}',
+    'code_expires_label': 'デバイスコードは {} 秒後に期限切れになります',
+    'waiting_verification': '認証待ち中...',
+    'login_timeout': 'ログインがタイムアウトまたは失敗しました。再試行してください',
+    'login_successful': '✅ ログイン成功！',
+    'token_saved': 'アクセストークンを保存しました：{}',
+    'token_type_label': 'トークンタイプ：{}',
+    'expires_in_label': '{} 秒後に期限切れ',
+    'login_cancelled': 'ログインがキャンセルされました',
+    'login_error': 'ログイン中にエラーが発生しました：{}',
+    'network_request_failed': 'ネットワークリクエストが失敗しました：{}',
+    'token_get_failed': 'トークンの取得に失敗しました：{}',
+    'token_check_failed': 'トークン状態の確認に失敗しました：{}',
+    'token_refresh_failed': 'トークンの更新に失敗しました：{}',
+    
+    # フォーム
+    'invalid_format_error': '無効なプラグイン作者です。文字、数字、アンダースコア、ハイフンのみを含む有効な名前を使用してください。',
+    'plugin_author': 'プラグイン作者',
+    'plugin_description': 'プラグインの説明',
+    
+    # ランタイム
+    'plugin_process_cancelled': 'プラグインプロセスがキャンセルされました',
+    'keyboard_interrupt': 'キーボード割り込み、終了中...',
+    'debug_url_not_set': '.env ファイルに DEBUG_RUNTIME_WS_URL が設定されていません',
+    
+    # ログアウト
+    'logout_successful': '✅ ログアウト成功！',
+    'config_file_removed': '設定ファイルを削除しました：{}',
+    'already_logged_out': '既にログアウトしています - 設定ファイルが見つかりません',
+    'logout_error': 'ログアウト中にエラーが発生しました：{}',
+    
+    # 公開
+    'not_logged_in': 'ログインしていません。先に `lbp login` でログインしてください',
+    'publish_failed': '!!! プラグインの公開に失敗しました：{}',
+    'publish_successful': '✅ プラグインの公開が完了しました。{}/market で確認できます',
+}

--- a/src/langbot_plugin/cli/locales/zh_Hans.py
+++ b/src/langbot_plugin/cli/locales/zh_Hans.py
@@ -2,7 +2,7 @@
 
 messages = {
     # 通用消息
-    'version_info': 'LangBot 插件 CLI v{}',
+    'version_info': 'LangBot Plugin CLI v{}',
     'unknown_command': '未知命令：{}',
     'running_plugin': '在当前目录运行插件',
     

--- a/src/langbot_plugin/cli/locales/zh_Hans.py
+++ b/src/langbot_plugin/cli/locales/zh_Hans.py
@@ -1,0 +1,79 @@
+"""简体中文翻译 for LangBot Plugin CLI"""
+
+messages = {
+    # 通用消息
+    'version_info': 'LangBot 插件 CLI v{}',
+    'unknown_command': '未知命令：{}',
+    'running_plugin': '在当前目录运行插件',
+    
+    # 插件初始化
+    'no_plugin_name': '未指定插件名称，将在当前目录生成插件内容',
+    'invalid_plugin_name': '无效的插件名称：{}',
+    'invalid_name_format': '请使用一个有效的名称，只能包含字母、数字、下划线和连字符。',
+    'directory_not_empty': '目录 {} 不为空，请使用其他名称或清空目录',
+    'creating_plugin': '创建插件 {}，任何输入都可以在之后修改。',
+    'creating_files': '在 {} 中创建文件...',
+    'git_repo_initialized': '初始化 Git 仓库 {}',
+    'git_init_warning': '警告：初始化 Git 仓库失败：{}',
+    'git_not_found': '请确保 Git 已安装并在 PATH 中可用，跳过 Git 仓库初始化。',
+    'plugin_created': '插件 {} 创建成功（目录：{}）',
+    
+    # 组件生成
+    'run_in_plugin_root': '请在插件的根目录下运行此命令。',
+    'generating_component': '正在生成组件 {}...',
+    'component_not_found': '未找到组件类型 {}。',
+    'available_components': '请使用以下组件类型之一：',
+    'component_generated': '组件 {} 生成成功。',
+    
+    # 构建
+    'manifest_not_found': '未找到插件清单文件',
+    'building_plugin': '正在构建插件到 {}...',
+    'skipping_ignored_dir': '  - 跳过忽略的目录：{}',
+    'skipping_ignored_file': '  - 跳过忽略的文件：{}',
+    'skipping_excluded_file': '  - 跳过排除的文件：{}',
+    'file_added': '  - 已添加：{}',
+    'file_add_error': '  - 添加文件 {} 时出错：{}',
+    'plugin_built': '插件构建成功：{}',
+    
+    # 登录
+    'starting_login': '正在启动 LangBot CLI 登录流程...',
+    'generating_device_code': '正在生成设备代码...',
+    'device_code_failed': '生成设备代码失败：{}',
+    'copy_user_code': '请复制用户代码并在浏览器中完成验证：',
+    'user_code_label': '用户代码：{}',
+    'verification_url_label': '验证网址：{}',
+    'code_expires_label': '设备代码将在 {} 秒后过期',
+    'waiting_verification': '等待验证中...',
+    'login_timeout': '登录超时或失败，请重试',
+    'login_successful': '✅ 登录成功！',
+    'token_saved': '访问令牌已保存到：{}',
+    'token_type_label': '令牌类型：{}',
+    'expires_in_label': '将在 {} 秒后过期',
+    'login_cancelled': '登录已取消',
+    'login_error': '登录过程中发生错误：{}',
+    'network_request_failed': '网络请求失败：{}',
+    'token_get_failed': '获取令牌失败：{}',
+    'token_check_failed': '检查令牌状态失败：{}',
+    'token_refresh_failed': '刷新令牌失败：{}',
+    
+    # 表单
+    'invalid_format_error': '无效的插件作者，请使用一个有效的名称，只能包含字母、数字、下划线和连字符。',
+    'plugin_author': '插件作者',
+    'plugin_description': '插件描述',
+    
+    # 运行时
+    'plugin_process_cancelled': '插件进程已取消',
+    'keyboard_interrupt': '键盘中断，正在退出...',
+    'debug_url_not_set': '.env 文件中未设置 DEBUG_RUNTIME_WS_URL',
+    
+    # 登出
+    'logout_successful': '✅ 登出成功！',
+    'config_file_removed': '配置文件已删除：{}',
+    'already_logged_out': '已经登出 - 未找到配置文件',
+    'logout_error': '登出过程中发生错误：{}',
+    
+    # 发布
+    'not_logged_in': '未登录，请先使用 `lbp login` 登录',
+    'publish_failed': '!!! 插件发布失败：{}',
+    'publish_successful': '✅ 插件发布成功。你可以在 {}/market 查看',
+}

--- a/src/langbot_plugin/cli/locales/zh_Hant.py
+++ b/src/langbot_plugin/cli/locales/zh_Hant.py
@@ -1,0 +1,79 @@
+"""繁體中文翻譯 for LangBot Plugin CLI"""
+
+messages = {
+    # 通用訊息
+    'version_info': 'LangBot Plugin CLI v{}',
+    'unknown_command': '未知指令：{}',
+    'running_plugin': '在目前目錄執行插件',
+    
+    # 插件初始化
+    'no_plugin_name': '未指定插件名稱，將在目前目錄產生插件內容',
+    'invalid_plugin_name': '無效的插件名稱：{}',
+    'invalid_name_format': '請使用一個有效的名稱，只能包含字母、數字、底線和連字符。',
+    'directory_not_empty': '目錄 {} 不是空的，請使用其他名稱或清空目錄',
+    'creating_plugin': '建立插件 {}，任何輸入都可以在之後修改。',
+    'creating_files': '在 {} 中建立檔案...',
+    'git_repo_initialized': '初始化 Git 倉庫 {}',
+    'git_init_warning': '警告：初始化 Git 倉庫失敗：{}',
+    'git_not_found': '請確保 Git 已安裝並在 PATH 中可用，跳過 Git 倉庫初始化。',
+    'plugin_created': '插件 {} 建立成功（目錄：{}）',
+    
+    # 組件產生
+    'run_in_plugin_root': '請在插件的根目錄下執行此指令。',
+    'generating_component': '正在產生組件 {}...',
+    'component_not_found': '未找到組件類型 {}。',
+    'available_components': '請使用以下組件類型之一：',
+    'component_generated': '組件 {} 產生成功。',
+    
+    # 建置
+    'manifest_not_found': '未找到插件清單檔案',
+    'building_plugin': '正在建置插件到 {}...',
+    'skipping_ignored_dir': '  - 跳過忽略的目錄：{}',
+    'skipping_ignored_file': '  - 跳過忽略的檔案：{}',
+    'skipping_excluded_file': '  - 跳過排除的檔案：{}',
+    'file_added': '  - 已新增：{}',
+    'file_add_error': '  - 新增檔案 {} 時出錯：{}',
+    'plugin_built': '插件建置成功：{}',
+    
+    # 登入
+    'starting_login': '正在啟動 LangBot CLI 登入流程...',
+    'generating_device_code': '正在產生裝置代碼...',
+    'device_code_failed': '產生裝置代碼失敗：{}',
+    'copy_user_code': '請複製使用者代碼並在瀏覽器中完成驗證：',
+    'user_code_label': '使用者代碼：{}',
+    'verification_url_label': '驗證網址：{}',
+    'code_expires_label': '裝置代碼將在 {} 秒後過期',
+    'waiting_verification': '等待驗證中...',
+    'login_timeout': '登入逾時或失敗，請重試',
+    'login_successful': '✅ 登入成功！',
+    'token_saved': '存取權杖已儲存到：{}',
+    'token_type_label': '權杖類型：{}',
+    'expires_in_label': '將在 {} 秒後過期',
+    'login_cancelled': '登入已取消',
+    'login_error': '登入過程中發生錯誤：{}',
+    'network_request_failed': '網路請求失敗：{}',
+    'token_get_failed': '取得權杖失敗：{}',
+    'token_check_failed': '檢查權杖狀態失敗：{}',
+    'token_refresh_failed': '更新權杖失敗：{}',
+    
+    # 表單
+    'invalid_format_error': '無效的插件作者，請使用一個有效的名稱，只能包含字母、數字、底線和連字符。',
+    'plugin_author': '插件作者',
+    'plugin_description': '插件描述',
+    
+    # 執行時
+    'plugin_process_cancelled': '插件程序已取消',
+    'keyboard_interrupt': '鍵盤中斷，正在退出...',
+    'debug_url_not_set': '.env 檔案中未設定 DEBUG_RUNTIME_WS_URL',
+    
+    # 登出
+    'logout_successful': '✅ 登出成功！',
+    'config_file_removed': '設定檔已刪除：{}',
+    'already_logged_out': '已經登出 - 未找到設定檔',
+    'logout_error': '登出過程中發生錯誤：{}',
+    
+    # 發布
+    'not_logged_in': '未登入，請先使用 `lbp login` 登入',
+    'publish_failed': '!!! 插件發布失敗：{}',
+    'publish_successful': '✅ 插件發布成功。你可以在 {}/market 查看',
+}

--- a/src/langbot_plugin/cli/utils/form.py
+++ b/src/langbot_plugin/cli/utils/form.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import re
+from langbot_plugin.cli.i18n import t
 
 
 NAME_REGEXP = r"^[a-zA-Z0-9_-]+$"
@@ -16,16 +17,36 @@ def input_form_values(
     for field in form_fields:
         if field["required"]:
             while True:
-                value = input(f"{field['label']['en_US']}: ")  # type: ignore
+                # 检查是否是内置字段类型，使用i18n消息
+                if field["name"] == "plugin_author":
+                    label = t("plugin_author")
+                elif field["name"] == "plugin_description":
+                    label = t("plugin_description")
+                else:
+                    label = field.get('label', {}).get('en_US', field["name"])  # type: ignore
+                
+                value = input(f"{label}: ")
                 if "format" in field and "regexp" in field["format"]:  # type: ignore
                     if not re.match(field["format"]["regexp"], value):  # type: ignore
-                        print(f"!! {field['format']['error']['en_US']}")  # type: ignore
-                        print(f"!! {field['format']['error']['zh_Hans']}")  # type: ignore
+                        # 对于内置错误消息使用i18n
+                        if field["name"] == "plugin_author":
+                            print("!! " + t("invalid_format_error"))
+                        else:
+                            # 如果不是内置字段，显示英文错误（向后兼容）
+                            print(f"!! {field['format']['error']['en_US']}")  # type: ignore
                         continue
                 break
             values[field["name"]] = value  # type: ignore
         else:
-            value = input(f"{field['label']['en_US']}: ")  # type: ignore
+            # 检查是否是内置字段类型，使用i18n消息
+            if field["name"] == "plugin_author":
+                label = t("plugin_author")
+            elif field["name"] == "plugin_description":
+                label = t("plugin_description")
+            else:
+                label = field.get('label', {}).get('en_US', field["name"])  # type: ignore
+                
+            value = input(f"{label}: ")
             values[field["name"]] = value  # type: ignore
 
     return values


### PR DESCRIPTION
- Create i18n system with modular language files for en_US and zh_Hans
- Implement automatic system locale detection (supports Chinese and English)
- Replace all CLI print statements with localized messages
- Add single-language output based on user's system locale
- Create language-specific message files following React i18n structure
- Add __main__.py to make CLI module directly executable

🤖 Generated with [Claude Code](https://claude.ai/code)