### PR TITLE
test(runtime/io): fill out handler.py coverage; document protocol as JSON-RPC 2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,34 +816,49 @@ Encapsulates plugin instance with:
 
 ### Communication Protocol (`runtime/io/`)
 
-**Action-Based Protocol**:
-- Bidirectional JSON messages
-- Request-response with sequence IDs
-- Streaming support via chunk status
-- File transfer (16KB chunks)
+This protocol is **JSON-RPC 2.0 in all but field names** — a bidirectional, action-based
+RPC carried over a single connection. It is the same shape the Language Server Protocol
+(LSP) and the Model Context Protocol (MCP) use: JSON-RPC 2.0 over stdio / WebSocket, with
+either peer free to initiate calls. We did not adopt the spec verbatim, but the semantics
+map 1:1, and it is useful to think of it that way:
 
-**Action Structure**:
+| Our field (`entities/io`)  | JSON-RPC 2.0             | Meaning |
+|----------------------------|--------------------------|---------|
+| `seq_id`                   | `id`                     | Correlates a response back to its request |
+| `action`                   | `method`                 | Which action to invoke |
+| `data` (in a request)      | `params`                 | Call arguments |
+| `data` (in a response)     | `result`                 | Return value (when `code == 0`) |
+| `code` + `message`         | `error.{code,message}`   | `code == 0` is success; non-zero carries the failure in `message` |
+| `chunk_status`             | (MCP-style streaming ext.) | `continue` per chunk, `end` closes a streamed response |
+
+Both peers share one connection and may call each other's actions. Requests and responses
+are told apart by shape: a message carrying `action` is an inbound request, one carrying
+`code` is a response. Each side allocates `seq_id` from its own incrementing counter, so the
+two id spaces are dispatched independently and never collide.
+
+**Request** (`ActionRequest`, `entities/io/req.py`):
 ```json
-{
-  "action": "action_name",
-  "seq": 12345,
-  "data": {...},
-  "chunk_status": "start|continue|end"
-}
+{ "seq_id": 12345, "action": "action_name", "data": {} }
 ```
 
-**Response Structure**:
+**Response** (`ActionResponse`, `entities/io/resp.py`):
 ```json
-{
-  "seq": 12345,
-  "ok": true,
-  "data": {...}
-}
+{ "seq_id": 12345, "code": 0, "message": "success", "data": {}, "chunk_status": "continue" }
 ```
 
-**Transport Implementations**:
-- `StdioHandler`: stdin/stdout communication
-- `WebSocketHandler`: WebSocket client/server
+- `code == 0` → success, payload in `data`; non-zero → error, human-readable text in `message`.
+- **Streaming**: the responder emits N chunks with `chunk_status: "continue"`, then a final
+  `chunk_status: "end"` (consumed by `Handler.call_action_generator`).
+- **File transfer**: large blobs travel as `__file_chunk` actions — 16KB base64 chunks,
+  reassembled to `data/temp/lbp/<file_key>` on the receiving side.
+
+**Core engine**: `runtime/io/handler.py` (`Handler`) owns `seq_id` allocation, the
+`resp_waiters` (single response) and `resp_queues` (streamed response) correlation maps,
+timeouts, and the receive loop (`Handler.run`).
+
+**Transport Implementations** (`Connection` subclasses, `runtime/io/connections/`):
+- `stdio.py`: stdin/stdout — default for subprocess (personal / lightweight) plugins
+- `ws.py`: WebSocket — for containerized / remote plugin deployments
 
 ## CLI Tools
 

--- a/tests/runtime/io/test_handler.py
+++ b/tests/runtime/io/test_handler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import contextlib
 import json
 
 import pytest
