### PR TITLE
feat(agent-tools): add run-scoped MCP bridge

### DIFF
--- a/src/langbot_plugin/api/agent_tools/__init__.py
+++ b/src/langbot_plugin/api/agent_tools/__init__.py
@@ -1,0 +1,23 @@
+"""External tool adapters for LangBot AgentRunner components."""
+
+from langbot_plugin.api.agent_tools.decorators import (
+    AgentToolSpec,
+    agent_tool,
+    collect_agent_tools,
+)
+from langbot_plugin.api.agent_tools.external_tools import AgentRunExternalTools
+from langbot_plugin.api.agent_tools.mcp_bridge import (
+    LANGBOT_AGENT_MCP_SERVER_NAME,
+    AgentRunMCPBridge,
+    merge_mcp_server_config,
+)
+
+__all__ = [
+    "AgentRunExternalTools",
+    "AgentRunMCPBridge",
+    "AgentToolSpec",
+    "LANGBOT_AGENT_MCP_SERVER_NAME",
+    "agent_tool",
+    "collect_agent_tools",
+    "merge_mcp_server_config",
+]

--- a/src/langbot_plugin/api/agent_tools/decorators.py
+++ b/src/langbot_plugin/api/agent_tools/decorators.py
@@ -1,0 +1,97 @@
+"""Declarative AgentRunner external tool registration."""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import typing
+
+import pydantic
+
+
+@dataclasses.dataclass(frozen=True)
+class AgentToolSpec:
+    """Metadata used to expose a run-scoped AgentRunner tool."""
+
+    name: str
+    description: str
+    args_model: type[pydantic.BaseModel]
+    read_only: bool = False
+
+    def input_schema(self) -> dict[str, typing.Any]:
+        return self.args_model.model_json_schema()
+
+    def to_mcp_tool(self) -> dict[str, typing.Any]:
+        tool: dict[str, typing.Any] = {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.input_schema(),
+        }
+        if self.read_only:
+            tool["annotations"] = {"readOnlyHint": True}
+        return tool
+
+
+@dataclasses.dataclass(frozen=True)
+class BoundAgentTool:
+    spec: AgentToolSpec
+    handler: typing.Callable[[pydantic.BaseModel], typing.Awaitable[typing.Any]]
+
+
+def agent_tool(
+    *,
+    name: str,
+    description: str,
+    args_model: type[pydantic.BaseModel],
+    read_only: bool = False,
+) -> typing.Callable[
+    [typing.Callable[..., typing.Any]], typing.Callable[..., typing.Any]
+]:
+    """Mark a method as safe to expose through external AgentRunner adapters."""
+
+    def decorator(
+        func: typing.Callable[..., typing.Any],
+    ) -> typing.Callable[..., typing.Any]:
+        setattr(
+            func,
+            "__langbot_agent_tool__",
+            AgentToolSpec(
+                name=name,
+                description=description,
+                args_model=args_model,
+                read_only=read_only,
+            ),
+        )
+        return func
+
+    return decorator
+
+
+def _tool_spec(method: typing.Any) -> AgentToolSpec | None:
+    spec = getattr(method, "__langbot_agent_tool__", None)
+    if isinstance(spec, AgentToolSpec):
+        return spec
+    func = getattr(method, "__func__", None)
+    spec = getattr(func, "__langbot_agent_tool__", None)
+    if isinstance(spec, AgentToolSpec):
+        return spec
+    return None
+
+
+def collect_agent_tools(obj: object) -> dict[str, BoundAgentTool]:
+    """Collect explicitly annotated tools from an object instance."""
+
+    tools: dict[str, BoundAgentTool] = {}
+    for attr_name in dir(obj):
+        method = getattr(obj, attr_name)
+        spec = _tool_spec(method)
+        if spec is None:
+            continue
+        if not callable(method):
+            continue
+        if not inspect.iscoroutinefunction(method):
+            raise TypeError(f"Agent tool {spec.name} must be async")
+        if spec.name in tools:
+            raise ValueError(f"Duplicate Agent tool name: {spec.name}")
+        tools[spec.name] = BoundAgentTool(spec=spec, handler=method)
+    return tools

