### PR TITLE
bugfix

### DIFF
--- a/src/langbot_plugin/entities/io/errors.py
+++ b/src/langbot_plugin/entities/io/errors.py
@@ -21,6 +21,33 @@ class ActionCallTimeoutError(Exception):
         return self.message
 
 
+class DependencyInstallError(Exception):
+    """依赖安装失败"""
+
+    def __init__(self, package: str, returncode: int, stderr: str):
+        self.package = package
+        self.returncode = returncode
+        self.stderr = stderr
+        super().__init__(f"Failed to install {package}: {stderr}")
+
+    def __str__(self):
+        return f"Failed to install {self.package}: {self.stderr}"
+
+
+class DependencyVerificationError(Exception):
+    """依赖验证失败"""
+
+    def __init__(self, missing: list[str], version_mismatch: list[str] = None):
+        self.missing = missing
+        self.version_mismatch = version_mismatch or []
+        super().__init__(
+            f"Missing dependencies: {missing}, Version mismatch: {self.version_mismatch}"
+        )
+
+    def __str__(self):
+        return f"Missing dependencies: {self.missing}, Version mismatch: {self.version_mismatch}"
+
+
 class ActionCallError(Exception):
     """The action call failed."""
 

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.util
 import re
 import subprocess
 import sys
@@ -127,3 +128,111 @@ def _parse_downloaded_bytes(output: str) -> int:
             else:
                 total += int(val)
     return total
+
+
+async def verify_dependencies(deps: list[str]) -> list[str]:
+    """验证依赖是否真正安装成功
+
+    Args:
+        deps: 依赖列表，格式如 ['package==1.0.0', 'package>=2.0']
+
+    Returns:
+        未安装成功的依赖列表
+    """
+    missing = []
+    for dep in deps:
+        # 提取包名（去除版本约束）
+        pkg_name = (
+            dep.split("==")[0]
+            .split(">=")[0]
+            .split("<=")[0]
+            .split("<")[0]
+            .split(">")[0]
+            .split("[")[0]
+            .strip()
+        )
+        # 处理包名中的连字符（pip 安装时会转换为下划线）
+        pkg_name_normalized = pkg_name.replace("-", "_")
+        if importlib.util.find_spec(pkg_name_normalized) is None:
+            # 尝试原始名称
+            if importlib.util.find_spec(pkg_name) is None:
+                missing.append(dep)
+    return missing
+
+
+async def install_with_retry(
+    package: str,
+    max_retries: int = 3,
+    retry_delay: float = 1.0,
+    extra_params: list | None = None,
+) -> tuple[int, int, str]:
+    """带重试机制的依赖安装
+
+    Args:
+        package: 要安装的包名
+        max_retries: 最大重试次数
+        retry_delay: 重试间隔（秒）
+        extra_params: 额外的 pip 参数
+
+    Returns:
+        (returncode, downloaded_bytes, error_message)
+    """
+    last_error = ""
+    for attempt in range(max_retries):
+        returncode, downloaded_bytes = await install_single_async(package, extra_params)
+        if returncode == 0:
+            return returncode, downloaded_bytes, ""
+
+        # 获取错误信息
+        last_error = f"Attempt {attempt + 1}/{max_retries} failed with code {returncode}"
+
+        if attempt < max_retries - 1:
+            await asyncio.sleep(retry_delay)
+
+    return returncode, 0, last_error
+
+
+async def precheck_dependencies(requirements_file: str) -> dict:
+    """依赖预检查 - 检查依赖冲突和已安装状态
+
+    Args:
+        requirements_file: requirements.txt 文件路径
+
+    Returns:
+        {
+            'deps': list[str],           # 所有依赖列表
+            'already_installed': list[str],  # 已安装的依赖
+            'to_install': list[str],     # 需要安装的依赖
+            'conflicts': list[str]       # 可能的冲突（可选）
+        }
+    """
+    deps = parse_requirements(requirements_file)
+    already_installed = []
+    to_install = []
+
+    for dep in deps:
+        pkg_name = (
+            dep.split("==")[0]
+            .split(">=")[0]
+            .split("<=")[0]
+            .split("<")[0]
+            .split(">")[0]
+            .split("[")[0]
+            .strip()
+        )
+        pkg_name_normalized = pkg_name.replace("-", "_")
+
+        if (
+            importlib.util.find_spec(pkg_name_normalized) is not None
+            or importlib.util.find_spec(pkg_name) is not None
+        ):
+            already_installed.append(dep)
+        else:
+            to_install.append(dep)
+
+    return {
+        "deps": deps,
+        "already_installed": already_installed,
+        "to_install": to_install,
+        "conflicts": [],  # 暂不实现冲突检测
+    }

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -310,10 +310,23 @@ class PluginManager:
         yield {"current_action": "installing dependencies"}
         requirements_file = os.path.join(plugin_path, "requirements.txt")
         if os.path.exists(requirements_file):
