### PR TITLE
Feat/robust dependency install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "e2b>=2.15",
     "httpx>=0.28.1",
     "jinja2>=3.1.6",
+    "packaging>=24.0",
     "pip>=25.2",
     "pydantic>=2.11.5",
     "pydantic-settings>=2.10.1",

--- a/src/langbot_plugin/entities/io/errors.py
+++ b/src/langbot_plugin/entities/io/errors.py
@@ -22,30 +22,63 @@ class ActionCallTimeoutError(Exception):
 
 
 class DependencyInstallError(Exception):
-    """Dependency installation failed."""
+    """One or more plugin dependencies failed to install via pip.
 
-    def __init__(self, package: str, returncode: int, stderr: str):
-        self.package = package
-        self.returncode = returncode
-        self.stderr = stderr
-        super().__init__(f"Failed to install {package}: {stderr}")
+    Carries enough structure for callers to log per-package diagnostics or
+    surface them to the UI, instead of a single flattened string.
+    """
 
-    def __str__(self):
-        return f"Failed to install {self.package}: {self.stderr}"
-
-
-class DependencyVerificationError(Exception):
-    """Dependency verification failed."""
-
-    def __init__(self, missing: list[str], version_mismatch: list[str] = None):
-        self.missing = missing
-        self.version_mismatch = version_mismatch or []
+    def __init__(
+        self,
+        failed: list[str],
+        plugin: str | None = None,
+        details: dict[str, str] | None = None,
+    ):
+        # List of requirement specs that pip could not install (after retries).
+        self.failed = failed
+        # "<author>/<name>" of the plugin being installed, when known.
+        self.plugin = plugin
+        # Optional per-package error text (requirement spec -> pip stderr tail).
+        self.details = details or {}
+        prefix = f"Plugin {plugin} " if plugin else ""
         super().__init__(
-            f"Missing dependencies: {missing}, Version mismatch: {self.version_mismatch}"
+            f"{prefix}failed to install {len(failed)} dependencies: {failed}"
         )
 
     def __str__(self):
-        return f"Missing dependencies: {self.missing}, Version mismatch: {self.version_mismatch}"
+        prefix = f"Plugin {self.plugin} " if self.plugin else ""
+        return f"{prefix}failed to install {len(self.failed)} dependencies: {self.failed}"
+
+
+class DependencyVerificationError(Exception):
+    """Dependencies were installed but could not be verified afterwards.
+
+    ``missing`` holds requirement specs whose distribution/import could not be
+    resolved after pip reported success; ``version_mismatch`` holds specs whose
+    installed version does not satisfy the requested specifier.
+    """
+
+    def __init__(
+        self,
+        missing: list[str],
+        version_mismatch: list[str] | None = None,
+        plugin: str | None = None,
+    ):
+        self.missing = missing
+        self.version_mismatch = version_mismatch or []
+        self.plugin = plugin
+        prefix = f"Plugin {plugin}: " if plugin else ""
+        super().__init__(
+            f"{prefix}missing dependencies: {missing}, "
+            f"version mismatch: {self.version_mismatch}"
+        )
+
+    def __str__(self):
+        prefix = f"Plugin {self.plugin}: " if self.plugin else ""
+        return (
+            f"{prefix}missing dependencies: {self.missing}, "
+            f"version mismatch: {self.version_mismatch}"
+        )
 
 
 class ActionCallError(Exception):

--- a/src/langbot_plugin/entities/io/errors.py
+++ b/src/langbot_plugin/entities/io/errors.py
@@ -21,6 +21,33 @@ class ActionCallTimeoutError(Exception):
         return self.message
 
 
