### PR TITLE
feat(api): expose LLM usage results

### DIFF
--- a/src/langbot_plugin/api/entities/builtin/provider/message.py
+++ b/src/langbot_plugin/api/entities/builtin/provider/message.py
@@ -95,6 +95,9 @@ class Message(pydantic.BaseModel):
 
     tool_call_id: typing.Optional[str] = None
 
+    resp_message_id: typing.Optional[str] = None
+    """Response message ID for tracking"""
+
     def readable_str(self) -> str:
         if self.content is not None:
             return (
@@ -185,6 +188,7 @@ class MessageChunk(pydantic.BaseModel):
     is_final: bool = False
     """是否是结束"""
 
+
     msg_sequence: int = 0
     """消息迭代次数"""
 
@@ -262,3 +266,40 @@ class ToolCallChunk(pydantic.BaseModel):
 
     function: FunctionCall
     """函数调用"""
+
+
+class LLMTokenUsage(pydantic.BaseModel):
+    """Token usage returned by an LLM provider.
+
+    The standard OpenAI-compatible counters are normalized when available.
+    Provider-specific fields such as prompt/completion token details or cache
+    counters are preserved as extra fields.
+    """
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+    model_config = pydantic.ConfigDict(extra="allow")
+
+
+class LLMInvokeResult(pydantic.BaseModel):
+    """Non-streaming LLM invoke result with optional provider usage."""
+
+    message: Message
+    usage: LLMTokenUsage | None = None
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class LLMStreamEvent(pydantic.BaseModel):
+    """Streaming LLM event.
+
+    Most events carry a message chunk. A final provider usage event may carry
+    usage without a chunk when the upstream API reports usage after completion.
+    """
+
+    chunk: MessageChunk | None = None
+    usage: LLMTokenUsage | None = None
+
+    model_config = pydantic.ConfigDict(extra="forbid")

--- a/src/langbot_plugin/api/proxies/langbot_api.py
+++ b/src/langbot_plugin/api/proxies/langbot_api.py
@@ -84,22 +84,96 @@ class LangBotAPIProxy:
         timeout: float | None = None,
     ) -> provider_message.Message:
         """Invoke an LLM model"""
-        effective_timeout = timeout if timeout is not None else 120.0
-        resp = (
-            await self.plugin_runtime_handler.call_action(
-                PluginToRuntimeAction.INVOKE_LLM,
-                {
-                    "llm_model_uuid": llm_model_uuid,
-                    "messages": [m.model_dump() for m in messages],
-                    "funcs": [f.model_dump() for f in funcs],
-                    "extra_args": extra_args,
-                    "timeout": effective_timeout,
-                },
-                timeout=effective_timeout,
-            )
-        )["message"]
+        result = await self.invoke_llm_with_usage(
+            llm_model_uuid=llm_model_uuid,
+            messages=messages,
+            funcs=funcs,
+            extra_args=extra_args,
+            timeout=timeout,
+        )
+        return result.message
 