@@ -14,6 +16,8 @@ from langbot_plugin.entities.io.errors import (
 from langbot_plugin.entities.io.resp import ActionResponse, ChunkStatus
 from langbot_plugin.runtime.io.connection import Connection
 from langbot_plugin.runtime.io.handler import Handler
+
+from tests.helpers.protocol import ProtocolConnection
 
 
 class SampleAction(ActionType):
@@ -226,3 +230,349 @@ def test_handler_file_storage_dir_is_created_for_instances(tmp_path, monkeypatch
     Handler(QueueConnection())
 
     assert (tmp_path / "data" / "temp" / "lbp").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Response routing through the receive loop (run()).
+#
+# The tests above resolve futures by poking handler.resp_waiters directly,
+# which bypasses run(). These drive a real response message in through the
+# connection so the full request -> wire -> response -> waiter path is covered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_routes_response_to_call_action_waiter():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+    run_task = asyncio.create_task(handler.run())
+
+    call_task = asyncio.create_task(
+        handler.call_action(SampleAction.ECHO, {"x": 1}, timeout=1)
+    )
+    [request] = await conn.sent_messages(1)
+    assert request["action"] == "echo"
+
+    await conn.send_peer_response(request["seq_id"], code=0, data={"ok": True})
+
+    assert await call_task == {"ok": True}
+    assert handler.resp_waiters == {}
+
+    await conn.close_peer()
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_run_routes_streaming_response_to_generator_queue():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+    run_task = asyncio.create_task(handler.run())
+
+    chunks: list[dict] = []
+
+    async def consume():
+        async for chunk in handler.call_action_generator(
+            SampleAction.STREAM, {}, timeout=1
+        ):
+            chunks.append(chunk)
+
+    consume_task = asyncio.create_task(consume())
+    [request] = await conn.sent_messages(1)
+    seq_id = request["seq_id"]
+
+    await conn.send_peer_response(seq_id, data={"part": 1}, chunk_status="continue")
+    await conn.send_peer_response(seq_id, data={"part": 2}, chunk_status="continue")
+    await conn.send_peer_response(seq_id, data={}, chunk_status="end")
+
+    await consume_task
+    assert chunks == [{"part": 1}, {"part": 2}]
+    assert handler.resp_queues == {}
+
+    await conn.close_peer()
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_run_skips_none_message_and_keeps_running():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    @handler.action(SampleAction.ECHO)
+    async def echo(data):
+        return ActionResponse.success({"seen": data})
+
+    run_task = asyncio.create_task(handler.run())
+    await conn.incoming.put(None)  # receive() returns None -> loop should just continue
+
+    await conn.send_peer_request("echo", {"v": 1}, seq_id=5)
+    [response] = await conn.sent_messages(1)
+
+    assert response["seq_id"] == 5
+    assert response["data"] == {"seen": {"v": 1}}
+
+    await conn.close_peer()
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_run_reconnects_while_disconnect_callback_returns_true():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    attempts: list[Handler] = []
+
+    async def on_disconnect(h: Handler) -> bool:
+        attempts.append(h)
+        return len(attempts) < 2  # reconnect once, then give up
+
+    handler.set_disconnect_callback(on_disconnect)
+
+    run_task = asyncio.create_task(handler.run())
+    await conn.incoming.put(ConnectionClosedError("drop-1"))  # -> reconnect (True)
+    await conn.incoming.put(ConnectionClosedError("drop-2"))  # -> give up -> break
+    await run_task
+
+    assert len(attempts) == 2
+    assert attempts[0] is handler
+
+
+@pytest.mark.asyncio
+async def test_run_supports_sync_action_handler_returning_response():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    # A handler whose return value is an ActionResponse rather than a coroutine;
+    # run() handles this via its `isinstance(response, Coroutine)` guard.
+    def sync_echo(data):
+        return ActionResponse.success({"echoed": data})
+
+    handler.actions[SampleAction.ECHO.value] = sync_echo
+
+    run_task = asyncio.create_task(handler.run())
+    await conn.send_peer_request("echo", {"a": 1}, seq_id=11)
+    [response] = await conn.sent_messages(1)
+
+    assert response["seq_id"] == 11
+    assert response["data"] == {"echoed": {"a": 1}}
+
+    await conn.close_peer()
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_call_action_wraps_unexpected_future_error():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    call_task = asyncio.create_task(
+        handler.call_action(SampleAction.ECHO, {}, timeout=1)
+    )
+    [request] = await conn.sent_messages(1)
+
+    # An arbitrary exception delivered on the waiter (not a normal ActionResponse)
+    # is wrapped as ActionCallError instead of leaking the raw exception type.
+    handler.resp_waiters[request["seq_id"]].set_exception(RuntimeError("kaboom"))
+
+    with pytest.raises(ActionCallError, match="RuntimeError: kaboom"):
+        await call_task
+
+    assert handler.resp_waiters == {}
+
+
+# ---------------------------------------------------------------------------
+# Streaming error / timeout / cancellation paths in call_action_generator.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_action_generator_raises_on_error_chunk():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    captured: dict[str, str] = {}
+
+    async def consume():
+        try:
+            async for _ in handler.call_action_generator(
+                SampleAction.STREAM, {}, timeout=1
+            ):
+                pass
+        except ActionCallError as exc:
+            captured["error"] = str(exc)
+
+    task = asyncio.create_task(consume())
+    [request] = await conn.sent_messages(1)
+    queue = handler.resp_queues[request["seq_id"]]
+    await queue.put(
+        ActionResponse(
+            seq_id=request["seq_id"], code=1, message="stream boom", data={}
+        )
+    )
+
+    await task
+    assert captured["error"] == "stream boom"
+    assert handler.resp_queues == {}
+
+
+@pytest.mark.asyncio
+async def test_call_action_generator_times_out_without_response():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    async def consume():
+        async for _ in handler.call_action_generator(
+            SampleAction.STREAM, {}, timeout=0.01
+        ):
+            pass
+
+    with pytest.raises(ActionCallTimeoutError, match="Action stream call timed out"):
+        await consume()
+
+    assert handler.resp_queues == {}
+
+
+@pytest.mark.asyncio
+async def test_call_action_generator_stops_on_cancellation():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    async def consume():
+        async for _ in handler.call_action_generator(
+            SampleAction.STREAM, {}, timeout=5
+        ):
+            pass
+
+    task = asyncio.create_task(consume())
+    [request] = await conn.sent_messages(1)  # generator is now blocked on queue.get
+    assert request["seq_id"] in handler.resp_queues
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    # The generator's finally clause clears its queue regardless of how it exits.
+    assert handler.resp_queues == {}
+
+
+# ---------------------------------------------------------------------------
+# Inbound file transfer: the __file_chunk handler reassembles chunks on disk,
+# then read_local_file / delete_local_file round-trip them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_file_chunk_action_reassembles_file_and_read_delete_roundtrip(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    payload = b"the quick brown fox jumps over the lazy dog" * 3
+    file_key = "roundtrip.bin"
+    chunk_handler = handler.actions[CommonAction.FILE_CHUNK.value]
+
+    size = len(payload)
+    step = (size + 2) // 3
+    pieces = [payload[i : i + step] for i in range(0, size, step)]
+    assert len(pieces) == 3  # exercises both the last-chunk and non-last branches
+
+    for index, piece in enumerate(pieces):
+        resp = await chunk_handler(
+            {
+                "file_key": file_key,
+                "chunk_base64": base64.b64encode(piece).decode("utf-8"),
+                "chunk_index": index,
+                "chunk_amount": len(pieces),
+            }
+        )
+        assert isinstance(resp, ActionResponse)
+        assert resp.code == 0
+
+    assert await handler.read_local_file(file_key) == payload
+
+    # Delete once, then again: the second call must swallow FileNotFoundError.
+    await handler.delete_local_file(file_key)
+    await handler.delete_local_file(file_key)
+
+
+@pytest.mark.asyncio
+async def test_call_action_generator_wraps_unexpected_error():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    captured: dict[str, str] = {}
+
+    async def consume():
+        try:
+            async for _ in handler.call_action_generator(
+                SampleAction.STREAM, {}, timeout=1
+            ):
+                pass
+        except ActionCallError as exc:
+            captured["error"] = str(exc)
+
+    task = asyncio.create_task(consume())
+    [request] = await conn.sent_messages(1)
+    # A malformed queue item (has no `.code`) is wrapped as ActionCallError,
+    # mirroring the same guard in call_action.
+    await handler.resp_queues[request["seq_id"]].put(object())  # type: ignore[arg-type]
+
+    await task
+    assert "AttributeError" in captured["error"]
+    assert handler.resp_queues == {}
+
+
+@pytest.mark.asyncio
+async def test_run_dispatches_file_chunk_action_and_writes_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    run_task = asyncio.create_task(handler.run())
+
+    payload = b"streamed-through-run"
+    file_key = "via-run.bin"
+    await conn.send_peer_request(
+        CommonAction.FILE_CHUNK.value,
+        {
+            "file_key": file_key,
+            "chunk_base64": base64.b64encode(payload).decode("utf-8"),
+            "chunk_index": 0,
+            "chunk_amount": 1,
+        },
+        seq_id=21,
+    )
+    [response] = await conn.sent_messages(1)
+    assert response["seq_id"] == 21
+    assert response["code"] == 0
+
+    # The __file_chunk action was dispatched through run() and written to disk.
+    assert await handler.read_local_file(file_key) == payload
+
+    await conn.close_peer()
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_run_ignores_malformed_message_without_crashing():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+
+    @handler.action(SampleAction.ECHO)
+    async def echo(data):
+        return ActionResponse.success(data)
+
+    run_task = asyncio.create_task(handler.run())
+
+    # A message with neither "action" nor "code" is silently ignored...
+    await conn.incoming.put(json.dumps({"seq_id": 1, "unexpected": "shape"}))
+
+    # ...and the loop keeps serving subsequent requests.
+    await conn.send_peer_request("echo", {"alive": True}, seq_id=2)
+    [response] = await conn.sent_messages(1)
+    assert response["seq_id"] == 2
+    assert response["data"] == {"alive": True}
+
+    await conn.close_peer()
+    await run_task


### PR DESCRIPTION
## Summary

Two related changes to the plugin IO layer. **No production code is touched** — docs + tests only.

1. **docs(runtime/io)** — The `Communication Protocol` section of `AGENTS.md` documented a wire format (`seq`/`ok`) that no longer matches the code. Rewrote it against the real `ActionRequest`/`ActionResponse` shape and added a field-by-field mapping to **JSON-RPC 2.0**, noting this protocol is structurally the same stdio/WebSocket + bidirectional design that **LSP** and **MCP** use.

2. **test(runtime/io)** — Filled out `tests/runtime/io/test_handler.py`. The existing tests resolved waiters by poking `handler.resp_waiters` directly, which bypassed the receive loop. Added cases that drive responses in through the connection so the full request → wire → response path is exercised.

## Coverage

`langbot_plugin/runtime/io/handler.py` branch coverage: **76% → 98%** (tests 9 → 22).

Newly covered paths:
- response / stream routing through `run()` into `resp_waiters` / `resp_queues`
- reconnect via `disconnect_callback`, `None`-message skip, malformed-message ignore
- sync (non-coroutine) action handlers
- generator error chunk / timeout / cancellation / unexpected-error wrapping
- `__file_chunk` reassembly + `read_local_file` / `delete_local_file` round-trip

The remaining ~2% are provably-unreachable defensive branches (e.g. the `elif isinstance(response, AsyncGenerator)` false arm; `del self.resp_queues[...]` in `call_action`'s `finally`). Reaching them would require changing production code, which this PR deliberately avoids.

## Testing

- `pytest tests/runtime/io/test_handler.py` — 22 passed
- Full suite — 793 passed
- `ruff check` — clean

New tests reuse the shared `ProtocolConnection` helper from `tests/helpers/protocol.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)