### PR TITLE
feat: add CLA signing workflow and contributing guide

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,41 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write          # re-run the failed CLA check after signing
+  contents: read          # signatures are stored in the remote langbot-app/cla repo
+  pull-requests: write    # post guidance comments, lock PR after merge
+  statuses: write         # set the commit status
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Upstream repo was archived in 2026-03; pin to the v2.6.1 commit SHA.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # repo-scope PAT with write access to langbot-app/cla
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          path-to-document: 'https://github.com/langbot-app/LangBot/blob/master/CLA.md'
+          remote-organization-name: 'langbot-app'
+          remote-repository-name: 'cla'
+          path-to-signatures: 'signatures/version1/cla.json'
+          branch: 'main'
+          allowlist: 'dependabot[bot],github-actions[bot],devin-ai-integration[bot],Copilot,renovate[bot],bot*'
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! :heart: Before we can merge this pull request, we need you to sign the [LangBot Contributor License Agreement (CLA)](https://github.com/langbot-app/LangBot/blob/master/CLA.md). You keep full copyright of your code — the CLA grants us a license to use and distribute your contribution. Signing takes 10 seconds and covers all repositories in this organization, permanently.
+
+            感谢您的贡献！合并前请阅读并签署[贡献者许可协议（CLA）](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。您保留代码的全部版权，签署仅需回复下方指定内容，一次签署对本组织全部仓库永久有效。
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. :white_check_mark: 所有贡献者均已签署 CLA。'
+          lock-pullrequest-aftermerge: true
+        # SECURITY: this workflow runs on pull_request_target (it holds secrets and has
+        # write access to the base repository). NEVER add an actions/checkout step that
+        # checks out the PR's code here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to langbot-plugin-sdk
+
+Thank you for your interest in contributing! For general contribution guidelines, please refer to the [LangBot contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md).
+
+感谢您有意参与贡献！通用贡献指引请参阅 [LangBot 贡献指南](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)。
+
+## Contributor License Agreement (CLA)
+
+To protect the project and every contributor, we require all code contributors to sign the [LangBot Contributor License Agreement](https://github.com/langbot-app/LangBot/blob/master/CLA.md). You keep full copyright of your code — the CLA only grants us a license to use and distribute your contribution.
+
+Signing takes 10 seconds: when you open your first PR, a bot will guide you to reply with a single comment. One signature covers all repositories in this organization, permanently.
+
+为了保护项目和每一位贡献者，我们要求所有代码贡献者签署 [LangBot 贡献者许可协议（CLA）](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。您保留自己代码的全部版权，CLA 仅授予项目使用、分发您贡献的许可。
+
+签署只需 10 秒：首次提交 PR 时，机器人会自动评论提示，按提示回复一句话即完成签署，此后对本组织所有仓库永久有效。


### PR DESCRIPTION
## Overview

Enables the organization-wide Contributor License Agreement check for this repository (companion to [LangBot#2236](https://github.com/langbot-app/LangBot/pull/2236)):

- **`.github/workflows/cla.yml`** — same automated signing workflow as the main repo (`contributor-assistant/github-action` pinned to v2.6.1). The CLA text lives in [langbot-app/LangBot/CLA.md](https://github.com/langbot-app/LangBot/blob/master/CLA.md); signatures are recorded in [langbot-app/cla](https://github.com/langbot-app/cla) and shared across all org repositories — contributors who signed in any org repo are automatically covered here.
- **`CONTRIBUTING.md`** — new file with a bilingual CLA notice, linking to the main repo's contribution guide.

为本仓库启用组织级 CLA 检查（与 LangBot#2236 配套）：复用同一份 CLA 文本与签名库，在任一组织仓库签署过的贡献者在此自动免签。

## ⚠️ Before merging / 合并前置条件

1. Add the repository secret **`CLA_PAT`** (the same PAT with write access to `langbot-app/cla` used in the main repo). / 添加仓库 secret `CLA_PAT`（与主仓库相同、对 `langbot-app/cla` 有写权限的 PAT）。
2. Merge after [LangBot#2236](https://github.com/langbot-app/LangBot/pull/2236) so the CLA document link resolves. / 在 LangBot#2236 合并之后再合并本 PR，确保 CLA 文档链接有效。

## Security note

The workflow runs on `pull_request_target` and holds secrets. It must never check out PR code — a warning comment is included in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)