### PR TITLE
[codex] Expose rerank invocation to plugins

### DIFF
--- a/src/langbot_plugin/api/proxies/langbot_api.py
+++ b/src/langbot_plugin/api/proxies/langbot_api.py
@@ -284,6 +284,43 @@ class LangBotAPIProxy:
             )
         )["vectors"]
 
+    async def invoke_rerank(
+        self,
+        rerank_model_uuid: str,
+        query: str,
+        documents: list[str],
+        top_k: int | None = None,
+        extra_args: dict[str, Any] | None = None,
+        timeout: float = 60.0,
+    ) -> list[dict[str, Any]]:
+        """Rerank documents using Host's rerank model.
+
+        Args:
+            rerank_model_uuid: The UUID of the rerank model to use.
+            query: Query text used to score document relevance.
+            documents: Candidate document texts to rerank.
+            top_k: Optional number of scored results to return.
+            extra_args: Optional provider-specific arguments.
+            timeout: Request timeout in seconds.
+
+        Returns:
+            List of score dicts, usually containing ``index`` and
+            ``relevance_score``.
+        """
+        return (
+            await self.plugin_runtime_handler.call_action(
+                PluginToRuntimeAction.INVOKE_RERANK,
+                {
+                    "rerank_model_uuid": rerank_model_uuid,
+                    "query": query,
+                    "documents": documents,
+                    "top_k": top_k,
+                    "extra_args": extra_args or {},
+                },
+                timeout=timeout,
+            )
+        )["results"]
+
     async def vector_upsert(
         self,
         collection_id: str,

--- a/src/langbot_plugin/entities/io/actions/enums.py
+++ b/src/langbot_plugin/entities/io/actions/enums.py
@@ -61,6 +61,7 @@ class PluginToRuntimeAction(ActionType):
     CALL_TOOL = "call_tool"
 
     INVOKE_EMBEDDING = "invoke_embedding"
+    INVOKE_RERANK = "invoke_rerank"
     VECTOR_UPSERT = "vector_upsert"
     VECTOR_SEARCH = "vector_search"
     VECTOR_DELETE = "vector_delete"

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -232,6 +232,17 @@ class PluginConnectionHandler(handler.Handler):
             )
             return handler.ActionResponse.success(result)
 
+        @self.action(PluginToRuntimeAction.INVOKE_RERANK)
+        async def invoke_rerank(data: dict[str, Any]) -> handler.ActionResponse:
+            result = await self.context.control_handler.call_action(
+                PluginToRuntimeAction.INVOKE_RERANK,
+                {
+                    **data,
+                },
+                timeout=60,
+            )
+            return handler.ActionResponse.success(result)
+
         # ================= RAG Capability Handlers (Plugin -> Runtime -> Host) =================
 
         async def _proxy_rag_action(

--- a/tests/api/proxies/test_langbot_api.py
+++ b/tests/api/proxies/test_langbot_api.py
@@ -146,6 +146,9 @@ async def test_tool_and_rag_helpers_preserve_payload_contracts():
             PluginToRuntimeAction.GET_TOOL_DETAIL: {"tool": {"name": "tool"}},
             PluginToRuntimeAction.CALL_TOOL: {"tool_response": {"ok": True}},
             PluginToRuntimeAction.INVOKE_EMBEDDING: {"vectors": [[0.1]]},
+            PluginToRuntimeAction.INVOKE_RERANK: {
+                "results": [{"index": 0, "relevance_score": 0.9}]
+            },
             PluginToRuntimeAction.VECTOR_SEARCH: {"results": [{"id": "1"}]},
             PluginToRuntimeAction.VECTOR_DELETE: {"count": 2},
             PluginToRuntimeAction.VECTOR_LIST: {"items": [], "total": 0},
@@ -161,6 +164,9 @@ async def test_tool_and_rag_helpers_preserve_payload_contracts():
     assert await proxy.get_tool_detail("tool") == {"name": "tool"}
     assert await proxy.call_tool("tool", {"q": 1}, {"s": 1}, 7) == {"ok": True}
     assert await proxy.invoke_embedding("embed", ["hi"]) == [[0.1]]
+    assert await proxy.invoke_rerank(
+        "rerank", "query", ["doc"], top_k=1, extra_args={"return_documents": False}
+    ) == [{"index": 0, "relevance_score": 0.9}]
     await proxy.vector_upsert("c", [[0.1]], ["id"], documents=["doc"])
     assert await proxy.vector_search("c", [0.1], filters={"a": 1}) == [{"id": "1"}]
     assert await proxy.vector_delete("c", file_ids=["f"]) == 2
@@ -173,6 +179,18 @@ async def test_tool_and_rag_helpers_preserve_payload_contracts():
     ][0]
     assert call_tool_call[1]["tool_parameters"] == {"q": 1}
     assert call_tool_call[2] == 180
+
+    rerank_call = [
+        call for call in handler.calls if call[0] is PluginToRuntimeAction.INVOKE_RERANK
+    ][0]
+    assert rerank_call[1] == {
+        "rerank_model_uuid": "rerank",
+        "query": "query",
+        "documents": ["doc"],
+        "top_k": 1,
+        "extra_args": {"return_documents": False},
+    }
+    assert rerank_call[2] == 60.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a dedicated plugin action for invoking LangBot rerank models from plugins.

- Adds PluginToRuntimeAction.INVOKE_RERANK.
- Adds LangBotAPIProxy.invoke_rerank(...).
- Forwards runtime plugin requests for rerank invocation.
- Covers the new proxy behavior with tests.

## Impact

Plugins can call Host-managed rerank models directly instead of approximating rerank through LLM model selectors.

## Validation

- uv run pytest tests/api/proxies/test_langbot_api.py
- git diff --check

## Related

Part of cross-repo LangRAG dedicated rerank model support. The LangBot core and LangRAG PRs depend on this SDK action being available.