### PR TITLE
fix(box): make nsjail cgroup detection container-safe, opt into cgrou…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.2b3"
+version = "0.4.2b4"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.1"
+version = "0.4.2b1"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.2b1"
+version = "0.4.2b2"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.2b2"
+version = "0.4.2b3"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/box/client.py
+++ b/src/langbot_plugin/box/client.py
@@ -233,6 +233,12 @@ class ActionRPCBoxClient(BoxRuntimeClient):
         data = await self._call(
             LangBotToBoxAction.START_MANAGED_PROCESS,
             {"session_id": session_id, "spec": spec.model_dump(mode="json")},
+            # Starting a managed process can involve a cold dependency bootstrap
+            # (e.g. `uvx <pkg>` downloading the package + interpreter on first
+            # run), which easily exceeds the default 15s action timeout and
+            # caused stdio MCP servers to be torn down mid-install. Give it
+            # headroom so the first launch can complete.
+            timeout=30.0,
         )
         return BoxManagedProcessInfo.model_validate(data)
 

--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -116,6 +116,19 @@ class NsjailBackend(BaseSandboxBackend):
         for d in (root_dir, workspace_dir, tmp_dir, home_dir):
             d.mkdir(parents=True, exist_ok=True)
 
+        # When a host_path is mounted into the sandbox it becomes the nsjail
+        # bind-mount source (see _build_mounts). nsjail requires the source to
+        # already exist on the host, otherwise the bind-mount fails and the
+        # command exits 255 with no stdout/stderr. The per-session loop above
+        # never creates host_path (it lives outside session_dir), so ensure it
+        # exists here. Read-only mounts intentionally are NOT auto-created: a
+        # missing read-only source is a caller error that should surface.
+        if (
+            spec.host_path is not None
+            and spec.host_path_mode == BoxHostMountMode.READ_WRITE
+        ):
+            os.makedirs(spec.host_path, exist_ok=True)
+
         # If host_path is specified, we will use it directly instead of the
         # per-session workspace when building nsjail args (see _build_mounts).
         meta = {

--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -424,14 +424,24 @@ class NsjailBackend(BaseSandboxBackend):
         args: list[str] = []
 
         if self._cgroup_v2_available:
-            # cgroup v2 – precise limits.
+            # cgroup v2 – precise limits. nsjail defaults to the legacy cgroup
+            # v1 layout, so we MUST opt into v2 explicitly; without this flag
+            # nsjail tries to mkdir under /sys/fs/cgroup/<controller>/... (v1
+            # paths) and aborts on a v2-only host. The writability of the v2
+            # root is already verified in _detect_cgroup_v2().
+            args.append('--use_cgroupv2')
             memory_bytes = spec.memory_mb * 1024 * 1024
             args.extend(['--cgroup_mem_max', str(memory_bytes)])
             args.extend(['--cgroup_pids_max', str(spec.pids_limit)])
             cpu_ms = int(spec.cpus * 1000)
             args.extend(['--cgroup_cpu_ms_per_sec', str(cpu_ms)])
         else:
-            # rlimit fallback – best-effort.
+            # rlimit fallback – best-effort. Used whenever the cgroup v2 root is
+            # not writable (the typical containerized case: /sys/fs/cgroup is
+            # mounted read-only), so the sandbox still launches with coarse
+            # resource caps instead of failing outright.
+            # --rlimit_as takes a value in MB (nsjail interprets the bare number
+            # as megabytes), matching spec.memory_mb directly.
             args.extend(['--rlimit_as', str(spec.memory_mb)])
             args.extend(['--rlimit_nproc', str(spec.pids_limit)])
 
@@ -478,25 +488,42 @@ class NsjailBackend(BaseSandboxBackend):
 
     @staticmethod
     def _detect_cgroup_v2() -> bool:
-        """Check whether the host runs cgroup v2 and we can write to it."""
+        """Check whether cgroup v2 is present AND nsjail can create a cgroup.
+
+        nsjail (with ``--use_cgroupv2``) creates its own child cgroup by
+        ``mkdir``-ing directly under the cgroup v2 mount root, then writes to
+        ``cgroup.subtree_control``. Merely detecting a cgroup v2 hierarchy is
+        not enough: inside most containers (Docker/k8s default) ``/sys/fs/cgroup``
+        is mounted **read-only**, so the mkdir fails and the whole sandbox
+        aborts. We must therefore probe real writability — running as root is
+        NOT sufficient, because a read-only bind mount denies root too.
+
+        Returns True only when we can actually create (and remove) a directory
+        under the cgroup v2 root, which is exactly what nsjail needs.
+        """
         cgroup_mount = pathlib.Path('/sys/fs/cgroup')
         if not cgroup_mount.exists():
             return False
-        # cgroup v2 has a single hierarchy with cgroup.controllers file.
+        # cgroup v2 has a single hierarchy with a cgroup.controllers file.
         controllers = cgroup_mount / 'cgroup.controllers'
         if not controllers.exists():
             return False
-        # Check if we can write to a cgroup subtree (needed for nsjail).
-        # A rough heuristic: if the user owns a cgroup directory we're probably
-        # running under systemd user delegation.
-        user_slice = cgroup_mount / f'user.slice/user-{os.getuid()}.slice'
-        if user_slice.exists() and os.access(user_slice, os.W_OK):
+        # Authoritative writability probe: try to create and remove a throwaway
+        # cgroup directory under the root, mirroring what nsjail does. This
+        # correctly reports False on a read-only /sys/fs/cgroup (the common
+        # containerized case) so the backend falls back to rlimit limits
+        # instead of selecting a cgroup path that is guaranteed to fail.
+        probe = cgroup_mount / f'.langbot-box-probe-{os.getpid()}'
+        try:
+            probe.mkdir(mode=0o700)
+        except Exception:
+            return False
+        else:
+            try:
+                probe.rmdir()
+            except Exception:
+                pass
             return True
-        # If running as root (uid 0), cgroup v2 is always usable.
-        if os.getuid() == 0:
-            return True
-        # Conservative: if we can't confirm writability, report unavailable.
-        return False
 
     async def _kill_session_processes(self, session_dir: pathlib.Path) -> None:
         """Best-effort kill of nsjail processes associated with a session dir.

--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -44,6 +44,23 @@ _READONLY_ETC_ENTRIES: list[str] = [
     '/etc/resolv.conf',  # needed when network=ON
 ]
 
+# Essential character devices bind-mounted into the sandbox's /dev.
+# /dev is a fresh empty tmpfs (see _build_args), so these nodes do not exist
+# unless we bind them in from the host. Tooling that shells out for probes
+# relies on them — notably `uv`/`uvx` redirects its glibc/musl detection
+# subprocess to /dev/null; without it uv fails with "Could not detect either
+# glibc version nor musl libc version" and the process exits before it can do
+# anything (e.g. an stdio MCP server dies before the initialize handshake,
+# surfacing as a misleading "Connection closed / please check URL").
+_DEV_NODES: list[str] = [
+    '/dev/null',
+    '/dev/zero',
+    '/dev/full',
+    '/dev/random',
+    '/dev/urandom',
+    '/dev/tty',
+]
+
 _DEFAULT_BASE_DIR = '/tmp/langbot-box-nsjail'
 
 
@@ -329,6 +346,15 @@ class NsjailBackend(BaseSandboxBackend):
         # Isolated /proc and minimal /dev.
         args.extend(['--mount', 'none:/proc:proc:rw'])
         args.extend(['--mount', 'none:/dev:tmpfs:rw'])
+
+        # /dev is a fresh empty tmpfs, so bind in the essential character
+        # devices. Without /dev/null in particular, uv's glibc/musl detection
+        # subprocess fails and any uvx-launched process (e.g. stdio MCP servers)
+        # exits before doing useful work. Mounted read-write so writes to
+        # /dev/null behave normally.
+        for dev in _DEV_NODES:
+            if os.path.exists(dev):
+                args.extend(['--bindmount', f'{dev}:{dev}'])
 
         # Working directory.
         args.extend(['--cwd', spec.workdir])

--- a/tests/box/test_nsjail_backend.py
+++ b/tests/box/test_nsjail_backend.py
@@ -215,6 +215,54 @@ def test_build_nsjail_args_basic(backend, tmp_base):
     assert (session_dir / 'root' / 'home').is_dir()
 
 
+def test_build_nsjail_args_binds_essential_dev_nodes(backend, tmp_base):
+    """/dev is a fresh empty tmpfs, so essential character devices must be
+    bind-mounted in. Regression: without /dev/null, uv's glibc/musl detection
+    subprocess fails ("Could not detect either glibc version nor musl libc
+    version") and uvx-launched stdio MCP servers die before the initialize
+    handshake, surfacing as a misleading "Connection closed / please check URL".
+    """
+    tmp_base.mkdir(parents=True, exist_ok=True)
+    session_dir = tmp_base / 'test_dev'
+    for d in ('root', 'workspace', 'tmp', 'home'):
+        (session_dir / d).mkdir(parents=True)
+
+    spec = BoxSpec(session_id='s-dev', cmd='echo hi')
+    session = BoxSessionInfo(
+        session_id='s-dev',
+        backend_name='nsjail',
+        backend_session_id=str(session_dir),
+        image=spec.image,
+        network=BoxNetworkMode.OFF,
+        created_at='2024-01-01T00:00:00+00:00',
+        last_used_at='2024-01-01T00:00:00+00:00',
+    )
+
+    # Pretend every candidate device node exists on the host.
+    with mock.patch('os.path.exists', return_value=True):
+        args = backend._build_nsjail_args(session, spec, session_dir)
+
+    # /dev itself is a tmpfs mount.
+    mount_specs = [args[i + 1] for i, a in enumerate(args) if a == '--mount']
+    assert 'none:/dev:tmpfs:rw' in mount_specs
+
+    # /dev/null (the critical one for uv) must be bind-mounted read-write,
+    # ordered AFTER the /dev tmpfs mount so it lands on the fresh tmpfs.
+    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == '--bindmount']
+    assert '/dev/null:/dev/null' in rw_binds
+    assert '/dev/urandom:/dev/urandom' in rw_binds
+
+    dev_tmpfs_idx = next(
+        i for i, a in enumerate(args)
+        if a == '--mount' and args[i + 1] == 'none:/dev:tmpfs:rw'
+    )
+    dev_null_idx = next(
+        i for i, a in enumerate(args)
+        if a == '--bindmount' and args[i + 1] == '/dev/null:/dev/null'
+    )
+    assert dev_tmpfs_idx < dev_null_idx
+
+
 def test_build_nsjail_args_network_on(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
     session_dir = tmp_base / 'test_session_net'

--- a/tests/box/test_nsjail_backend.py
+++ b/tests/box/test_nsjail_backend.py
@@ -301,6 +301,9 @@ def test_build_resource_limits_cgroup(backend):
 
     args = backend._build_resource_limits(spec)
 
+    # Bug regression: cgroup v2 mode MUST opt in explicitly, otherwise nsjail
+    # falls back to the v1 layout and aborts on a v2-only host.
+    assert '--use_cgroupv2' in args
     assert '--cgroup_mem_max' in args
     mem_idx = args.index('--cgroup_mem_max')
     assert args[mem_idx + 1] == str(1024 * 1024 * 1024)
@@ -326,6 +329,7 @@ def test_build_resource_limits_rlimit_fallback(backend):
     assert args[nproc_idx + 1] == '128'
 
     # cgroup flags should NOT be present.
+    assert '--use_cgroupv2' not in args
     assert '--cgroup_mem_max' not in args
 
 
@@ -376,35 +380,41 @@ def test_detect_cgroup_v2_no_mount():
         assert NsjailBackend._detect_cgroup_v2() is False
 
 
-def test_detect_cgroup_v2_root_user():
-    def always_exists(self):
-        return True
+def test_detect_cgroup_v2_writable():
+    """When the cgroup v2 root is writable (mkdir succeeds), report True.
+
+    This mirrors the only thing nsjail actually needs: the ability to create a
+    child cgroup under /sys/fs/cgroup. Being root is irrelevant on its own.
+    """
+    def fake_exists(self):
+        path = str(self)
+        return path == '/sys/fs/cgroup' or path.endswith('cgroup.controllers')
+
+    with (
+        mock.patch.object(pathlib.Path, 'exists', fake_exists),
+        mock.patch.object(pathlib.Path, 'mkdir', return_value=None),
+        mock.patch.object(pathlib.Path, 'rmdir', return_value=None),
+    ):
+        assert NsjailBackend._detect_cgroup_v2() is True
+
+
+def test_detect_cgroup_v2_readonly_root_returns_false():
+    """A read-only /sys/fs/cgroup (the default containerized case) must report
+    False so the backend falls back to rlimit limits instead of selecting a
+    cgroup path that nsjail cannot use. Root does NOT override a RO mount."""
+    def fake_exists(self):
+        path = str(self)
+        return path == '/sys/fs/cgroup' or path.endswith('cgroup.controllers')
 
     with (
         mock.patch('os.getuid', return_value=0),
-        mock.patch.object(pathlib.Path, 'exists', always_exists),
-    ):
-        assert NsjailBackend._detect_cgroup_v2() is True
-
-
-def test_detect_cgroup_v2_user_slice_must_be_writable():
-    def fake_exists(self):
-        path = str(self)
-        return path == '/sys/fs/cgroup' or path.endswith('cgroup.controllers') or 'user.slice' in path
-
-    with (
-        mock.patch('os.getuid', return_value=1000),
         mock.patch.object(pathlib.Path, 'exists', fake_exists),
-        mock.patch('os.access', return_value=False),
+        mock.patch.object(
+            pathlib.Path, 'mkdir',
+            side_effect=OSError('Read-only file system'),
+        ),
     ):
         assert NsjailBackend._detect_cgroup_v2() is False
-
-    with (
-        mock.patch('os.getuid', return_value=1000),
-        mock.patch.object(pathlib.Path, 'exists', fake_exists),
-        mock.patch('os.access', return_value=True),
-    ):
-        assert NsjailBackend._detect_cgroup_v2() is True
 
 
 # ── cleanup_orphaned_containers ───────────────────────────────────────

--- a/tests/box/test_nsjail_backend.py
+++ b/tests/box/test_nsjail_backend.py
@@ -93,18 +93,60 @@ async def test_start_session_creates_directories(backend, tmp_base):
 @pytest.mark.anyio
 async def test_start_session_with_host_path(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
+    host_path = str(tmp_base / 'rw_host')
     spec = BoxSpec(
         session_id='sess2',
         cmd='ls',
-        host_path='/some/path',
+        host_path=host_path,
         host_path_mode=BoxHostMountMode.READ_WRITE,
         mount_path='/project',
     )
 
     info = await backend.start_session(spec)
-    assert info.host_path == '/some/path'
+    assert info.host_path == host_path
     assert info.host_path_mode == BoxHostMountMode.READ_WRITE
     assert info.mount_path == '/project'
+
+
+@pytest.mark.anyio
+async def test_start_session_creates_missing_rw_host_path(backend, tmp_base):
+    """Regression: a read-write host_path that does not yet exist must be
+    created by start_session, otherwise nsjail's --bindmount source is missing
+    and the command exits 255 with no output (SaaS MCP shared-workspace bug)."""
+    tmp_base.mkdir(parents=True, exist_ok=True)
+    host_path = tmp_base / 'never_created' / 'workspace'
+    assert not host_path.exists()
+
+    spec = BoxSpec(
+        session_id='sess-mkdir',
+        cmd='ls',
+        host_path=str(host_path),
+        host_path_mode=BoxHostMountMode.READ_WRITE,
+        mount_path='/workspace',
+    )
+
+    await backend.start_session(spec)
+    assert host_path.is_dir()
+
+
+@pytest.mark.anyio
+async def test_start_session_does_not_create_ro_host_path(backend, tmp_base):
+    """A missing read-only host_path is a caller error and must NOT be silently
+    created — it should surface rather than mount an empty dir."""
+    tmp_base.mkdir(parents=True, exist_ok=True)
+    host_path = tmp_base / 'ro_missing'
+    assert not host_path.exists()
+
+    spec = BoxSpec(
+        session_id='sess-ro',
+        cmd='ls',
+        host_path=str(host_path),
+        host_path_mode=BoxHostMountMode.READ_ONLY,
+        mount_path='/project',
+    )
+
+    await backend.start_session(spec)
+    assert not host_path.exists()
 
 
 # ── stop_session ──────────────────────────────────────────────────────


### PR DESCRIPTION
…p v2

Two bugs broke the nsjail backend inside containers (the SaaS/k8s case):

1. _detect_cgroup_v2() returned True for any root user even when /sys/fs/cgroup is mounted read-only (the default in Docker/k8s pods). The backend then selected the cgroup path and nsjail aborted with 'mkdir(...) failed: Read-only file system'. Now we probe real writability by creating+removing a throwaway cgroup dir under the v2 root; a RO mount correctly reports False and the backend falls back to rlimit-based limits, so the sandbox launches instead of failing.

2. _build_resource_limits() emitted v2-style --cgroup_* flags but never passed --use_cgroupv2, so nsjail used the legacy v1 layout and tried to mkdir under /sys/fs/cgroup/<controller>/... which does not exist on a v2-only host. Added the flag in the cgroup branch.

Verified end-to-end on a v6.1/cgroup2 host (matches LangBot Cloud prod):
- RO cgroupfs -> rlimit fallback -> exec exit 0, PID-namespace isolation OK
- writable cgroupfs -> --use_cgroupv2 -> exec exit 0 Both require the pod's /proc to be unmasked (k8s procMount: Unmasked + seccompProfile: Unconfined), which is the documented deployment contract.

Tests updated to assert writability-based detection and the presence/ absence of --use_cgroupv2 in each mode.