-            deps = pkgmgr_helper.parse_requirements(requirements_file)
+            # 预检查依赖状态
+            precheck_result = await pkgmgr_helper.precheck_dependencies(
+                requirements_file
+            )
+            deps = precheck_result["deps"]
+            to_install = precheck_result["to_install"]
+            already_installed = precheck_result["already_installed"]
+
+            logger.info(
+                f"Dependency precheck: {len(already_installed)} already installed, "
+                f"{len(to_install)} to install"
+            )
+
             total_deps = len(deps)
             total_downloaded = 0
             start_time = time.time()
+            failed_deps = []
 
             for i, dep in enumerate(deps):
                 elapsed = time.time() - start_time
@@ -326,29 +339,55 @@ class PluginManager:
                         "current_dep": dep,
                         "deps_downloaded_size": total_downloaded,
                         "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
+                        "already_installed": len(already_installed),
+                        "to_install": len(to_install),
                     },
                 }
 
-                returncode, downloaded_bytes = await pkgmgr_helper.install_single_async(
-                    dep
+                # 使用带重试机制的安装
+                returncode, downloaded_bytes, error_msg = (
+                    await pkgmgr_helper.install_with_retry(dep, max_retries=3)
                 )
                 total_downloaded += downloaded_bytes
 
                 if returncode != 0:
-                    logger.error(f"Failed to install dependency: {dep}")
+                    logger.error(
+                        f"Failed to install dependency after retries: {dep}, "
+                        f"error: {error_msg}"
+                    )
+                    failed_deps.append(dep)
+
+            # 验证所有依赖是否真正安装成功
+            missing_deps = await pkgmgr_helper.verify_dependencies(deps)
+            if missing_deps:
+                logger.warning(
+                    f"Dependency verification failed, missing: {missing_deps}"
+                )
+                # 将验证失败的依赖添加到失败列表（去重）
+                for dep in missing_deps:
+                    if dep not in failed_deps:
+                        failed_deps.append(dep)
 
             elapsed = time.time() - start_time
             yield {
                 "current_action": "installing dependencies",
                 "metadata": {
                     "deps_total": total_deps,
-                    "deps_installed": total_deps,
+                    "deps_installed": total_deps - len(failed_deps),
                     "deps_remaining": 0,
+                    "deps_failed": len(failed_deps),
+                    "failed_deps": failed_deps,
                     "current_dep": "",
                     "deps_downloaded_size": total_downloaded,
                     "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
                 },
             }
+
+            if failed_deps:
+                logger.error(
+                    f"Plugin {plugin_author}/{plugin_name} has {len(failed_deps)} "
+                    f"failed dependencies: {failed_deps}"
+                )
 
         # initialize plugin settings
         yield {"current_action": "initializing plugin settings"}


### PR DESCRIPTION
1. **添加依赖验证步骤**
   ```python
   async def verify_dependencies(deps: list[str]) -> list[str]:
       """验证依赖是否真正安装成功"""
       missing = []
       for dep in deps:
           pkg_name = dep.split('==')[0].split('>=')[0].split('<=')[0]
           if importlib.util.find_spec(pkg_name) is None:
               missing.append(dep)
       return missing
   ```

2. **添加重试机制**
   ```python
   async def install_with_retry(dep: str, max_retries: int = 3):
       for attempt in range(max_retries):
           returncode, _ = await install_single_async(dep)
           if returncode == 0:
               return True
           await asyncio.sleep(1)  # 等待后重试
       return False
   ```

3. **改进错误反馈**
   - 前端显示详细的依赖安装状态
   - 提供"重新安装依赖"按钮
   - 失败时显示具体的 pip 错误输出

4. **依赖预检查**
   - 安装前检查依赖冲突