+class DependencyInstallError(Exception):
+    """Dependency installation failed."""
+
+    def __init__(self, package: str, returncode: int, stderr: str):
+        self.package = package
+        self.returncode = returncode
+        self.stderr = stderr
+        super().__init__(f"Failed to install {package}: {stderr}")
+
+    def __str__(self):
+        return f"Failed to install {self.package}: {self.stderr}"
+
+
+class DependencyVerificationError(Exception):
+    """Dependency verification failed."""
+
+    def __init__(self, missing: list[str], version_mismatch: list[str] = None):
+        self.missing = missing
+        self.version_mismatch = version_mismatch or []
+        super().__init__(
+            f"Missing dependencies: {missing}, Version mismatch: {self.version_mismatch}"
+        )
+
+    def __str__(self):
+        return f"Missing dependencies: {self.missing}, Version mismatch: {self.version_mismatch}"
+
+
 class ActionCallError(Exception):
     """The action call failed."""
 

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -249,21 +249,58 @@ async def verify_dependencies(deps: list[str]) -> list[str]:
     Returns:
         List of dependency specs that failed verification.
     """
-    missing = []
+    missing, _ = classify_unsatisfied_dependencies(deps)
+    return missing
+
+
+def classify_unsatisfied_dependencies(
+    deps: list[str],
+) -> tuple[list[str], list[str]]:
+    """Split dependency specs into (missing, version_mismatch).
+
+    A spec is reported as ``version_mismatch`` when its distribution IS
+    installed but the installed version does not satisfy the requested
+    specifier; otherwise, if it is not satisfied at all, it is ``missing``.
+    Specs that are satisfied (including skipped environment markers and
+    URL requirements whose distribution exists) are omitted from both lists.
+
+    Returns:
+        (missing, version_mismatch) — two disjoint lists of requirement specs.
+    """
+    missing: list[str] = []
+    version_mismatch: list[str] = []
     for dep in deps:
         if _check_dependency_installed(dep):
             continue
-        # _check_dependency_installed always returns False for URL
-        # requirements (preferring pip to decide).  After pip has run,
-        # distribution existence is sufficient verification.
+
         try:
             req = Requirement(dep)
-            if req.url and _is_distribution_installed(req.name):
-                continue
         except Exception:
-            pass
+            # Genuinely malformed spec — pip should have decided. Treat as
+            # missing so the caller surfaces it rather than silently passing.
+            missing.append(dep)
+            continue
+
+        # Environment marker excludes this dep from the current env → satisfied.
+        if req.marker and not req.marker.evaluate():
+            continue
+
+        # URL requirement: _check_dependency_installed always defers to pip and
+        # returns False. After pip has run, the presence of the distribution is
+        # sufficient verification.
+        if req.url:
+            if _is_distribution_installed(req.name):
+                continue
+            missing.append(dep)
+            continue
+
+        # Distribution present but specifier not met → version mismatch.
+        if req.specifier and _is_distribution_installed(req.name):
+            version_mismatch.append(dep)
+            continue
+
         missing.append(dep)
-    return missing
+    return missing, version_mismatch
 
 
 async def install_with_retry(

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.util
 import os
 import re
 import subprocess
@@ -139,3 +140,111 @@ def _parse_downloaded_bytes(output: str) -> int:
             else:
                 total += int(val)
     return total
+
+
+async def verify_dependencies(deps: list[str]) -> list[str]:
+    """Verify that installed dependencies are actually importable.
+
+    Args:
+        deps: List of dependency specs, e.g. ['pkg==1.0.0', 'pkg>=2.0']
+
+    Returns:
+        List of dependencies that failed import verification.
+    """
+    missing = []
+    for dep in deps:
+        pkg_name = (
+            dep.split("==")[0]
+            .split(">=")[0]
+            .split("<=")[0]
+            .split("<")[0]
+            .split(">")[0]
+            .split("[")[0]
+            .strip()
+        )
+        pkg_name_normalized = pkg_name.replace("-", "_")
+        if importlib.util.find_spec(pkg_name_normalized) is None:
+            if importlib.util.find_spec(pkg_name) is None:
+                missing.append(dep)
+    return missing
+
+
+async def install_with_retry(
+    package: str,
+    max_retries: int = 3,
+    retry_delay: float = 1.0,
+    extra_params: list | None = None,
+) -> tuple[int, int, str]:
+    """Install a package with retry on failure.
+
+    Args:
+        package: Package name to install.
+        max_retries: Maximum number of retry attempts.
+        retry_delay: Delay between retries in seconds.
+        extra_params: Additional pip parameters.
+
+    Returns:
+        (returncode, downloaded_bytes, error_message)
+    """
+    last_error = ""
+    for attempt in range(max_retries):
+        returncode, downloaded_bytes, _ = await install_single_async(
+            package, extra_params
+        )
+        if returncode == 0:
+            return returncode, downloaded_bytes, ""
+
+        last_error = (
+            f"Attempt {attempt + 1}/{max_retries} failed with code {returncode}"
+        )
+
+        if attempt < max_retries - 1:
+            await asyncio.sleep(retry_delay)
+
+    return returncode, 0, last_error
+
+
+async def precheck_dependencies(requirements_file: str) -> dict:
+    """Pre-check dependency status before installation.
+
+    Args:
+        requirements_file: Path to requirements.txt.
+
+    Returns:
+        {
+            'deps': list[str],
+            'already_installed': list[str],
+            'to_install': list[str],
+            'conflicts': list[str],
+        }
+    """
+    deps = parse_requirements(requirements_file)
+    already_installed = []
+    to_install = []
+
+    for dep in deps:
+        pkg_name = (
+            dep.split("==")[0]
+            .split(">=")[0]
+            .split("<=")[0]
+            .split("<")[0]
+            .split(">")[0]
+            .split("[")[0]
+            .strip()
+        )
+        pkg_name_normalized = pkg_name.replace("-", "_")
+
+        if (
+            importlib.util.find_spec(pkg_name_normalized) is not None
+            or importlib.util.find_spec(pkg_name) is not None
+        ):
+            already_installed.append(dep)
+        else:
+            to_install.append(dep)
+
+    return {
+        "deps": deps,
+        "already_installed": already_installed,
+        "to_install": to_install,
+        "conflicts": [],
+    }

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -147,23 +147,6 @@ def _parse_downloaded_bytes(output: str) -> int:
 _dist_to_packages: dict[str, set[str]] | None = None
 
 
-def _extract_package_name(dep_spec: str) -> str:
-    """Extract the pip package name from a dependency spec string.
-
-    Uses ``packaging.requirements.Requirement`` for proper PEP 508 parsing,
-    handling all version operators, extras, environment markers, and URL
-    references (e.g. ``yiri-mirai>=1.0`` → ``yiri-mirai``).
-
-    Falls back to a simple operator split for truly malformed specs.
-    """
-    try:
-        return Requirement(dep_spec).name
-    except Exception:
-        for sep in ("==", ">=", "<=", "!=", "~=", "===", "<", ">", "["):
-            dep_spec = dep_spec.split(sep)[0]
-        return dep_spec.strip()
-
-
 def _is_distribution_installed(pkg_name: str) -> bool:
     """Check whether a pip distribution is installed via its metadata.
 
@@ -206,17 +189,52 @@ def _resolve_import_names(pkg_name: str) -> set[str]:
 
 
 def _check_dependency_installed(dep_spec: str) -> bool:
-    """Check whether a dependency is installed and importable.
+    """Check whether a dependency requirement is fully satisfied.
 