--- a/src/langbot_plugin/api/agent_tools/external_tools.py
+++ b/src/langbot_plugin/api/agent_tools/external_tools.py
@@ -1,0 +1,207 @@
+"""Run-scoped LangBot tools exposed to external harnesses."""
+
+from __future__ import annotations
+
+import json
+import typing
+
+import pydantic
+
+from langbot_plugin.api.agent_tools.decorators import agent_tool, collect_agent_tools
+from langbot_plugin.api.entities.builtin.agent_runner.context import AgentRunContext
+from langbot_plugin.api.proxies.agent_run_api import AgentRunAPIProxy
+
+
+class EmptyArgs(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class HistoryPageArgs(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    conversation_id: str | None = None
+    before_cursor: str | None = None
+    after_cursor: str | None = None
+    limit: int = pydantic.Field(default=50, ge=1, le=100)
+    direction: str = pydantic.Field(default="backward", pattern="^(backward|forward)$")
+    include_artifacts: bool = False
+
+
+class RetrieveKnowledgeArgs(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    kb_id: str
+    query_text: str | None = None
+    query: str | None = None
+    top_k: int = pydantic.Field(default=5, ge=1, le=20)
+    filters: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+class CallToolArgs(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    tool_name: str
+    parameters: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+
+
+def _dump_jsonable(value: typing.Any) -> typing.Any:
+    if value is None:
+        return None
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    if isinstance(value, dict):
+        return {str(k): _dump_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_dump_jsonable(item) for item in value]
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+class AgentRunExternalTools:
+    """Annotated tool surface backed by AgentRunAPIProxy."""
+
+    def __init__(self, api: AgentRunAPIProxy, ctx: AgentRunContext) -> None:
+        self.api = api
+        self.ctx = ctx
+        self._tools = collect_agent_tools(self)
+
+    def _available_tool_names(self) -> set[str]:
+        names = {"langbot_get_current_event"}
+
+        available_apis = self.ctx.context.available_apis
+        if available_apis.history_page:
+            names.add("langbot_history_page")
+        if self.ctx.resources.knowledge_bases:
+            names.add("langbot_retrieve_knowledge")
+        if self.ctx.resources.tools:
+            names.add("langbot_call_tool")
+
+        return names
+
+    def mcp_tools(self) -> list[dict[str, typing.Any]]:
+        available_names = self._available_tool_names()
+        return [
+            tool.spec.to_mcp_tool()
+            for name, tool in self._tools.items()
+            if name in available_names
+        ]
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, typing.Any] | None = None
+    ) -> typing.Any:
+        tool = self._tools.get(name) if name in self._available_tool_names() else None
+        if tool is None:
+            raise ValueError(f"Unknown LangBot external tool: {name}")
+        args = tool.spec.args_model.model_validate(arguments or {})
+        return await tool.handler(args)
+
+    async def call_mcp_tool(
+        self, name: str, arguments: dict[str, typing.Any] | None = None
+    ) -> dict[str, typing.Any]:
+        try:
+            result = await self.call_tool(name, arguments)
+        except Exception as e:
+            return {
+                "isError": True,
+                "content": [
+                    {
+                        "type": "text",
+                        "text": str(e),
+                    }
+                ],
+            }
+
+        structured = _dump_jsonable(result)
+        if not isinstance(structured, dict):
+            structured = {"result": structured}
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(structured, ensure_ascii=False),
+                }
+            ],
+            "structuredContent": structured,
+        }
+
+    @agent_tool(
+        name="langbot_get_current_event",
+        description="Return the current LangBot event, input, actor, subject, resources, context, state, and runtime snapshot.",
+        args_model=EmptyArgs,
+        read_only=True,
+    )
+    async def get_current_event(self, args: EmptyArgs) -> dict[str, typing.Any]:
+        input_value = self.ctx.input
+        input_text = ""
+        if input_value is not None:
+            to_text = getattr(input_value, "to_text", None)
+            if callable(to_text):
+                input_text = to_text()
+            else:
+                input_text = getattr(input_value, "text", "") or ""
+
+        return {
+            "run_id": self.ctx.run_id,
+            "trigger": _dump_jsonable(self.ctx.trigger),
+            "event": _dump_jsonable(self.ctx.event),
+            "conversation": _dump_jsonable(self.ctx.conversation),
+            "actor": _dump_jsonable(self.ctx.actor),
+            "subject": _dump_jsonable(self.ctx.subject),
+            "input": {
+                "text": input_text,
+                "attachments": _dump_jsonable(getattr(input_value, "attachments", [])),
+                "contents": _dump_jsonable(getattr(input_value, "contents", [])),
+            },
+            "resources": _dump_jsonable(self.ctx.resources),
+            "context": _dump_jsonable(self.ctx.context),
+            "state": _dump_jsonable(self.ctx.state),
+            "runtime": _dump_jsonable(self.ctx.runtime),
+        }
+
+    @agent_tool(
+        name="langbot_history_page",
+        description="Page through authorized LangBot conversation history for the current run.",
+        args_model=HistoryPageArgs,
+        read_only=True,
+    )
+    async def history_page(self, args: HistoryPageArgs) -> dict[str, typing.Any]:
+        return await self.api.history_page(
+            conversation_id=args.conversation_id,
+            before_cursor=args.before_cursor,
+            after_cursor=args.after_cursor,
+            limit=args.limit,
+            direction=args.direction,
+            include_artifacts=args.include_artifacts,
+        )
+
+    @agent_tool(
+        name="langbot_retrieve_knowledge",
+        description="Retrieve documents from an authorized LangBot knowledge base for the current run.",
+        args_model=RetrieveKnowledgeArgs,
+        read_only=True,
+    )
+    async def retrieve_knowledge(
+        self, args: RetrieveKnowledgeArgs
+    ) -> list[dict[str, typing.Any]]:
+        query_text = (args.query_text or args.query or "").strip()
+        if not query_text:
+            raise ValueError("query_text is required")
+        return await self.api.retrieve_knowledge(
+            kb_id=args.kb_id,
+            query_text=query_text,
+            top_k=args.top_k,
+            filters=args.filters,
+        )
+
+    @agent_tool(
+        name="langbot_call_tool",
+        description="Call an authorized LangBot tool for the current run.",
+        args_model=CallToolArgs,
+    )
+    async def call_langbot_tool(self, args: CallToolArgs) -> dict[str, typing.Any]:
+        return await self.api.call_tool(
+            tool_name=args.tool_name,
+            parameters=args.parameters,
+        )

