### PR TITLE
refactor(rag): remove redundant builtin fields, unify settings via schema

### DIFF
--- a/src/langbot_plugin/api/entities/builtin/rag/__init__.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/__init__.py
@@ -34,7 +34,6 @@ from .errors import (
 # Context and retrieval types
 from .context import (
     RetrievalResultEntry,
-    RetrievalConfig,
     RetrievalContext,
     RetrievalResponse,
 )
@@ -61,7 +60,6 @@ __all__ = [
     "ChunkingError",
     # Context
     "RetrievalResultEntry",
-    "RetrievalConfig",
     "RetrievalContext",
     "RetrievalResponse",
 ]

--- a/src/langbot_plugin/api/entities/builtin/rag/context.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/context.py
@@ -26,25 +26,6 @@ class RetrievalResultEntry(pydantic.BaseModel):
     """Optional similarity score (higher is more similar)."""
 
 
-class RetrievalConfig(pydantic.BaseModel):
-    """Configuration for retrieval operations."""
-
-    top_k: int = Field(default=5, ge=1, le=100)
-    """Number of results to retrieve."""
-
-    similarity_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
-    """Minimum similarity score threshold."""
-
-    rerank: bool = Field(default=False)
-    """Whether to apply reranking."""
-
-    rerank_top_k: int | None = Field(default=None, ge=1)
-    """Number of results after reranking."""
-
-    custom_settings: dict[str, Any] = Field(default_factory=dict)
-    """Plugin-specific retrieval settings."""
-
-
 class RetrievalContext(pydantic.BaseModel):
     """The retrieval context."""
 
@@ -52,31 +33,22 @@ class RetrievalContext(pydantic.BaseModel):
     """The query."""
 
     top_k: int = pydantic.Field(default=5)
-    """The top k (legacy field, kept for backward compatibility)."""
+    """The top k."""
 
-    # ========== New fields for enhanced retrieval ==========
     knowledge_base_id: str | None = None
     """Knowledge base to search in."""
 
     collection_id: str | None = None
     """Target vector collection ID. Defaults to knowledge_base_id if not set."""
 
-    config: RetrievalConfig | None = None
-    """New-style retrieval configuration."""
+    retrieval_settings: dict[str, Any] = Field(default_factory=dict)
+    """Plugin-specific retrieval settings."""
 
     creation_settings: dict[str, Any] = Field(default_factory=dict)
     """Creation settings of the knowledge base (e.g. API keys)."""
 
     filters: dict[str, Any] = Field(default_factory=dict)
     """Metadata filters for retrieval."""
-
-    def get_top_k(self) -> int:
-        """Get top_k value, supporting both old and new config styles.
-
-        Returns:
-            The top_k value from config if available, otherwise from legacy field.
-        """
-        return self.config.top_k if self.config else self.top_k
 
     def get_collection_id(self) -> str:
         """Get the collection ID, falling back to knowledge_base_id.

--- a/src/langbot_plugin/api/entities/builtin/rag/models.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/models.py
@@ -75,16 +75,7 @@ class IngestionContext(pydantic.BaseModel):
     collection_id: str | None = None
     """Target vector collection ID. Defaults to knowledge_base_id if not set."""
 
-    chunking_strategy: str | None = None
-    """Chunking strategy to use. Determined by plugin if not provided. Plugin authors should define their own strategies via config schema."""
-
-    chunk_size: int | None = None
-    """Target chunk size (characters or tokens, strategy-dependent). Determined by plugin if not provided."""
-
-    chunk_overlap: int | None = None
-    """Overlap between chunks. Determined by plugin if not provided."""
-
-    custom_settings: dict[str, Any] = Field(default_factory=dict)
+    creation_settings: dict[str, Any] = Field(default_factory=dict)
     """Plugin-specific ingestion settings (from knowledge base creation_settings)."""
 
     def get_collection_id(self) -> str:

--- a/src/langbot_plugin/assets/templates/components/rag_engine/{rag_engine_name}.py.example
+++ b/src/langbot_plugin/assets/templates/components/rag_engine/{rag_engine_name}.py.example
@@ -117,7 +117,7 @@ class {{ rag_engine_attr }}(RAGEngine):
         # results = await self.plugin.vector_search(
         #     collection_id=context.get_collection_id(),
         #     query_vector=query_embedding,
-        #     top_k=context.get_top_k(),
+        #     top_k=context.top_k,
         # )
 
         # 3. Build response


### PR DESCRIPTION
## Summary
- Remove `RetrievalConfig` class — all retrieval parameters (`top_k`, `similarity_threshold`, `rerank`, etc.) can be covered by `retrieval_settings_schema` via `retrieval_settings` dict
- Remove `IngestionContext` redundant fields (`chunking_strategy`, `chunk_size`, `chunk_overlap`) — all ingestion parameters can be covered by `creation_schema` via `creation_settings` dict
- Rename `IngestionContext.custom_settings` → `creation_settings` and add `RetrievalContext.retrieval_settings` to align field names with the host side

## Test plan
- [ ] Verify existing RAG plugins still compile against updated SDK
- [ ] Verify host-side `retrieval_context` dict keys match new `RetrievalContext` fields
- [ ] Verify host-side `ingestion_context` dict keys match new `IngestionContext` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)