-    Resolution order:
-    1. importlib.metadata.distribution() - authoritative pip install check
-    2. packages_distributions() reverse mapping - find actual import names
-    3. fallback: find_spec on the normalized package name
+    Returns True only when:
+    1. Environment markers do not apply → treat as satisfied (skip)
+    2. Distribution is installed AND version satisfies the specifier
+    3. Package is importable (fallback for name-mismatch cases,
+       e.g. yiri-mirai → mirai, PyYAML → yaml)
+
+    Returns False when the installed version does not meet the specifier
+    or the package is not installed at all.
     """
-    pkg_name = _extract_package_name(dep_spec)
+    try:
+        req = Requirement(dep_spec)
+    except Exception:
+        # parse_requirements() already filters comments, empty lines, and
+        # option lines (-r / --index-url).  If Requirement() still fails, the
+        # input is genuinely malformed and no heuristic name extraction will
+        # be reliable.  Return False so pip gets a chance to install it.
+        return False
+
+    if req.marker and not req.marker.evaluate():
+        return True
+
+    pkg_name = req.name
 
     if _is_distribution_installed(pkg_name):
-        return True
+        if req.url:
+            # URL requirements (e.g. ``foo @ https://...``) cannot be
+            # reliably verified from Python — the installed distribution
+            # may have come from a different source or version.  Reading
+            # pip's internal direct_url.json (PEP 610) is fragile and
+            # couples us to pip implementation details.  Returning True
+            # would risk silently keeping a mismatched version.
+            #
+            # Instead, return False so pip decides.  If the URL points to
+            # an already-satisfied version, pip will output "Requirement
+            # already satisfied" and exit without downloading — the
+            # overhead is a single subprocess spawn.
+            return False
+        if not req.specifier:
+            return True
+        try:
+            installed_version = importlib.metadata.version(pkg_name)
+            return installed_version in req.specifier
+        except importlib.metadata.PackageNotFoundError:
+            return False
 
     for import_name in _resolve_import_names(pkg_name):
         if importlib.util.find_spec(import_name) is not None:
@@ -233,8 +251,18 @@ async def verify_dependencies(deps: list[str]) -> list[str]:
     """
     missing = []
     for dep in deps:
-        if not _check_dependency_installed(dep):
-            missing.append(dep)
+        if _check_dependency_installed(dep):
+            continue
+        # _check_dependency_installed always returns False for URL
+        # requirements (preferring pip to decide).  After pip has run,
+        # distribution existence is sufficient verification.
+        try:
+            req = Requirement(dep)
+            if req.url and _is_distribution_installed(req.name):
+                continue
+        except Exception:
+            pass
+        missing.append(dep)
     return missing
 
 

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.metadata
 import importlib.util
 import os
 import re
@@ -142,30 +143,87 @@ def _parse_downloaded_bytes(output: str) -> int:
     return total
 
 
-async def verify_dependencies(deps: list[str]) -> list[str]:
-    """Verify that installed dependencies are actually importable.
+_dist_to_packages: dict[str, set[str]] | None = None
 
-    Args:
-        deps: List of dependency specs, e.g. ['pkg==1.0.0', 'pkg>=2.0']
+
+def _extract_package_name(dep_spec: str) -> str:
+    """Extract the pip package name from a dependency spec string."""
+    for sep in ("==", ">=", "<=", "<", ">", "["):
+        dep_spec = dep_spec.split(sep)[0]
+    return dep_spec.strip()
+
+
+def _is_distribution_installed(pkg_name: str) -> bool:
+    """Check whether a pip distribution is installed via its metadata.
+
+    This is the authoritative check, regardless of whether the pip
+    package name matches the actual Python module name.
+    """
+    candidates = {pkg_name, pkg_name.replace("-", "_"), pkg_name.replace("_", "-")}
+    for name in candidates:
+        try:
+            importlib.metadata.distribution(name)
+            return True
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return False
+
+
+def _resolve_import_names(pkg_name: str) -> set[str]:
+    """Resolve top-level Python import names for a pip distribution.
+
+    Many pip package names differ from their importable module name.
+    E.g. yiri-mirai -> mirai, PyYAML -> yaml, Pillow -> PIL.
+    Uses importlib.metadata.packages_distributions() reverse mapping.
+    """
+    global _dist_to_packages
+
+    if _dist_to_packages is None:
+        _dist_to_packages = {}
+        try:
+            for top_pkg, dist_names in importlib.metadata.packages_distributions().items():
+                for dist_name in dist_names:
+                    key = dist_name.lower().replace("_", "-")
+                    _dist_to_packages.setdefault(key, set()).add(top_pkg)
+        except Exception:
+            pass
+
+    key = pkg_name.lower().replace("_", "-")
+    names = _dist_to_packages.get(key, set()).copy()
+    names.add(pkg_name.replace("-", "_"))
+    return names
+
+
+def _check_dependency_installed(dep_spec: str) -> bool:
+    """Check whether a dependency is installed and importable.
+
+    Resolution order:
+    1. importlib.metadata.distribution() - authoritative pip install check
+    2. packages_distributions() reverse mapping - find actual import names
+    3. fallback: find_spec on the normalized package name
+    """
+    pkg_name = _extract_package_name(dep_spec)
+
+    if _is_distribution_installed(pkg_name):
+        return True
+
+    for import_name in _resolve_import_names(pkg_name):
+        if importlib.util.find_spec(import_name) is not None:
+            return True
+
+    return False
+
+
+async def verify_dependencies(deps: list[str]) -> list[str]:
+    """Verify installed dependencies are actually importable.
 
     Returns:
-        List of dependencies that failed import verification.
+        List of dependency specs that failed verification.
     """
     missing = []
     for dep in deps:
-        pkg_name = (
-            dep.split("==")[0]
-            .split(">=")[0]
-            .split("<=")[0]
-            .split("<")[0]
-            .split(">")[0]
-            .split("[")[0]
-            .strip()
-        )
-        pkg_name_normalized = pkg_name.replace("-", "_")
-        if importlib.util.find_spec(pkg_name_normalized) is None:
-            if importlib.util.find_spec(pkg_name) is None:
-                missing.append(dep)
+        if not _check_dependency_installed(dep):
+            missing.append(dep)
     return missing
 
 
@@ -207,9 +265,6 @@ async def install_with_retry(
 async def precheck_dependencies(requirements_file: str) -> dict:
     """Pre-check dependency status before installation.
 