-        return provider_message.Message.model_validate(resp)
+    async def invoke_llm_with_usage(
+        self,
+        llm_model_uuid: str,
+        messages: list[provider_message.Message],
+        funcs: list[resource_tool.LLMTool] = [],
+        extra_args: dict[str, Any] = {},
+        timeout: float | None = None,
+    ) -> provider_message.LLMInvokeResult:
+        """Invoke an LLM model and return the message plus optional provider usage."""
+        effective_timeout = timeout if timeout is not None else 120.0
+        resp = await self.plugin_runtime_handler.call_action(
+            PluginToRuntimeAction.INVOKE_LLM,
+            {
+                "llm_model_uuid": llm_model_uuid,
+                "messages": [m.model_dump() for m in messages],
+                "funcs": [f.model_dump() for f in funcs],
+                "extra_args": extra_args,
+                "timeout": effective_timeout,
+            },
+            timeout=effective_timeout,
+        )
+
+        return provider_message.LLMInvokeResult.model_validate(
+            {
+                "message": resp["message"],
+                "usage": resp.get("usage") if isinstance(resp, dict) else None,
+            }
+        )
+
+    async def invoke_llm_stream(
+        self,
+        llm_model_uuid: str,
+        messages: list[provider_message.Message],
+        funcs: list[resource_tool.LLMTool] = [],
+        extra_args: dict[str, Any] = {},
+    ):
+        """Invoke an LLM model with streaming response
+
+        Args:
+            llm_model_uuid: The UUID of the LLM model to use
+            messages: List of conversation messages
+            funcs: List of tools available to the LLM
+            extra_args: Extra arguments for the LLM provider
+
+        Yields:
+            MessageChunk: Streamed message chunks from the LLM
+        """
+        async for event in self.invoke_llm_stream_events(
+            llm_model_uuid=llm_model_uuid,
+            messages=messages,
+            funcs=funcs,
+            extra_args=extra_args,
+        ):
+            if event.chunk is not None:
+                yield event.chunk
+
+    async def invoke_llm_stream_events(
+        self,
+        llm_model_uuid: str,
+        messages: list[provider_message.Message],
+        funcs: list[resource_tool.LLMTool] = [],
+        extra_args: dict[str, Any] = {},
+    ):
+        """Invoke an LLM model and yield chunks plus optional final usage events."""
+        async for chunk_data in self.plugin_runtime_handler.call_action_generator(
+            PluginToRuntimeAction.INVOKE_LLM_STREAM,
+            {
+                "llm_model_uuid": llm_model_uuid,
+                "messages": [m.model_dump() for m in messages],
+                "funcs": [f.model_dump() for f in funcs],
+                "extra_args": extra_args,
+            },
+        ):
+            event_data: dict[str, Any] = {}
+            if isinstance(chunk_data, dict) and "chunk" in chunk_data:
+                event_data["chunk"] = chunk_data["chunk"]
+            if isinstance(chunk_data, dict) and "usage" in chunk_data:
+                event_data["usage"] = chunk_data["usage"]
+            if not event_data:
+                event_data["chunk"] = chunk_data["chunk"]
+            yield provider_message.LLMStreamEvent.model_validate(event_data)
 
     async def set_plugin_storage(self, key: str, value: bytes) -> None:
         """Set a plugin storage value"""

--- a/tests/api/proxies/test_langbot_api.py
+++ b/tests/api/proxies/test_langbot_api.py
@@ -99,6 +99,36 @@ async def test_invoke_llm_serializes_messages_and_uses_effective_timeout():
 
 
 @pytest.mark.asyncio
+async def test_invoke_llm_with_usage_preserves_provider_usage():
+    handler = FakeHandler(
+        {
+            PluginToRuntimeAction.INVOKE_LLM: {
+                "message": {"role": "assistant", "content": "ok"},
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 8,
+                    "total_tokens": 20,
+                    "prompt_tokens_details": {"cached_tokens": 5},
+                },
+            }
+        }
+    )
+    proxy = LangBotAPIProxy(handler)
+
+    result = await proxy.invoke_llm_with_usage(
+        "model",
+        [Message(role="user", content="hello")],
+    )
+
+    assert result.message == Message(role="assistant", content="ok")
+    assert result.usage is not None
+    assert result.usage.total_tokens == 20
+    assert result.usage.model_dump()["prompt_tokens_details"] == {
+        "cached_tokens": 5
+    }
+
+
+@pytest.mark.asyncio
 async def test_storage_helpers_encode_and_decode_base64():
     handler = FakeHandler(
         {


### PR DESCRIPTION
## Summary

Split the generic LangBotAPI LLM usage changes out of the AgentRunner pluginization PR.

This PR adds provider response usage models and keeps the existing `invoke_llm` / `invoke_llm_stream` compatibility surface while exposing explicit APIs for usage-aware responses.

## Changes

- Add `LLMTokenUsage`, `LLMInvokeResult`, and `LLMStreamEvent` provider entities.
- Add `LangBotAPIProxy.invoke_llm_with_usage`.
- Add `LangBotAPIProxy.invoke_llm_stream_events` while preserving chunk-only streaming behavior for `invoke_llm_stream`.

## Validation

- `uv run pytest tests/api/proxies/test_langbot_api.py` (`8 passed`)
- `uv run ruff check src/langbot_plugin/api/entities/builtin/provider/message.py src/langbot_plugin/api/proxies/langbot_api.py tests/api/proxies/test_langbot_api.py`