--- a/src/langbot_plugin/api/agent_tools/mcp_bridge.py
+++ b/src/langbot_plugin/api/agent_tools/mcp_bridge.py
@@ -1,0 +1,341 @@
+"""MCP adapter for annotated LangBot AgentRunner tools."""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import secrets
+import sys
+import threading
+import typing
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from langbot_plugin.api.agent_tools.external_tools import AgentRunExternalTools
+from langbot_plugin.api.entities.builtin.agent_runner.context import AgentRunContext
+from langbot_plugin.api.proxies.agent_run_api import AgentRunAPIProxy
+
+LANGBOT_AGENT_MCP_SERVER_NAME = "langbot_agent"
+MCP_SERVER_INFO = {"name": "langbot-agent", "version": "0.1.0"}
+
+
+def merge_mcp_server_config(
+    base_config: dict[str, typing.Any] | None,
+    server_config: dict[str, typing.Any],
+    *,
+    server_name: str = LANGBOT_AGENT_MCP_SERVER_NAME,
+) -> dict[str, typing.Any]:
+    """Return an MCP config with a LangBot run-scoped server added."""
+
+    data = dict(base_config or {})
+    servers = data.get("mcpServers") or data.get("mcp_servers") or {}
+    if not isinstance(servers, dict):
+        raise ValueError("MCP config mcpServers must be an object")
+
+    merged_servers = dict(servers)
+    merged_servers[server_name] = server_config
+    data["mcpServers"] = merged_servers
+    data.pop("mcp_servers", None)
+    return data
+
+
+class AgentRunMCPBridge:
+    """Run-scoped localhost bridge used by stdio MCP proxy processes."""
+
+    def __init__(
+        self,
+        tools: AgentRunExternalTools,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        request_timeout: float = 60.0,
+        server_name: str = LANGBOT_AGENT_MCP_SERVER_NAME,
+    ) -> None:
+        self.tools = tools
+        self.host = host
+        self.port = port
+        self.request_timeout = request_timeout
+        self.server_name = server_name
+        self.token = secrets.token_urlsafe(32)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @classmethod
+    def from_run_api(
+        cls,
+        api: AgentRunAPIProxy,
+        ctx: AgentRunContext,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        request_timeout: float = 60.0,
+        server_name: str = LANGBOT_AGENT_MCP_SERVER_NAME,
+    ) -> "AgentRunMCPBridge":
+        return cls(
+            AgentRunExternalTools(api, ctx),
+            host=host,
+            port=port,
+            request_timeout=request_timeout,
+            server_name=server_name,
+        )
+
+    @property
+    def endpoint(self) -> str:
+        if self._server is None:
+            raise RuntimeError("LangBot Agent MCP bridge is not started")
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    @property
+    def http_mcp_endpoint(self) -> str:
+        return f"{self.endpoint}/mcp/http"
+
+    def start(self) -> None:
+        if self._server is not None:
+            return
+
+        self._loop = asyncio.get_running_loop()
+        bridge = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args: typing.Any) -> None:
+                return
+
+            def do_GET(self) -> None:
+                if self.path != "/healthz":
+                    self.send_error(404)
+                    return
+                self._write_json(200, {"ok": True})
+
+            def do_POST(self) -> None:
+                if self.path not in {"/mcp", "/mcp/http"}:
+                    self.send_error(404)
+                    return
+                if not self._authorized():
+                    self._write_json(401, {"ok": False, "error": "unauthorized"})
+                    return
+
+                payload = self._read_json_payload()
+                if isinstance(payload, Exception):
+                    self._write_json(400, {"ok": False, "error": f"invalid JSON: {payload}"})
+                    return
+
+                if self.path == "/mcp/http":
+                    assert bridge._loop is not None
+                    future = asyncio.run_coroutine_threadsafe(
+                        bridge.handle_http_mcp_request(payload),
+                        bridge._loop,
+                    )
+                    try:
+                        result = future.result(timeout=bridge.request_timeout)
+                    except Exception as e:
+                        self._write_json(500, _jsonrpc_error(None, -32000, str(e)))
+                        return
+                    if result is None:
+                        self._write_empty(202)
+                        return
+                    self._write_json(200, result)
+                    return
+
+                if not isinstance(payload, dict):
+                    self._write_json(
+                        400, {"ok": False, "error": "request must be an object"}
+                    )
+                    return
+
+                try:
+                    assert bridge._loop is not None
+                    future = asyncio.run_coroutine_threadsafe(
+                        bridge.handle_mcp_method(
+                            str(payload.get("method") or ""),
+                            payload.get("params") or {},
+                        ),
+                        bridge._loop,
+                    )
+                    result = future.result(timeout=bridge.request_timeout)
+                except Exception as e:
+                    self._write_json(500, {"ok": False, "error": str(e)})
+                    return
+                self._write_json(200, {"ok": True, "result": result})
+
+            def _authorized(self) -> bool:
+                token = self.headers.get("X-LangBot-Agent-MCP-Token", "")
+                authorization = self.headers.get("Authorization", "")
+                return hmac.compare_digest(token, bridge.token) or hmac.compare_digest(
+                    authorization,
+                    f"Bearer {bridge.token}",
+                )
+
+            def _read_json_payload(self) -> typing.Any:
+                try:
+                    length = int(self.headers.get("Content-Length", "0"))
+                except ValueError:
+                    length = 0
+                try:
+                    body = self.rfile.read(length).decode("utf-8")
+                    return json.loads(body) if body else {}
+                except Exception as e:
+                    return e
+
+            def _write_json(self, status: int, payload: dict[str, typing.Any]) -> None:
+                data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def _write_empty(self, status: int) -> None:
+                self.send_response(status)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        self._server = ThreadingHTTPServer((self.host, self.port), Handler)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="langbot-agent-mcp-bridge",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        server = self._server
+        thread = self._thread
+        self._server = None
+        self._thread = None
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if thread is not None:
+            thread.join(timeout=2)
+
+    def mcp_server_config(self) -> dict[str, typing.Any]:
+        """Return stdio MCP config for external harnesses."""
+
+        return {
+            "command": sys.executable,
+            "args": ["-m", "langbot_plugin.api.agent_tools.mcp_stdio"],
+            "env": {
+                "LANGBOT_AGENT_MCP_ENDPOINT": self.endpoint,
+                "LANGBOT_AGENT_MCP_TOKEN": self.token,
+            },
+        }
+
+    def http_mcp_server_config(
+        self,
+        *,
+        public_url: str | None = None,
+        transport: str = "http",
+    ) -> dict[str, typing.Any]:
+        """Return HTTP MCP server config for external harnesses."""
+
+        url = (public_url or self.http_mcp_endpoint).strip()
+        return {
+            "name": self.server_name,
+            "url": url,
+            "type": transport,
+            "transport": transport,
+            "headers": {
+                "Authorization": f"Bearer {self.token}",
+                "X-LangBot-Agent-MCP-Token": self.token,
+            },
+        }
+
+    def merged_mcp_config(
+        self, base_config: dict[str, typing.Any] | None = None
+    ) -> dict[str, typing.Any]:
+        return merge_mcp_server_config(
+            base_config,
+            self.mcp_server_config(),
+            server_name=self.server_name,
+        )
+
+    async def handle_mcp_method(
+        self, method: str, params: dict[str, typing.Any]
+    ) -> dict[str, typing.Any]:
+        if method == "tools/list":
+            return {"tools": self.tools.mcp_tools()}
+        if method == "tools/call":
+            name = str(params.get("name") or "")
+            arguments = params.get("arguments") or {}
+            if not isinstance(arguments, dict):
+                arguments = {}
+            return await self.tools.call_mcp_tool(name, arguments)
+        raise ValueError(f"Unsupported MCP bridge method: {method}")
+
+    async def handle_http_mcp_request(
+        self, payload: typing.Any
+    ) -> dict[str, typing.Any] | list[dict[str, typing.Any]] | None:
+        if isinstance(payload, list):
+            if not payload:
+                return _jsonrpc_error(None, -32600, "Invalid request")
+            responses: list[dict[str, typing.Any]] = []
+            for item in payload:
+                response = await self._handle_http_mcp_message(item)
+                if response is not None:
+                    responses.append(response)
+            return responses or None
+        return await self._handle_http_mcp_message(payload)
+
+    async def _handle_http_mcp_message(
+        self, message: typing.Any
+    ) -> dict[str, typing.Any] | None:
+        if not isinstance(message, dict):
+            return _jsonrpc_error(None, -32600, "Invalid request")
+
+        message_id = message.get("id")
+        method = str(message.get("method") or "")
+        params = message.get("params") or {}
+        if not isinstance(params, dict):
+            params = {}
+
+        if message_id is None:
+            return None
+
+        if method == "initialize":
+            return _jsonrpc_result(
+                message_id,
+                {
+                    "protocolVersion": str(
+                        params.get("protocolVersion") or "2025-06-18"
+                    ),
+                    "capabilities": {
+                        "tools": {
+                            "listChanged": False,
+                        }
+                    },
+                    "serverInfo": MCP_SERVER_INFO,
+                },
+            )
+        if method == "ping":
+            return _jsonrpc_result(message_id, {})
+        if method in {"tools/list", "tools/call"}:
+            try:
+                result = await self.handle_mcp_method(method, params)
+            except Exception as e:
+                return _jsonrpc_error(message_id, -32000, str(e))
+            return _jsonrpc_result(message_id, result)
+        return _jsonrpc_error(message_id, -32601, f"Method not found: {method}")
+
+
+def _jsonrpc_result(
+    message_id: typing.Any,
+    result: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+
+def _jsonrpc_error(
+    message_id: typing.Any,
+    code: int,
+    message: str,
+) -> dict[str, typing.Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }

--- a/src/langbot_plugin/api/agent_tools/mcp_stdio.py
+++ b/src/langbot_plugin/api/agent_tools/mcp_stdio.py
@@ -1,0 +1,167 @@
+"""Stdio MCP proxy for a run-scoped LangBot AgentRunner bridge."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import typing
+import urllib.error
+import urllib.request
+
+SERVER_INFO = {"name": "langbot-agent", "version": "0.1.0"}
+
+
+def _write_message(message: dict[str, typing.Any]) -> None:
+    sys.stdout.write(
+        json.dumps(message, ensure_ascii=False, separators=(",", ":")) + "\n"
+    )
+    sys.stdout.flush()
+
+
+def _result(
+    message_id: typing.Any, result: dict[str, typing.Any]
+) -> dict[str, typing.Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+
+def _error(message_id: typing.Any, code: int, message: str) -> dict[str, typing.Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+
+
+def _bridge_request(
+    *,
+    endpoint: str,
+    token: str,
+    method: str,
+    params: dict[str, typing.Any],
+    timeout: float,
+) -> dict[str, typing.Any]:
+    payload = json.dumps(
+        {"method": method, "params": params}, ensure_ascii=False
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint.rstrip("/") + "/mcp",
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json; charset=utf-8",
+            "X-LangBot-Agent-MCP-Token": token,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        return {"ok": False, "error": f"invalid bridge response: {e}"}
+    if not isinstance(data, dict):
+        return {"ok": False, "error": "bridge response must be an object"}
+    return data
+
+
+def handle_message(
+    message: dict[str, typing.Any],
+    *,
+    endpoint: str,
+    token: str,
+    timeout: float,
+) -> dict[str, typing.Any] | None:
+    message_id = message.get("id")
+    method = str(message.get("method") or "")
+    params = message.get("params") or {}
+    if not isinstance(params, dict):
+        params = {}
+
+    if message_id is None:
+        return None
+
+    if method == "initialize":
+        return _result(
+            message_id,
+            {
+                "protocolVersion": str(params.get("protocolVersion") or "2025-06-18"),
+                "capabilities": {
+                    "tools": {
+                        "listChanged": False,
+                    }
+                },
+                "serverInfo": SERVER_INFO,
+            },
+        )
+
+    if method == "ping":
+        return _result(message_id, {})
+
+    if method in {"tools/list", "tools/call"}:
+        response = _bridge_request(
+            endpoint=endpoint,
+            token=token,
+            method=method,
+            params=params,
+            timeout=timeout,
+        )
+        if response.get("ok"):
+            result = response.get("result")
+            return _result(
+                message_id, result if isinstance(result, dict) else {"result": result}
+            )
+        return _error(
+            message_id, -32000, str(response.get("error") or "LangBot MCP bridge error")
+        )
+
+    return _error(message_id, -32601, f"Method not found: {method}")
+
+
+def main() -> int:
+    endpoint = os.environ.get("LANGBOT_AGENT_MCP_ENDPOINT", "")
+    token = os.environ.get("LANGBOT_AGENT_MCP_TOKEN", "")
+    try:
+        timeout = float(os.environ.get("LANGBOT_AGENT_MCP_TIMEOUT", "60") or 60)
+    except ValueError:
+        timeout = 60.0
+
+    if not endpoint or not token:
+        sys.stderr.write(
+            "LANGBOT_AGENT_MCP_ENDPOINT and LANGBOT_AGENT_MCP_TOKEN are required\n"
+        )
+        sys.stderr.flush()
+        return 2
+
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as e:
+            _write_message(_error(None, -32700, f"Parse error: {e}"))
+            continue
+        if not isinstance(message, dict):
+            _write_message(_error(None, -32600, "Invalid request"))
+            continue
+
+        response = handle_message(
+            message, endpoint=endpoint, token=token, timeout=timeout
+        )
+        if response is not None:
+            _write_message(response)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_agent_tools_mcp_bridge.py
+++ b/tests/api/test_agent_tools_mcp_bridge.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.request
+
+import pytest
+
+from langbot_plugin.api.agent_tools import (
+    AgentRunExternalTools,
+    AgentRunMCPBridge,
+)
+from langbot_plugin.api.entities.builtin.agent_runner import (
+    AgentEventContext,
+    AgentInput,
+    AgentResources,
+    AgentRunContext,
+    AgentRuntimeContext,
+    AgentTrigger,
+    DeliveryContext,
+    HistoryPage,
+    TranscriptItem,
+)
+from langbot_plugin.api.entities.builtin.agent_runner.context_access import (
+    ContextAccess,
+    ContextAPICapabilities,
+)
+
+
+def _ctx() -> AgentRunContext:
+    return AgentRunContext(
+        run_id="run_1",
+        trigger=AgentTrigger(type="message.received"),
+        event=AgentEventContext(
+            event_id="evt_1",
+            event_type="message.received",
+            source="host_adapter",
+        ),
+        input=AgentInput(text="hello from im"),
+        delivery=DeliveryContext(surface="platform"),
+        resources=AgentResources(),
+        runtime=AgentRuntimeContext(),
+        config={},
+    )
+
+
+def _authorized_ctx() -> AgentRunContext:
+    ctx = _ctx()
+    ctx.resources = AgentResources.model_validate(
+        {
+            "knowledge_bases": [{"kb_id": "kb_1"}],
+            "tools": [{"tool_name": "weather"}],
+        }
+    )
+    ctx.context = ContextAccess(
+        available_apis=ContextAPICapabilities(history_page=True)
+    )
+    return ctx
+
+
+class FakeRunAPI:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def history_page(self, **kwargs):
+        self.calls.append(("history_page", kwargs))
+        return HistoryPage(
+            items=[
+                TranscriptItem(
+                    transcript_id="transcript_1",
+                    event_id="event_1",
+                    role="user",
+                    content="older",
+                )
+            ],
+            has_more=False,
+        )
+
+    async def retrieve_knowledge(self, **kwargs):
+        self.calls.append(("retrieve_knowledge", kwargs))
+        return [{"content": f"kb:{kwargs['query_text']}"}]
+
+    async def call_tool(self, **kwargs):
+        self.calls.append(("call_tool", kwargs))
+        return {"ok": True, "tool_name": kwargs["tool_name"]}
+
+
+def test_agent_run_external_tools_are_annotation_backed() -> None:
+    api = FakeRunAPI()
+    tools = AgentRunExternalTools(api, _authorized_ctx())
+
+    mcp_tools = {tool["name"]: tool for tool in tools.mcp_tools()}
+
+    assert set(mcp_tools) == {
+        "langbot_get_current_event",
+        "langbot_history_page",
+        "langbot_retrieve_knowledge",
+        "langbot_call_tool",
+    }
+    assert (
+        mcp_tools["langbot_retrieve_knowledge"]["inputSchema"]["properties"]["kb_id"][
+            "type"
+        ]
+        == "string"
+    )
+    assert mcp_tools["langbot_get_current_event"]["annotations"]["readOnlyHint"] is True
+
+
+def test_agent_run_external_tools_are_run_authorization_filtered() -> None:
+    api = FakeRunAPI()
+    tools = AgentRunExternalTools(api, _ctx())
+
+    assert {tool["name"] for tool in tools.mcp_tools()} == {"langbot_get_current_event"}
+
+    with pytest.raises(ValueError, match="Unknown LangBot external tool"):
+        asyncio.run(tools.call_tool("langbot_history_page", {"limit": 1}))
+
+
+def test_agent_run_external_tools_call_agent_run_api() -> None:
+    api = FakeRunAPI()
+    tools = AgentRunExternalTools(api, _authorized_ctx())
+
+    event = asyncio.run(tools.call_tool("langbot_get_current_event"))
+    retrieved = asyncio.run(
+        tools.call_tool(
+            "langbot_retrieve_knowledge",
+            {
+                "kb_id": "kb_1",
+                "query_text": "hello",
+                "top_k": 2,
+            },
+        )
+    )
+    tool_result = asyncio.run(
+        tools.call_tool(
+            "langbot_call_tool",
+            {
+                "tool_name": "weather",
+                "parameters": {"city": "Shanghai"},
+            },
+        )
+    )
+
+    assert event["input"]["text"] == "hello from im"
+    assert retrieved == [{"content": "kb:hello"}]
+    assert tool_result == {"ok": True, "tool_name": "weather"}
+    assert api.calls[0] == (
+        "retrieve_knowledge",
+        {
+            "kb_id": "kb_1",
+            "query_text": "hello",
+            "top_k": 2,
+            "filters": {},
+        },
+    )
+    assert api.calls[1] == (
+        "call_tool",
+        {
+            "tool_name": "weather",
+            "parameters": {"city": "Shanghai"},
+        },
+    )
+
+
+def test_mcp_stdio_proxy_round_trips_history_rag_and_tool_actions() -> None:
+    async def run_probe() -> FakeRunAPI:
+        api = FakeRunAPI()
+        bridge = AgentRunMCPBridge.from_run_api(api, _authorized_ctx())
+        bridge.start()
+        try:
+            config = bridge.mcp_server_config()
+            messages = [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {"protocolVersion": "2025-06-18"},
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                    "params": {},
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "langbot_history_page",
+                        "arguments": {"limit": 3, "direction": "backward"},
+                    },
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "langbot_retrieve_knowledge",
+                        "arguments": {
+                            "kb_id": "kb_1",
+                            "query_text": "stdio",
+                            "top_k": 2,
+                        },
+                    },
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "langbot_call_tool",
+                        "arguments": {
+                            "tool_name": "weather",
+                            "parameters": {"city": "Shanghai"},
+                        },
+                    },
+                },
+            ]
+            stdin = (
+                "\n".join(json.dumps(item, ensure_ascii=False) for item in messages)
+                + "\n"
+            )
+            process = await asyncio.create_subprocess_exec(
+                config["command"],
+                *config["args"],
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env={**os.environ, **config["env"]},
+            )
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(stdin.encode("utf-8")), timeout=20
+            )
+            assert process.returncode == 0, stderr.decode("utf-8", errors="replace")
+
+            responses = [
+                json.loads(line)
+                for line in stdout.decode("utf-8").splitlines()
+                if line.strip()
+            ]
+            listed_tools = {tool["name"] for tool in responses[1]["result"]["tools"]}
+            assert "langbot_history_page" in listed_tools
+            assert responses[2]["result"]["structuredContent"]["items"][0]["content"] == "older"
+            assert responses[2]["result"]["content"][0]["text"].startswith('{"items"')
+            assert responses[3]["result"]["structuredContent"]["result"] == [
+                {"content": "kb:stdio"}
+            ]
+            assert responses[4]["result"]["structuredContent"] == {
+                "ok": True,
+                "tool_name": "weather",
+            }
+            return api
+        finally:
+            bridge.stop()
+
+    api = asyncio.run(run_probe())
+
+    assert api.calls == [
+        (
+            "history_page",
+            {
+                "conversation_id": None,
+                "before_cursor": None,
+                "after_cursor": None,
+                "limit": 3,
+                "direction": "backward",
+                "include_artifacts": False,
+            },
+        ),
+        (
+            "retrieve_knowledge",
+            {
+                "kb_id": "kb_1",
+                "query_text": "stdio",
+                "top_k": 2,
+                "filters": {},
+            },
+        ),
+        (
+            "call_tool",
+            {
+                "tool_name": "weather",
+                "parameters": {"city": "Shanghai"},
+            },
+        ),
+    ]
+
+
+def test_mcp_http_endpoint_round_trips_langbot_actions() -> None:
+    async def run_probe() -> FakeRunAPI:
+        api = FakeRunAPI()
+        bridge = AgentRunMCPBridge.from_run_api(api, _authorized_ctx())
+        bridge.start()
+        try:
+            config = bridge.http_mcp_server_config()
+
+            def call(message: dict) -> dict:
+                payload = json.dumps(message).encode("utf-8")
+                request = urllib.request.Request(
+                    config["url"],
+                    data=payload,
+                    method="POST",
+                    headers={
+                        "Content-Type": "application/json",
+                        **config["headers"],
+                    },
+                )
+                with urllib.request.urlopen(request, timeout=10) as response:
+                    return json.loads(response.read().decode("utf-8"))
+
+            initialized = await asyncio.to_thread(
+                call,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {"protocolVersion": "2025-06-18"},
+                }
+            )
+            tools = await asyncio.to_thread(
+                call,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                    "params": {},
+                }
+            )
+            history = await asyncio.to_thread(
+                call,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "langbot_history_page",
+                        "arguments": {"limit": 2},
+                    },
+                }
+            )
+
+            assert initialized["result"]["serverInfo"]["name"] == "langbot-agent"
+            assert {
+                tool["name"] for tool in tools["result"]["tools"]
+            } >= {"langbot_history_page", "langbot_retrieve_knowledge", "langbot_call_tool"}
+            assert history["result"]["structuredContent"]["items"][0]["content"] == "older"
+            return api
+        finally:
+            bridge.stop()
+
+    api = asyncio.run(run_probe())
+
+    assert api.calls == [
+        (
+            "history_page",
+            {
+                "conversation_id": None,
+                "before_cursor": None,
+                "after_cursor": None,
+                "limit": 2,
+                "direction": "backward",
+                "include_artifacts": False,
+            },
+        ),
+    ]


### PR DESCRIPTION
## Summary

Split the MCP bridge adapter out of the AgentRunner pluginization PR as a stacked PR.

This branch is based on `feat/agent-runner-plugin` because the bridge consumes AgentRunContext and AgentRunAPI types from that PR. It intentionally does not add `AgentRunner.create_external_mcp_bridge`; callers can instantiate `AgentRunMCPBridge` from the run API/context adapter layer instead, keeping the AgentRunner base class decoupled from MCP transport concerns.

## Changes

- Add annotated external tool registration for run-scoped LangBot actions.
- Add stdio and HTTP MCP bridge adapters for history, RAG retrieval, current-event, and tool-call access.
- Add bridge tests without coupling through the AgentRunner base class.

## Validation

- `uv run pytest tests/api/test_agent_tools_mcp_bridge.py` (`5 passed`)
- `uv run ruff check src/langbot_plugin/api/agent_tools tests/api/test_agent_tools_mcp_bridge.py`