-    Args:
-        requirements_file: Path to requirements.txt.
-
     Returns:
         {
             'deps': list[str],
@@ -223,21 +278,7 @@ async def precheck_dependencies(requirements_file: str) -> dict:
     to_install = []
 
     for dep in deps:
-        pkg_name = (
-            dep.split("==")[0]
-            .split(">=")[0]
-            .split("<=")[0]
-            .split("<")[0]
-            .split(">")[0]
-            .split("[")[0]
-            .strip()
-        )
-        pkg_name_normalized = pkg_name.replace("-", "_")
-
-        if (
-            importlib.util.find_spec(pkg_name_normalized) is not None
-            or importlib.util.find_spec(pkg_name) is not None
-        ):
+        if _check_dependency_installed(dep):
             already_installed.append(dep)
         else:
             to_install.append(dep)

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 
+from packaging.requirements import Requirement
 from pip._internal import main as pipmain
 
 
@@ -147,10 +148,20 @@ _dist_to_packages: dict[str, set[str]] | None = None
 
 
 def _extract_package_name(dep_spec: str) -> str:
-    """Extract the pip package name from a dependency spec string."""
-    for sep in ("==", ">=", "<=", "<", ">", "["):
-        dep_spec = dep_spec.split(sep)[0]
-    return dep_spec.strip()
+    """Extract the pip package name from a dependency spec string.
+
+    Uses ``packaging.requirements.Requirement`` for proper PEP 508 parsing,
+    handling all version operators, extras, environment markers, and URL
+    references (e.g. ``yiri-mirai>=1.0`` → ``yiri-mirai``).
+
+    Falls back to a simple operator split for truly malformed specs.
+    """
+    try:
+        return Requirement(dep_spec).name
+    except Exception:
+        for sep in ("==", ">=", "<=", "!=", "~=", "===", "<", ">", "["):
+            dep_spec = dep_spec.split(sep)[0]
+        return dep_spec.strip()
 
 
 def _is_distribution_installed(pkg_name: str) -> bool:
@@ -246,7 +257,7 @@ async def install_with_retry(
     """
     last_error = ""
     for attempt in range(max_retries):
-        returncode, downloaded_bytes, _ = await install_single_async(
+        returncode, downloaded_bytes, output = await install_single_async(
             package, extra_params
         )
         if returncode == 0:
@@ -255,6 +266,8 @@ async def install_with_retry(
         last_error = (
             f"Attempt {attempt + 1}/{max_retries} failed with code {returncode}"
         )
+        if output.strip():
+            last_error += f"\n{output.strip()}"
 
         if attempt < max_retries - 1:
             await asyncio.sleep(retry_delay)

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -328,20 +328,22 @@ class PluginManager:
             total_downloaded = 0
             start_time = time.time()
             failed_deps = []
+            already_installed_count = len(already_installed)
+            to_install_count = len(to_install)
 
-            for i, dep in enumerate(deps):
+            for i, dep in enumerate(to_install):
                 elapsed = time.time() - start_time
                 yield {
                     "current_action": "installing dependencies",
                     "metadata": {
                         "deps_total": total_deps,
-                        "deps_installed": i,
-                        "deps_remaining": total_deps - i,
+                        "deps_installed": already_installed_count + i,
+                        "deps_remaining": to_install_count - i,
                         "current_dep": dep,
                         "deps_downloaded_size": total_downloaded,
                         "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
-                        "already_installed": len(already_installed),
-                        "to_install": len(to_install),
+                        "already_installed": already_installed_count,
+                        "to_install": to_install_count,
                     },
                 }
 

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -38,6 +38,10 @@ from langbot_plugin.api.entities.builtin.command.context import (
 )
 from langbot_plugin.runtime.helper import marketplace as marketplace_helper
 from langbot_plugin.runtime.helper import pkgmgr as pkgmgr_helper
+from langbot_plugin.entities.io.errors import (
+    DependencyInstallError,
+    DependencyVerificationError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -327,7 +331,9 @@ class PluginManager:
             total_deps = len(deps)
             total_downloaded = 0
             start_time = time.time()
-            failed_deps = []
+            # Requirement specs pip could not install even after retries,
+            # mapped to the tail of pip's stderr for diagnostics.
+            install_failures: dict[str, str] = {}
             already_installed_count = len(already_installed)
             to_install_count = len(to_install)
 
@@ -357,16 +363,20 @@ class PluginManager:
                         f"Failed to install dependency after retries: {dep}, "
                         f"error: {error_msg}"
                     )
-                    failed_deps.append(dep)
+                    install_failures[dep] = error_msg
 
-            missing_deps = await pkgmgr_helper.verify_dependencies(deps)
-            if missing_deps:
-                logger.warning(
-                    f"Dependency verification failed, missing: {missing_deps}"
-                )
-                for dep in missing_deps:
-                    if dep not in failed_deps:
-                        failed_deps.append(dep)
+            # Verification: pip may report success while the distribution is
+            # still unimportable or the installed version violates the
+            # specifier. Only verify deps that pip did not already flag as a
+            # hard install failure, so the two error classes stay distinct.
+            verified_targets = [d for d in deps if d not in install_failures]
+            missing_deps, version_mismatch = (
+                pkgmgr_helper.classify_unsatisfied_dependencies(verified_targets)
+            )
+
+            failed_deps = (
+                list(install_failures.keys()) + missing_deps + version_mismatch
+            )
 
             elapsed = time.time() - start_time
             yield {
@@ -383,13 +393,34 @@ class PluginManager:
                 },
             }
 
-            if failed_deps:
-                error_message = (
-                    f"Plugin {plugin_author}/{plugin_name} has {len(failed_deps)} "
-                    f"failed dependencies: {failed_deps}"
+            plugin_ref = f"{plugin_author}/{plugin_name}"
+
+            # pip-level install failures take priority — they are the root
+            # cause and carry the actual pip stderr for debugging.
+            if install_failures:
+                logger.error(
+                    f"Plugin {plugin_ref} failed to install "
+                    f"{len(install_failures)} dependencies: "
+                    f"{list(install_failures.keys())}"
                 )
-                logger.error(error_message)
-                raise RuntimeError(error_message)
+                raise DependencyInstallError(
+                    failed=list(install_failures.keys()),
+                    plugin=plugin_ref,
+                    details=install_failures,
+                )
+
+            # pip succeeded but the result cannot be verified — surface which
+            # deps are missing vs. version-mismatched so callers can react.
+            if missing_deps or version_mismatch:
+                logger.error(
+                    f"Plugin {plugin_ref} dependency verification failed — "
+                    f"missing: {missing_deps}, version mismatch: {version_mismatch}"
+                )
+                raise DependencyVerificationError(
+                    missing=missing_deps,
+                    version_mismatch=version_mismatch,
+                    plugin=plugin_ref,
+                )
 
         # initialize plugin settings
         yield {"current_action": "initializing plugin settings"}

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -312,10 +312,22 @@ class PluginManager:
         yield {"current_action": "installing dependencies"}
         requirements_file = os.path.join(plugin_path, "requirements.txt")
         if os.path.exists(requirements_file):
-            deps = pkgmgr_helper.parse_requirements(requirements_file)
+            precheck_result = await pkgmgr_helper.precheck_dependencies(
+                requirements_file
+            )
+            deps = precheck_result["deps"]
+            to_install = precheck_result["to_install"]
+            already_installed = precheck_result["already_installed"]
+
+            logger.info(
+                f"Dependency precheck: {len(already_installed)} already installed, "
+                f"{len(to_install)} to install"
+            )
+
             total_deps = len(deps)
             total_downloaded = 0
             start_time = time.time()
+            failed_deps = []
 
             for i, dep in enumerate(deps):
                 elapsed = time.time() - start_time
@@ -328,33 +340,54 @@ class PluginManager:
                         "current_dep": dep,
                         "deps_downloaded_size": total_downloaded,
                         "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
+                        "already_installed": len(already_installed),
+                        "to_install": len(to_install),
                     },
                 }
 
-                returncode, downloaded_bytes, output = (
-                    await pkgmgr_helper.install_single_async(dep)
+                returncode, downloaded_bytes, error_msg = (
+                    await pkgmgr_helper.install_with_retry(dep, max_retries=3)
                 )
                 total_downloaded += downloaded_bytes
 
                 if returncode != 0:
-                    error_message = f"Failed to install dependency: {dep}"
-                    if output:
-                        error_message = f"{error_message}\n{output.strip()}"
-                    logger.error(error_message)
-                    raise RuntimeError(error_message)
+                    logger.error(
+                        f"Failed to install dependency after retries: {dep}, "
+                        f"error: {error_msg}"
+                    )
+                    failed_deps.append(dep)
+
+            missing_deps = await pkgmgr_helper.verify_dependencies(deps)
+            if missing_deps:
+                logger.warning(
+                    f"Dependency verification failed, missing: {missing_deps}"
+                )
+                for dep in missing_deps:
+                    if dep not in failed_deps:
+                        failed_deps.append(dep)
 
             elapsed = time.time() - start_time
             yield {
                 "current_action": "installing dependencies",
                 "metadata": {
                     "deps_total": total_deps,
-                    "deps_installed": total_deps,
+                    "deps_installed": total_deps - len(failed_deps),
                     "deps_remaining": 0,
+                    "deps_failed": len(failed_deps),
+                    "failed_deps": failed_deps,
                     "current_dep": "",
                     "deps_downloaded_size": total_downloaded,
                     "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
                 },
             }
+
+            if failed_deps:
+                error_message = (
+                    f"Plugin {plugin_author}/{plugin_name} has {len(failed_deps)} "
+                    f"failed dependencies: {failed_deps}"
+                )
+                logger.error(error_message)
+                raise RuntimeError(error_message)
 
         # initialize plugin settings
         yield {"current_action": "initializing plugin settings"}

--- a/tests/entities/io/test_dependency_errors.py
+++ b/tests/entities/io/test_dependency_errors.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from langbot_plugin.entities.io.errors import (
+    DependencyInstallError,
+    DependencyVerificationError,
+)
+
+
+def test_dependency_install_error_carries_structured_fields():
+    err = DependencyInstallError(
+        failed=["foo>=1", "bar"],
+        plugin="alice/demo",
+        details={"foo>=1": "could not find version", "bar": "network error"},
+    )
+
+    assert err.failed == ["foo>=1", "bar"]
+    assert err.plugin == "alice/demo"
+    assert err.details["bar"] == "network error"
+    # The plugin ref and count appear in the message for log/UI surfacing.
+    msg = str(err)
+    assert "alice/demo" in msg
+    assert "2 dependencies" in msg
+    assert "foo>=1" in msg
+
+
+def test_dependency_install_error_without_plugin():
+    err = DependencyInstallError(failed=["foo"])
+    assert err.plugin is None
+    assert err.details == {}
+    assert "1 dependencies" in str(err)
+    # No leading "Plugin " prefix when the plugin ref is unknown.
+    assert not str(err).startswith("Plugin ")
+
+
+def test_dependency_install_error_is_exception():
+    assert isinstance(DependencyInstallError(failed=["x"]), Exception)
+
+
+def test_dependency_verification_error_carries_missing_and_mismatch():
+    err = DependencyVerificationError(
+        missing=["ghost"],
+        version_mismatch=["pkg>=9999"],
+        plugin="bob/plugin",
+    )
+
+    assert err.missing == ["ghost"]
+    assert err.version_mismatch == ["pkg>=9999"]
+    assert err.plugin == "bob/plugin"
+    msg = str(err)
+    assert "bob/plugin" in msg
+    assert "ghost" in msg
+    assert "pkg>=9999" in msg
+
+
+def test_dependency_verification_error_defaults_mismatch_to_empty():
+    err = DependencyVerificationError(missing=["ghost"])
+    assert err.version_mismatch == []
+    assert err.plugin is None
+    assert isinstance(err, Exception)

--- a/tests/runtime/helper/test_pkgmgr.py
+++ b/tests/runtime/helper/test_pkgmgr.py
@@ -107,3 +107,282 @@ def test_install_single_async_builds_pip_command_and_parses_output(monkeypatch):
     assert downloaded == 2048
     assert "Downloading async.whl" in output
     assert calls[0][0][-2:] == ("install", "demo")
+
+
+# ---------------------------------------------------------------------------
+# Dependency satisfaction checks (_check_dependency_installed)
+#
+# These anchor on packages that are guaranteed installed in the test/runtime
+# environment (declared in pyproject): pytest, packaging, pydantic. PyYAML is
+# the canonical pip-name != module-name case (distribution "PyYAML", import
+# "yaml"). We avoid asserting on the *absence* of well-known names; instead we
+# use a deliberately fabricated name for the not-installed path.
+# ---------------------------------------------------------------------------
+
+_DEFINITELY_ABSENT = "langbot-totally-absent-package-xyz"
+
+
+def test_check_dependency_installed_plain_name_present():
+    assert pkgmgr._check_dependency_installed("pytest") is True
+
+
+def test_check_dependency_installed_absent_package():
+    assert pkgmgr._check_dependency_installed(_DEFINITELY_ABSENT) is False
+
+
+def test_check_dependency_installed_canonical_vs_underscore_dash():
+    # Distribution lookup tries name, dash<->underscore variants. "pytest" is
+    # single-token; use a multi-token absent name to ensure variants are tried
+    # without false positives.
+    assert pkgmgr._check_dependency_installed("langbot_totally_absent_xyz") is False
+
+
+def test_check_dependency_installed_version_specifier_satisfied():
+    import importlib.metadata as m
+
+    ver = m.version("packaging")
+    assert pkgmgr._check_dependency_installed(f"packaging>={ver}") is True
+    assert pkgmgr._check_dependency_installed("packaging>=1.0") is True
+
+
+def test_check_dependency_installed_version_specifier_violated():
+    # An impossibly high lower bound must not be satisfied by the installed one.
+    assert pkgmgr._check_dependency_installed("packaging>=9999.0") is False
+
+
+def test_check_dependency_installed_exact_pin_mismatch():
+    assert pkgmgr._check_dependency_installed("pytest==0.0.1") is False
+
+
+def test_check_dependency_installed_name_module_mismatch_pyyaml():
+    # Distribution name PyYAML, importable module name "yaml". The metadata
+    # lookup must resolve it without relying on the import name.
+    assert pkgmgr._check_dependency_installed("PyYAML") is True
+    assert pkgmgr._check_dependency_installed("pyyaml") is True
+
+
+def test_check_dependency_installed_skips_inapplicable_marker():
+    # A marker that never matches the current interpreter → treated as satisfied.
+    spec = f"{_DEFINITELY_ABSENT}; python_version < '2.0'"
+    assert pkgmgr._check_dependency_installed(spec) is True
+
+
+def test_check_dependency_installed_applicable_marker_still_checks():
+    # Marker matches → the (absent) package is still evaluated and unsatisfied.
+    spec = f"{_DEFINITELY_ABSENT}; python_version >= '3.0'"
+    assert pkgmgr._check_dependency_installed(spec) is False
+
+
+def test_check_dependency_installed_url_requirement_defers_to_pip():
+    # URL requirements always return False so pip gets to decide, even when a
+    # distribution of the same name happens to be installed.
+    spec = "packaging @ https://example.invalid/packaging.whl"
+    assert pkgmgr._check_dependency_installed(spec) is False
+
+
+def test_check_dependency_installed_malformed_spec_returns_false():
+    # Requirement() raises on this; helper must return False (let pip try).
+    assert pkgmgr._check_dependency_installed(">>>not a spec<<<") is False
+
+
+def test_check_dependency_installed_importable_fallback(monkeypatch):
+    # Distribution metadata missing but the module is importable (name-mismatch
+    # safety net). Force the metadata path to miss, keep the import path hot.
+    monkeypatch.setattr(pkgmgr, "_is_distribution_installed", lambda name: False)
+    monkeypatch.setattr(pkgmgr, "_resolve_import_names", lambda name: {"os"})
+    assert pkgmgr._check_dependency_installed("anything-here") is True
+
+
+def test_resolve_import_names_includes_underscore_variant():
+    names = pkgmgr._resolve_import_names("PyYAML")
+    # Reverse mapping should surface the real import module "yaml".
+    assert "yaml" in names
+
+
+def test_is_distribution_installed_variants():
+    assert pkgmgr._is_distribution_installed("pytest") is True
+    assert pkgmgr._is_distribution_installed(_DEFINITELY_ABSENT) is False
+
+
+# ---------------------------------------------------------------------------
+# precheck_dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_precheck_dependencies_categorizes(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        f"pytest\npackaging>=1.0\n{_DEFINITELY_ABSENT}\n",
+        encoding="utf-8",
+    )
+
+    result = asyncio.run(pkgmgr.precheck_dependencies(str(requirements)))
+
+    assert result["deps"] == ["pytest", "packaging>=1.0", _DEFINITELY_ABSENT]
+    assert "pytest" in result["already_installed"]
+    assert "packaging>=1.0" in result["already_installed"]
+    assert result["to_install"] == [_DEFINITELY_ABSENT]
+    assert result["conflicts"] == []
+
+
+def test_precheck_dependencies_all_installed(tmp_path):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pytest\npackaging\n", encoding="utf-8")
+
+    result = asyncio.run(pkgmgr.precheck_dependencies(str(requirements)))
+
+    assert result["to_install"] == []
+    assert set(result["already_installed"]) == {"pytest", "packaging"}
+
+
+# ---------------------------------------------------------------------------
+# verify_dependencies / classify_unsatisfied_dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_verify_dependencies_all_satisfied_returns_empty():
+    assert asyncio.run(pkgmgr.verify_dependencies(["pytest", "packaging"])) == []
+
+
+def test_verify_dependencies_reports_missing():
+    missing = asyncio.run(pkgmgr.verify_dependencies([_DEFINITELY_ABSENT, "pytest"]))
+    assert missing == [_DEFINITELY_ABSENT]
+
+
+def test_classify_splits_missing_and_version_mismatch():
+    deps = [
+        "pytest",  # satisfied
+        _DEFINITELY_ABSENT,  # missing (no distribution at all)
+        "packaging>=9999.0",  # installed but version too low → mismatch
+    ]
+    missing, version_mismatch = pkgmgr.classify_unsatisfied_dependencies(deps)
+
+    assert missing == [_DEFINITELY_ABSENT]
+    assert version_mismatch == ["packaging>=9999.0"]
+
+
+def test_classify_skips_inapplicable_marker():
+    deps = [f"{_DEFINITELY_ABSENT}; python_version < '2.0'"]
+    missing, version_mismatch = pkgmgr.classify_unsatisfied_dependencies(deps)
+    assert missing == []
+    assert version_mismatch == []
+
+
+def test_classify_malformed_spec_is_missing():
+    missing, version_mismatch = pkgmgr.classify_unsatisfied_dependencies(["@@bad@@"])
+    assert missing == ["@@bad@@"]
+    assert version_mismatch == []
+
+
+def test_classify_url_requirement_satisfied_when_distribution_present(monkeypatch):
+    # URL req whose distribution exists post-install → neither missing nor mismatch.
+    monkeypatch.setattr(pkgmgr, "_is_distribution_installed", lambda name: True)
+    spec = "packaging @ https://example.invalid/packaging.whl"
+    missing, version_mismatch = pkgmgr.classify_unsatisfied_dependencies([spec])
+    assert missing == []
+    assert version_mismatch == []
+
+
+def test_classify_url_requirement_missing_when_distribution_absent(monkeypatch):
+    monkeypatch.setattr(pkgmgr, "_is_distribution_installed", lambda name: False)
+    spec = "ghostpkg @ https://example.invalid/ghostpkg.whl"
+    missing, version_mismatch = pkgmgr.classify_unsatisfied_dependencies([spec])
+    assert missing == [spec]
+    assert version_mismatch == []
+
+
+# ---------------------------------------------------------------------------
+# install_with_retry
+# ---------------------------------------------------------------------------
+
+
+def _patch_install_sequence(monkeypatch, results):
+    """Patch install_single_async to yield the given (rc, bytes, output) tuples."""
+    seq = list(results)
+    calls = {"n": 0}
+
+    async def fake_install(package, extra_params=None):
+        calls["n"] += 1
+        return seq.pop(0)
+
+    monkeypatch.setattr(pkgmgr, "install_single_async", fake_install)
+    return calls
+
+
+def test_install_with_retry_succeeds_first_attempt(monkeypatch):
+    calls = _patch_install_sequence(monkeypatch, [(0, 1024, "")])
+
+    rc, downloaded, err = asyncio.run(
+        pkgmgr.install_with_retry("demo", max_retries=3, retry_delay=0)
+    )
+
+    assert rc == 0
+    assert downloaded == 1024
+    assert err == ""
+    assert calls["n"] == 1
+
+
+def test_install_with_retry_recovers_after_transient_failure(monkeypatch):
+    calls = _patch_install_sequence(
+        monkeypatch,
+        [
+            (1, 0, "temporary network error"),
+            (0, 2048, ""),
+        ],
+    )
+    sleeps = []
+    monkeypatch.setattr(pkgmgr.asyncio, "sleep", _record_async(sleeps))
+
+    rc, downloaded, err = asyncio.run(
+        pkgmgr.install_with_retry("demo", max_retries=3, retry_delay=0.01)
+    )
+
+    assert rc == 0
+    assert downloaded == 2048
+    assert err == ""
+    assert calls["n"] == 2
+    # One sleep between the failed attempt and the successful retry.
+    assert sleeps == [0.01]
+
+
+def test_install_with_retry_exhausts_and_returns_last_error(monkeypatch):
+    calls = _patch_install_sequence(
+        monkeypatch,
+        [
+            (1, 0, "err-1"),
+            (1, 0, "err-2"),
+            (2, 0, "fatal-3"),
+        ],
+    )
+    sleeps = []
+    monkeypatch.setattr(pkgmgr.asyncio, "sleep", _record_async(sleeps))
+
+    rc, downloaded, err = asyncio.run(
+        pkgmgr.install_with_retry("demo", max_retries=3, retry_delay=0.01)
+    )
+
+    assert rc == 2  # last returncode preserved
+    assert downloaded == 0
+    assert "Attempt 3/3" in err
+    assert "fatal-3" in err  # pip stderr surfaced for debugging
+    assert calls["n"] == 3
+    # Sleeps only happen between attempts, not after the final one.
+    assert sleeps == [0.01, 0.01]
+
+
+def test_install_with_retry_no_sleep_after_final_attempt(monkeypatch):
+    _patch_install_sequence(monkeypatch, [(1, 0, "x"), (1, 0, "y")])
+    sleeps = []
+    monkeypatch.setattr(pkgmgr.asyncio, "sleep", _record_async(sleeps))
+
+    asyncio.run(pkgmgr.install_with_retry("demo", max_retries=2, retry_delay=0.5))
+
+    # 2 attempts → exactly 1 inter-attempt sleep.
+    assert sleeps == [0.5]
+
+
+def _record_async(bucket):
+    async def _sleep(delay):
+        bucket.append(delay)
+
+    return _sleep

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -20,6 +20,10 @@ from langbot_plugin.runtime.plugin.container import (
     RuntimeContainerStatus,
 )
 from langbot_plugin.runtime.plugin.mgr import PluginInstallSource, PluginManager
+from langbot_plugin.entities.io.errors import (
+    DependencyInstallError,
+    DependencyVerificationError,
+)
 
 
 def _manifest(
@@ -290,8 +294,65 @@ async def test_install_plugin_raises_when_dependency_install_fails(tmp_path, mon
     async def fake_install_from_file(plugin_file):
         return "data/plugins/tester__demo", "tester", "demo", "1.0.0"
 
-    async def fake_install_single_async(dep):
+    call_count = {"n": 0}
+
+    async def fake_install_single_async(dep, extra_params=None):
+        call_count["n"] += 1
         return 1, 0, "pip could not find package"
+
+    # No real sleeping between retries.
+    async def fake_sleep(delay):
+        return None
+
+    monkeypatch.setattr(manager, "install_plugin_from_file", fake_install_from_file)
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.install_single_async",
+        fake_install_single_async,
+    )
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.helper.pkgmgr.asyncio.sleep",
+        fake_sleep,
+    )
+
+    progress = []
+    with pytest.raises(DependencyInstallError) as exc_info:
+        async for item in manager.install_plugin(
+            PluginInstallSource.LOCAL,
+            {"plugin_file": b"zip"},
+        ):
+            progress.append(item["current_action"])
+
+    err = exc_info.value
+    assert err.plugin == "tester/demo"
+    assert err.failed == ["missing-package"]
+    # pip stderr preserved in structured details for debugging.
+    assert "pip could not find package" in err.details["missing-package"]
+    # install_with_retry must have retried up to max_retries (3) before giving up.
+    assert call_count["n"] == 3
+
+    assert progress[0] == "downloading plugin package"
+    assert "installing dependencies" in progress
+    assert "initializing plugin settings" not in progress
+    assert "launching plugin" not in progress
+
+
+@pytest.mark.asyncio
+async def test_install_plugin_raises_verification_error_when_pip_lies(tmp_path, monkeypatch):
+    """pip reports success but the dependency is still unsatisfiable."""
+    monkeypatch.chdir(tmp_path)
+    plugin_path = tmp_path / "data/plugins/tester__demo"
+    plugin_path.mkdir(parents=True)
+    (plugin_path / "requirements.txt").write_text(
+        "langbot-absent-after-install\n", encoding="utf-8"
+    )
+    manager = _manager()
+
+    async def fake_install_from_file(plugin_file):
+        return "data/plugins/tester__demo", "tester", "demo", "1.0.0"
+
+    # pip exits 0 (success) but nothing actually got installed.
+    async def fake_install_single_async(dep, extra_params=None):
+        return 0, 0, "Successfully installed langbot-absent-after-install"
 
     monkeypatch.setattr(manager, "install_plugin_from_file", fake_install_from_file)
     monkeypatch.setattr(
@@ -299,18 +360,17 @@ async def test_install_plugin_raises_when_dependency_install_fails(tmp_path, mon
         fake_install_single_async,
     )
 
-    progress = []
-    with pytest.raises(RuntimeError, match="pip could not find package"):
-        async for item in manager.install_plugin(
+    with pytest.raises(DependencyVerificationError) as exc_info:
+        async for _ in manager.install_plugin(
             PluginInstallSource.LOCAL,
             {"plugin_file": b"zip"},
         ):
-            progress.append(item["current_action"])
+            pass
 
-    assert progress[0] == "downloading plugin package"
-    assert "installing dependencies" in progress
-    assert "initializing plugin settings" not in progress
-    assert "launching plugin" not in progress
+    err = exc_info.value
+    assert err.plugin == "tester/demo"
+    assert "langbot-absent-after-install" in err.missing
+    assert err.version_mismatch == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What's new

- Added `precheck_dependencies()` to scan requirements.txt before install and categorize already-installed vs to-install deps
- Added `install_with_retry()` to retry pip install up to 3 times for transient failures
- Added `verify_dependencies()` for post-install import verification
- Added `DependencyInstallError` and `DependencyVerificationError` exception classes
- Install loop now skips already-installed dependencies (only iterates `to_install`)
- Retry error messages now include pip stderr output for debugging

## Fixes over the original PR

- Adapted to current main branch baseline — install_single_async returns 3-tuple here vs 2-tuple in the original, and retained existing `get_pip_index_args()` env-var mirror configuration.
- `find_spec false` negatives for packages where pip name ≠ Python module name (e.g. yiri-mirai → mirai, PyYAML → yaml). Replaced with `importlib.metadata.distribution()` authoritative check + `packages_distributions()` reverse mapping fallback
- Fragile package name extraction — the original manual chained `.split()` missed operators (!=, ~=, ===) and couldn't handle URL refs or environment markers. Replaced with `packaging.requirements.Requirement` for PEP 508 parsing
- Already-installed deps were re-installed — precheck categorized deps but the loop still iterated all of them. Now skips `already_installed` and only installs `to_install`
- Pip stderr was discarded on failure — retry wrapper threw away the actual error output, making diagnosis impossible. Now included in error message
- ~No error was raised on failure — original PR silently logged failures and continued. Restored the existing raise RuntimeError behavior (retries are exhausted, verification fails, then raise)~

## Credits

Thanks to @TyperBody for the original implementation in #54 (https://github.com/langbot-app/langbot-plugin-sdk/pull/54).