### PR TITLE
ci: enforce src lint and formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
             --cov-fail-under=75
 
   test-lint:
-    name: Test Lint
+    name: Lint and Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,5 +42,7 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-      - name: Ruff tests
-        run: uv run ruff check tests --output-format=concise
+      - name: Ruff check
+        run: uv run ruff check src tests --output-format=concise
+      - name: Ruff format check
+        run: uv run ruff format --check src tests

--- a/src/langbot_plugin/box/__init__.py
+++ b/src/langbot_plugin/box/__init__.py
@@ -2,4 +2,4 @@
 
 from .client import BoxRuntimeClient, ActionRPCBoxClient
 
-__all__ = ['BoxRuntimeClient', 'ActionRPCBoxClient']
+__all__ = ["BoxRuntimeClient", "ActionRPCBoxClient"]

--- a/src/langbot_plugin/box/backend.py
+++ b/src/langbot_plugin/box/backend.py
@@ -38,7 +38,7 @@ class _CommandResult:
 
 class BaseSandboxBackend(abc.ABC):
     name: str
-    instance_id: str = ''
+    instance_id: str = ""
 
     def __init__(self, logger: logging.Logger):
         self.logger = logger
@@ -66,9 +66,9 @@ class BaseSandboxBackend(abc.ABC):
         return True
 
     async def start_managed_process(self, session: BoxSessionInfo, spec):
-        raise BoxError(f'{self.name} backend does not support managed processes')
+        raise BoxError(f"{self.name} backend does not support managed processes")
 
-    async def cleanup_orphaned_containers(self, current_instance_id: str = ''):
+    async def cleanup_orphaned_containers(self, current_instance_id: str = ""):
         """Remove lingering containers from previous runs. No-op by default."""
         pass
 
@@ -85,7 +85,9 @@ class CLISandboxBackend(BaseSandboxBackend):
         if shutil.which(self.command) is None:
             return False
 
-        result = await self._run_command([self.command, 'info'], timeout_sec=5, check=False)
+        result = await self._run_command(
+            [self.command, "info"], timeout_sec=5, check=False
+        )
         return result.return_code == 0 and not result.timed_out
 
     async def start_session(self, spec: BoxSpec) -> BoxSessionInfo:
@@ -96,53 +98,59 @@ class CLISandboxBackend(BaseSandboxBackend):
 
         args = [
             self.command,
-            'run',
-            '-d',
+            "run",
+            "-d",
         ]
 
         if not spec.persistent:
-            args.append('--rm')
+            args.append("--rm")
 
-        args.extend([
-            '--name',
-            container_name,
-            '--label',
-            'langbot.box=true',
-            '--label',
-            f'langbot.session_id={spec.session_id}',
-            '--label',
-            f'langbot.box.instance_id={self.instance_id}',
-        ])
+        args.extend(
+            [
+                "--name",
+                container_name,
+                "--label",
+                "langbot.box=true",
+                "--label",
+                f"langbot.session_id={spec.session_id}",
+                "--label",
+                f"langbot.box.instance_id={self.instance_id}",
+            ]
+        )
 
         if spec.network == BoxNetworkMode.OFF:
-            args.extend(['--network', 'none'])
+            args.extend(["--network", "none"])
 
         # Resource limits
-        args.extend(['--cpus', str(spec.cpus)])
-        args.extend(['--memory', f'{spec.memory_mb}m'])
-        args.extend(['--pids-limit', str(spec.pids_limit)])
+        args.extend(["--cpus", str(spec.cpus)])
+        args.extend(["--memory", f"{spec.memory_mb}m"])
+        args.extend(["--pids-limit", str(spec.pids_limit)])
 
         if spec.read_only_rootfs:
-            args.append('--read-only')
-            args.extend(['--tmpfs', '/tmp:size=64m'])
+            args.append("--read-only")
+            args.extend(["--tmpfs", "/tmp:size=64m"])
 
         if spec.host_path is not None and spec.host_path_mode != BoxHostMountMode.NONE:
-            mount_spec = f'{spec.host_path}:{spec.mount_path}:{spec.host_path_mode.value}'
-            args.extend(['-v', mount_spec])
+            mount_spec = (
+                f"{spec.host_path}:{spec.mount_path}:{spec.host_path_mode.value}"
+            )
+            args.extend(["-v", mount_spec])
 
         for mount in spec.extra_mounts:
             if mount.mode != BoxHostMountMode.NONE:
-                args.extend(['-v', f'{mount.host_path}:{mount.mount_path}:{mount.mode.value}'])
+                args.extend(
+                    ["-v", f"{mount.host_path}:{mount.mount_path}:{mount.mode.value}"]
+                )
 
-        args.extend([spec.image, 'sh', '-lc', 'while true; do sleep 3600; done'])
+        args.extend([spec.image, "sh", "-lc", "while true; do sleep 3600; done"])
 
         self.logger.info(
-            f'LangBot Box backend start_session: backend={self.name} '
-            f'session_id={spec.session_id} container_name={container_name} '
-            f'image={spec.image} network={spec.network.value} '
-            f'host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={spec.mount_path} '
-            f'cpus={spec.cpus} memory_mb={spec.memory_mb} pids_limit={spec.pids_limit} '
-            f'read_only_rootfs={spec.read_only_rootfs} workspace_quota_mb={spec.workspace_quota_mb}'
+            f"LangBot Box backend start_session: backend={self.name} "
+            f"session_id={spec.session_id} container_name={container_name} "
+            f"image={spec.image} network={spec.network.value} "
+            f"host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={spec.mount_path} "
+            f"cpus={spec.cpus} memory_mb={spec.memory_mb} pids_limit={spec.pids_limit} "
+            f"read_only_rootfs={spec.read_only_rootfs} workspace_quota_mb={spec.workspace_quota_mb}"
         )
 
         await self._run_command(args, timeout_sec=30, check=True)
@@ -168,32 +176,36 @@ class CLISandboxBackend(BaseSandboxBackend):
 
     async def exec(self, session: BoxSessionInfo, spec: BoxSpec) -> BoxExecutionResult:
         start = dt.datetime.now(dt.timezone.utc)
-        args = [self.command, 'exec']
+        args = [self.command, "exec"]
 
         for key, value in spec.env.items():
-            args.extend(['-e', f'{key}={value}'])
+            args.extend(["-e", f"{key}={value}"])
 
         args.extend(
             [
                 session.backend_session_id,
-                'sh',
-                '-lc',
+                "sh",
+                "-lc",
                 self._build_exec_command(spec.workdir, spec.cmd),
             ]
         )
 
         cmd_preview = spec.cmd.strip()
         if len(cmd_preview) > 400:
-            cmd_preview = f'{cmd_preview[:397]}...'
+            cmd_preview = f"{cmd_preview[:397]}..."
         self.logger.info(
-            f'LangBot Box backend exec: backend={self.name} '
-            f'session_id={session.session_id} container_name={session.backend_session_id} '
-            f'workdir={spec.workdir} timeout_sec={spec.timeout_sec} '
-            f'env_keys={sorted(spec.env.keys())} cmd={cmd_preview}'
+            f"LangBot Box backend exec: backend={self.name} "
+            f"session_id={session.session_id} container_name={session.backend_session_id} "
+            f"workdir={spec.workdir} timeout_sec={spec.timeout_sec} "
+            f"env_keys={sorted(spec.env.keys())} cmd={cmd_preview}"
         )
 
-        result = await self._run_command(args, timeout_sec=spec.timeout_sec, check=False)
-        duration_ms = int((dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000)
+        result = await self._run_command(
+            args, timeout_sec=spec.timeout_sec, check=False
+        )
+        duration_ms = int(
+            (dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000
+        )
 
         if result.timed_out:
             return BoxExecutionResult(
@@ -202,7 +214,8 @@ class CLISandboxBackend(BaseSandboxBackend):
                 status=BoxExecutionStatus.TIMED_OUT,
                 exit_code=None,
                 stdout=result.stdout,
-                stderr=result.stderr or f'Command timed out after {spec.timeout_sec} seconds.',
+                stderr=result.stderr
+                or f"Command timed out after {spec.timeout_sec} seconds.",
                 duration_ms=duration_ms,
             )
 
@@ -218,11 +231,11 @@ class CLISandboxBackend(BaseSandboxBackend):
 
     async def stop_session(self, session: BoxSessionInfo):
         self.logger.info(
-            f'LangBot Box backend stop_session: backend={self.name} '
-            f'session_id={session.session_id} container_name={session.backend_session_id}'
+            f"LangBot Box backend stop_session: backend={self.name} "
+            f"session_id={session.session_id} container_name={session.backend_session_id}"
         )
         await self._run_command(
-            [self.command, 'rm', '-f', session.backend_session_id],
+            [self.command, "rm", "-f", session.backend_session_id],
             timeout_sec=20,
             check=False,
         )
@@ -231,17 +244,17 @@ class CLISandboxBackend(BaseSandboxBackend):
         result = await self._run_command(
             [
                 self.command,
-                'inspect',
-                '-f',
-                '{{.State.Running}}',
+                "inspect",
+                "-f",
+                "{{.State.Running}}",
                 session.backend_session_id,
             ],
             timeout_sec=5,
             check=False,
         )
-        return result.return_code == 0 and result.stdout.strip().lower() == 'true'
+        return result.return_code == 0 and result.stdout.strip().lower() == "true"
 
-    async def cleanup_orphaned_containers(self, current_instance_id: str = ''):
+    async def cleanup_orphaned_containers(self, current_instance_id: str = ""):
         """Remove langbot.box containers from previous instances.
 
         Only removes containers whose ``langbot.box.instance_id`` label does
@@ -251,11 +264,11 @@ class CLISandboxBackend(BaseSandboxBackend):
         result = await self._run_command(
             [
                 self.command,
-                'ps',
-                '-a',
-                '--filter',
-                'label=langbot.box=true',
-                '--format',
+                "ps",
+                "-a",
+                "--filter",
+                "label=langbot.box=true",
+                "--format",
                 '{{.ID}}\t{{.Label "langbot.box.instance_id"}}',
             ],
             timeout_sec=10,
@@ -264,44 +277,46 @@ class CLISandboxBackend(BaseSandboxBackend):
         if result.return_code != 0 or not result.stdout.strip():
             return
         orphan_ids = []
-        for line in result.stdout.strip().split('\n'):
+        for line in result.stdout.strip().split("\n"):
             line = line.strip()
             if not line:
                 continue
-            parts = line.split('\t', 1)
+            parts = line.split("\t", 1)
             cid = parts[0].strip()
-            label_instance = parts[1].strip() if len(parts) > 1 else ''
+            label_instance = parts[1].strip() if len(parts) > 1 else ""
             if label_instance != current_instance_id:
                 orphan_ids.append(cid)
         if not orphan_ids:
             return
         for cid in orphan_ids:
-            self.logger.info(f'Cleaning up orphaned Box container: {cid}')
+            self.logger.info(f"Cleaning up orphaned Box container: {cid}")
         await self._run_command(
-            [self.command, 'rm', '-f', *orphan_ids],
+            [self.command, "rm", "-f", *orphan_ids],
             timeout_sec=30,
             check=False,
         )
 
-    async def start_managed_process(self, session: BoxSessionInfo, spec) -> asyncio.subprocess.Process:
-        args = [self.command, 'exec', '-i']
+    async def start_managed_process(
+        self, session: BoxSessionInfo, spec
+    ) -> asyncio.subprocess.Process:
+        args = [self.command, "exec", "-i"]
 
         for key, value in spec.env.items():
-            args.extend(['-e', f'{key}={value}'])
+            args.extend(["-e", f"{key}={value}"])
 
         args.extend(
             [
                 session.backend_session_id,
-                'sh',
-                '-lc',
+                "sh",
+                "-lc",
                 self._build_spawn_command(spec.cwd, spec.command, spec.args),
             ]
         )
 
         self.logger.info(
-            f'LangBot Box backend start_managed_process: backend={self.name} '
-            f'session_id={session.session_id} container_name={session.backend_session_id} '
-            f'cwd={spec.cwd} env_keys={sorted(spec.env.keys())} command={spec.command} args={spec.args}'
+            f"LangBot Box backend start_managed_process: backend={self.name} "
+            f"session_id={session.session_id} container_name={session.backend_session_id} "
+            f"cwd={spec.cwd} env_keys={sorted(spec.env.keys())} command={spec.command} args={spec.args}"
         )
 
         return await asyncio.create_subprocess_exec(
@@ -312,18 +327,20 @@ class CLISandboxBackend(BaseSandboxBackend):
         )
 
     def _build_container_name(self, session_id: str) -> str:
-        normalized = re.sub(r'[^a-zA-Z0-9_.-]+', '-', session_id).strip('-').lower() or 'session'
+        normalized = (
+            re.sub(r"[^a-zA-Z0-9_.-]+", "-", session_id).strip("-").lower() or "session"
+        )
         suffix = uuid.uuid4().hex[:8]
-        return f'langbot-box-{normalized[:32]}-{suffix}'
+        return f"langbot-box-{normalized[:32]}-{suffix}"
 
     def _build_exec_command(self, workdir: str, cmd: str) -> str:
         quoted_workdir = shlex.quote(workdir)
-        return f'mkdir -p {quoted_workdir} && cd {quoted_workdir} && {cmd}'
+        return f"mkdir -p {quoted_workdir} && cd {quoted_workdir} && {cmd}"
 
     def _build_spawn_command(self, cwd: str, command: str, args: list[str]) -> str:
         quoted_cwd = shlex.quote(cwd)
         command_parts = [shlex.quote(command), *[shlex.quote(arg) for arg in args]]
-        return f'mkdir -p {quoted_cwd} && cd {quoted_cwd} && exec {" ".join(command_parts)}'
+        return f"mkdir -p {quoted_cwd} && cd {quoted_cwd} && exec {' '.join(command_parts)}"
 
     async def _run_command(
         self,
@@ -362,7 +379,9 @@ class CLISandboxBackend(BaseSandboxBackend):
         stderr = self._clip_captured_bytes(stderr_bytes, stderr_total)
 
         if check and process.returncode != 0:
-            raise BoxError(self._format_cli_error(stderr or stdout or 'unknown backend error'))
+            raise BoxError(
+                self._format_cli_error(stderr or stdout or "unknown backend error")
+            )
 
         return _CommandResult(
             return_code=process.returncode,
@@ -372,10 +391,12 @@ class CLISandboxBackend(BaseSandboxBackend):
         )
 
     @staticmethod
-    def _clip_captured_bytes(data: bytes, total_size: int, limit: int = _MAX_RAW_OUTPUT_BYTES) -> str:
-        text = data.decode('utf-8', errors='replace').strip()
+    def _clip_captured_bytes(
+        data: bytes, total_size: int, limit: int = _MAX_RAW_OUTPUT_BYTES
+    ) -> str:
+        text = data.decode("utf-8", errors="replace").strip()
         if total_size > limit:
-            text += f'\n... [raw output clipped at {limit} bytes, {total_size - limit} bytes discarded]'
+            text += f"\n... [raw output clipped at {limit} bytes, {total_size - limit} bytes discarded]"
         return text
 
     @staticmethod
@@ -384,7 +405,7 @@ class CLISandboxBackend(BaseSandboxBackend):
         limit: int = _MAX_RAW_OUTPUT_BYTES,
     ) -> tuple[bytes, int]:
         if stream is None:
-            return b'', 0
+            return b"", 0
 
         chunks = bytearray()
         total_size = 0
@@ -400,12 +421,12 @@ class CLISandboxBackend(BaseSandboxBackend):
         return bytes(chunks), total_size
 
     def _format_cli_error(self, message: str) -> str:
-        message = ' '.join(message.split())
+        message = " ".join(message.split())
         if len(message) > 300:
-            message = f'{message[:297]}...'
-        return f'{self.name} backend error: {message}'
+            message = f"{message[:297]}..."
+        return f"{self.name} backend error: {message}"
 
 
 class DockerBackend(CLISandboxBackend):
     def __init__(self, logger: logging.Logger):
-        super().__init__(logger=logger, command='docker', backend_name='docker')
+        super().__init__(logger=logger, command="docker", backend_name="docker")

--- a/src/langbot_plugin/box/e2b_backend.py
+++ b/src/langbot_plugin/box/e2b_backend.py
@@ -13,7 +13,6 @@ from .models import (
     BoxExecutionResult,
     BoxExecutionStatus,
     BoxHostMountMode,
-    BoxNetworkMode,
     BoxSessionInfo,
     BoxSpec,
 )
@@ -21,8 +20,8 @@ from .security import validate_sandbox_security
 
 # E2B sandbox uses /home/user as the default writable directory
 # We map /workspace to /home/user/workspace for compatibility
-E2B_DEFAULT_WORKDIR = '/home/user'
-E2B_WORKSPACE_DIR = '/home/user/workspace'
+E2B_DEFAULT_WORKDIR = "/home/user"
+E2B_WORKSPACE_DIR = "/home/user/workspace"
 
 # Lazy imports for e2b - only imported when actually needed
 _e2b_available: bool | None = None
@@ -66,14 +65,14 @@ def _adapt_path_for_e2b(path: str) -> str:
     E2B sandbox doesn't have /workspace by default, so we map it to
     /home/user/workspace which is writable.
     """
-    if path == '/workspace' or path.startswith('/workspace/'):
-        return path.replace('/workspace', E2B_WORKSPACE_DIR, 1)
+    if path == "/workspace" or path.startswith("/workspace/"):
+        return path.replace("/workspace", E2B_WORKSPACE_DIR, 1)
     return path
 
 
 def _rewrite_command_paths_for_e2b(command: str) -> str:
     """Rewrite LangBot's logical /workspace paths for E2B's real writable path."""
-    return command.replace('/workspace', E2B_WORKSPACE_DIR)
+    return command.replace("/workspace", E2B_WORKSPACE_DIR)
 
 
 class E2BSandboxBackend(BaseSandboxBackend):
@@ -85,7 +84,7 @@ class E2BSandboxBackend(BaseSandboxBackend):
     2. Configuration passed via configure() method (from LangBot config.yaml)
     """
 
-    name = 'e2b'
+    name = "e2b"
 
     def __init__(self, logger: logging.Logger):
         super().__init__(logger)
@@ -106,9 +105,13 @@ class E2BSandboxBackend(BaseSandboxBackend):
     async def initialize(self):
         """Load configuration from environment variables (priority) or config.yaml."""
         # Environment variables take precedence
-        self._api_key = os.getenv('E2B_API_KEY') or self._config_from_langbot.get('api_key')
-        self._api_url = os.getenv('E2B_API_URL') or self._config_from_langbot.get('api_url')
-        self._template = self._config_from_langbot.get('template')
+        self._api_key = os.getenv("E2B_API_KEY") or self._config_from_langbot.get(
+            "api_key"
+        )
+        self._api_url = os.getenv("E2B_API_URL") or self._config_from_langbot.get(
+            "api_url"
+        )
+        self._template = self._config_from_langbot.get("template")
 
     async def is_available(self) -> bool:
         """Check if E2B backend is available.
@@ -118,11 +121,11 @@ class E2BSandboxBackend(BaseSandboxBackend):
         2. E2B_API_KEY environment variable is set
         """
         if not _check_e2b_available():
-            self.logger.info('e2b package not installed')
+            self.logger.info("e2b package not installed")
             return False
 
         if not self._api_key:
-            self.logger.info('E2B_API_KEY not set')
+            self.logger.info("E2B_API_KEY not set")
             return False
 
         return True
@@ -139,62 +142,65 @@ class E2BSandboxBackend(BaseSandboxBackend):
         validate_sandbox_security(spec)
 
         if not _check_e2b_available():
-            raise BoxError('e2b package not installed')
+            raise BoxError("e2b package not installed")
 
         now = dt.datetime.now(dt.timezone.utc)
 
         # Adapt paths for E2B environment
-        workdir = _adapt_path_for_e2b(spec.workdir)
         mount_path = _adapt_path_for_e2b(spec.mount_path)
 
         # Build create parameters
         create_kwargs = {}
 
         # Template - use spec.image if provided, otherwise configured template, otherwise E2B default
-        if spec.image and spec.image != 'rockchin/langbot-sandbox:latest':
-            create_kwargs['template'] = spec.image
+        if spec.image and spec.image != "rockchin/langbot-sandbox:latest":
+            create_kwargs["template"] = spec.image
         elif self._template:
-            create_kwargs['template'] = self._template
+            create_kwargs["template"] = self._template
 
         # Environment variables
         if spec.env:
-            create_kwargs['envs'] = spec.env
+            create_kwargs["envs"] = spec.env
 
         # API key and domain (for CubeSandbox self-deployment)
         if self._api_key:
-            create_kwargs['api_key'] = self._api_key
+            create_kwargs["api_key"] = self._api_key
         if self._api_url:
             # E2B SDK uses 'domain' for self-hosted API URL
-            create_kwargs['domain'] = self._api_url
+            create_kwargs["domain"] = self._api_url
 
         # Build metadata for CubeSandbox host-mount
         metadata = {}
         if spec.host_path and spec.host_path_mode != BoxHostMountMode.NONE:
-            metadata['host-mount'] = json.dumps([{
-                'hostPath': spec.host_path,
-                'mountPath': mount_path,
-                'readOnly': spec.host_path_mode == BoxHostMountMode.READ_ONLY,
-            }])
+            metadata["host-mount"] = json.dumps(
+                [
+                    {
+                        "hostPath": spec.host_path,
+                        "mountPath": mount_path,
+                        "readOnly": spec.host_path_mode == BoxHostMountMode.READ_ONLY,
+                    }
+                ]
+            )
         if metadata:
-            create_kwargs['metadata'] = metadata
+            create_kwargs["metadata"] = metadata
 
         # Network mode - E2B uses allow_internet_access parameter
         # Note: E2B SDK doesn't have this directly in create(), but CubeSandbox may support it
         # For now, we rely on template configuration for network access
 
         self.logger.info(
-            f'LangBot Box backend start_session: backend=e2b '
-            f'session_id={spec.session_id} '
-            f'template={create_kwargs.get("template", "default")} '
-            f'network={spec.network.value} '
-            f'host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={mount_path} '
-            f'env_keys={sorted(spec.env.keys())}'
+            f"LangBot Box backend start_session: backend=e2b "
+            f"session_id={spec.session_id} "
+            f"template={create_kwargs.get('template', 'default')} "
+            f"network={spec.network.value} "
+            f"host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={mount_path} "
+            f"env_keys={sorted(spec.env.keys())}"
         )
 
         try:
             sandbox = await _AsyncSandbox.create(**create_kwargs)
         except Exception as exc:
-            raise BoxError(f'Failed to create E2B sandbox: {exc}')
+            raise BoxError(f"Failed to create E2B sandbox: {exc}")
 
         return BoxSessionInfo(
             session_id=spec.session_id,
@@ -225,16 +231,16 @@ class E2BSandboxBackend(BaseSandboxBackend):
         Reconnects to existing sandbox via AsyncSandbox.connect() and runs command.
         """
         if not _check_e2b_available():
-            raise BoxError('e2b package not installed')
+            raise BoxError("e2b package not installed")
 
         start = dt.datetime.now(dt.timezone.utc)
 
         # Connect kwargs
         connect_kwargs = {}
         if self._api_key:
-            connect_kwargs['api_key'] = self._api_key
+            connect_kwargs["api_key"] = self._api_key
         if self._api_url:
-            connect_kwargs['domain'] = self._api_url
+            connect_kwargs["domain"] = self._api_url
 
         # Adapt workdir and logical /workspace command paths for E2B.
         workdir = _adapt_path_for_e2b(spec.workdir)
@@ -242,21 +248,20 @@ class E2BSandboxBackend(BaseSandboxBackend):
 
         cmd_preview = spec.cmd.strip()
         if len(cmd_preview) > 400:
-            cmd_preview = f'{cmd_preview[:397]}...'
+            cmd_preview = f"{cmd_preview[:397]}..."
         self.logger.info(
-            f'LangBot Box backend exec: backend=e2b '
-            f'session_id={session.session_id} sandbox_id={session.backend_session_id} '
-            f'workdir={workdir} timeout_sec={spec.timeout_sec} '
-            f'env_keys={sorted(spec.env.keys())} cmd={cmd_preview}'
+            f"LangBot Box backend exec: backend=e2b "
+            f"session_id={session.session_id} sandbox_id={session.backend_session_id} "
+            f"workdir={workdir} timeout_sec={spec.timeout_sec} "
+            f"env_keys={sorted(spec.env.keys())} cmd={cmd_preview}"
         )
 
         try:
             sandbox = await _AsyncSandbox.connect(
-                sandbox_id=session.backend_session_id,
-                **connect_kwargs
+                sandbox_id=session.backend_session_id, **connect_kwargs
             )
         except Exception as exc:
-            raise BoxError(f'Failed to connect to E2B sandbox: {exc}')
+            raise BoxError(f"Failed to connect to E2B sandbox: {exc}")
 
         await self._sync_mounts_to_e2b(sandbox, spec)
 
@@ -264,37 +269,41 @@ class E2BSandboxBackend(BaseSandboxBackend):
         # Note: E2B requires cwd to exist before running command. We create it
         # as part of the command and then run from that directory.
         run_kwargs = {
-            'cmd': f'mkdir -p {shlex.quote(workdir)} && cd {shlex.quote(workdir)} && {command}',
-            'timeout': spec.timeout_sec,
+            "cmd": f"mkdir -p {shlex.quote(workdir)} && cd {shlex.quote(workdir)} && {command}",
+            "timeout": spec.timeout_sec,
         }
         if spec.env:
-            run_kwargs['envs'] = spec.env
+            run_kwargs["envs"] = spec.env
 
         try:
             result = await sandbox.commands.run(**run_kwargs)
         except Exception as exc:
             # Check if it's a timeout
-            duration_ms = int((dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000)
+            duration_ms = int(
+                (dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000
+            )
             error_msg = str(exc)
-            if 'timeout' in error_msg.lower() or 'timed out' in error_msg.lower():
+            if "timeout" in error_msg.lower() or "timed out" in error_msg.lower():
                 return BoxExecutionResult(
                     session_id=session.session_id,
                     backend_name=self.name,
                     status=BoxExecutionStatus.TIMED_OUT,
                     exit_code=None,
-                    stdout='',
-                    stderr=f'Command timed out after {spec.timeout_sec} seconds.',
+                    stdout="",
+                    stderr=f"Command timed out after {spec.timeout_sec} seconds.",
                     duration_ms=duration_ms,
                 )
-            raise BoxError(f'E2B command execution failed: {exc}')
+            raise BoxError(f"E2B command execution failed: {exc}")
 
         await self._sync_mounts_from_e2b(sandbox, spec)
 
-        duration_ms = int((dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000)
+        duration_ms = int(
+            (dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000
+        )
 
         # Process output - apply truncation if needed
-        stdout = self._truncate_output(result.stdout or '')
-        stderr = self._truncate_output(result.stderr or '')
+        stdout = self._truncate_output(result.stdout or "")
+        stderr = self._truncate_output(result.stderr or "")
 
         return BoxExecutionResult(
             session_id=session.session_id,
@@ -326,7 +335,10 @@ class E2BSandboxBackend(BaseSandboxBackend):
 
     async def _sync_mounts_from_e2b(self, sandbox, spec: BoxSpec) -> None:
         """Best-effort download of writable E2B mounts into host paths."""
-        if spec.host_path is not None and spec.host_path_mode == BoxHostMountMode.READ_WRITE:
+        if (
+            spec.host_path is not None
+            and spec.host_path_mode == BoxHostMountMode.READ_WRITE
+        ):
             await self._sync_e2b_tree_to_host(
                 sandbox,
                 remote_root=_adapt_path_for_e2b(spec.mount_path),
@@ -342,19 +354,31 @@ class E2BSandboxBackend(BaseSandboxBackend):
                 host_root=mount.host_path,
             )
 
-    async def _sync_host_tree_to_e2b(self, sandbox, *, host_root: str, remote_root: str) -> None:
+    async def _sync_host_tree_to_e2b(
+        self, sandbox, *, host_root: str, remote_root: str
+    ) -> None:
         """Best-effort sync for public E2B, which has no local bind mounts."""
         if not os.path.isdir(host_root):
             return
 
         for root, dirs, files in os.walk(host_root):
-            dirs[:] = [d for d in dirs if d not in {'.git', '__pycache__', '.venv', 'node_modules'}]
+            dirs[:] = [
+                d
+                for d in dirs
+                if d not in {".git", "__pycache__", ".venv", "node_modules"}
+            ]
             rel_dir = os.path.relpath(root, host_root)
-            remote_dir = remote_root if rel_dir == '.' else posixpath.join(remote_root, rel_dir.replace(os.sep, '/'))
+            remote_dir = (
+                remote_root
+                if rel_dir == "."
+                else posixpath.join(remote_root, rel_dir.replace(os.sep, "/"))
+            )
             try:
-                await sandbox.commands.run(f'mkdir -p {shlex.quote(remote_dir)}', timeout=10)
+                await sandbox.commands.run(
+                    f"mkdir -p {shlex.quote(remote_dir)}", timeout=10
+                )
             except Exception as exc:
-                self.logger.debug(f'Failed to create E2B sync dir {remote_dir}: {exc}')
+                self.logger.debug(f"Failed to create E2B sync dir {remote_dir}: {exc}")
                 continue
 
             for filename in files:
@@ -362,49 +386,64 @@ class E2BSandboxBackend(BaseSandboxBackend):
                 try:
                     if os.path.getsize(host_file) > _MAX_RAW_OUTPUT_BYTES:
                         continue
-                    with open(host_file, 'rb') as f:
+                    with open(host_file, "rb") as f:
                         data = f.read()
                     remote_file = posixpath.join(remote_dir, filename)
                     await sandbox.files.write(remote_file, data)
                 except Exception as exc:
-                    self.logger.debug(f'Failed to sync host file to E2B {host_file}: {exc}')
+                    self.logger.debug(
+                        f"Failed to sync host file to E2B {host_file}: {exc}"
+                    )
 
-    async def _sync_e2b_tree_to_host(self, sandbox, *, remote_root: str, host_root: str) -> None:
+    async def _sync_e2b_tree_to_host(
+        self, sandbox, *, remote_root: str, host_root: str
+    ) -> None:
         """Best-effort download of an E2B mount into the matching host path."""
         os.makedirs(host_root, exist_ok=True)
         try:
             entries = await sandbox.files.list(remote_root, depth=16)
         except Exception as exc:
-            self.logger.debug(f'Failed to list E2B mount for sync {remote_root}: {exc}')
+            self.logger.debug(f"Failed to list E2B mount for sync {remote_root}: {exc}")
             return
 
         for entry in entries:
-            remote_path = str(getattr(entry, 'path', '') or '')
-            if not remote_path or remote_path == remote_root or not remote_path.startswith(remote_root + '/'):
+            remote_path = str(getattr(entry, "path", "") or "")
+            if (
+                not remote_path
+                or remote_path == remote_root
+                or not remote_path.startswith(remote_root + "/")
+            ):
                 continue
-            rel_path = remote_path[len(remote_root) :].lstrip('/')
+            rel_path = remote_path[len(remote_root) :].lstrip("/")
             real_host_root = os.path.realpath(host_root)
-            host_path = os.path.realpath(os.path.join(real_host_root, *rel_path.split('/')))
-            if not (host_path == real_host_root or host_path.startswith(real_host_root + os.sep)):
+            host_path = os.path.realpath(
+                os.path.join(real_host_root, *rel_path.split("/"))
+            )
+            if not (
+                host_path == real_host_root
+                or host_path.startswith(real_host_root + os.sep)
+            ):
                 continue
 
-            entry_type = getattr(getattr(entry, 'type', None), 'value', '')
+            entry_type = getattr(getattr(entry, "type", None), "value", "")
             try:
-                if entry_type == 'dir':
+                if entry_type == "dir":
                     os.makedirs(host_path, exist_ok=True)
-                elif entry_type == 'file':
+                elif entry_type == "file":
                     os.makedirs(os.path.dirname(host_path), exist_ok=True)
-                    data = await sandbox.files.read(remote_path, format='bytes')
-                    with open(host_path, 'wb') as f:
+                    data = await sandbox.files.read(remote_path, format="bytes")
+                    with open(host_path, "wb") as f:
                         f.write(bytes(data))
             except Exception as exc:
-                self.logger.debug(f'Failed to sync E2B file to host {remote_path}: {exc}')
+                self.logger.debug(
+                    f"Failed to sync E2B file to host {remote_path}: {exc}"
+                )
 
     async def stop_session(self, session: BoxSessionInfo):
         """Kill the E2B sandbox."""
         self.logger.info(
-            f'LangBot Box backend stop_session: backend=e2b '
-            f'session_id={session.session_id} sandbox_id={session.backend_session_id}'
+            f"LangBot Box backend stop_session: backend=e2b "
+            f"session_id={session.session_id} sandbox_id={session.backend_session_id}"
         )
 
         if not _check_e2b_available():
@@ -417,13 +456,13 @@ class E2BSandboxBackend(BaseSandboxBackend):
                 domain=self._api_url,
             )
         except Exception as exc:
-            self.logger.warning(f'Failed to kill E2B sandbox: {exc}')
+            self.logger.warning(f"Failed to kill E2B sandbox: {exc}")
 
     def _truncate_output(self, output: str, limit: int = _MAX_RAW_OUTPUT_BYTES) -> str:
         """Truncate output if exceeds the limit."""
-        if len(output.encode('utf-8', errors='replace')) > limit:
+        if len(output.encode("utf-8", errors="replace")) > limit:
             # Truncate to approximately the limit
             truncated = output[:limit]
-            truncated += f'\n... [output clipped at {limit} bytes]'
+            truncated += f"\n... [output clipped at {limit} bytes]"
             return truncated
         return output

--- a/src/langbot_plugin/box/models.py
+++ b/src/langbot_plugin/box/models.py
@@ -8,29 +8,29 @@ import posixpath
 import pydantic
 
 
-DEFAULT_BOX_IMAGE = 'rockchin/langbot-sandbox:latest'
-DEFAULT_BOX_MOUNT_PATH = '/workspace'
+DEFAULT_BOX_IMAGE = "rockchin/langbot-sandbox:latest"
+DEFAULT_BOX_MOUNT_PATH = "/workspace"
 
 
 class BoxNetworkMode(str, enum.Enum):
-    OFF = 'off'
-    ON = 'on'
+    OFF = "off"
+    ON = "on"
 
 
 class BoxExecutionStatus(str, enum.Enum):
-    COMPLETED = 'completed'
-    TIMED_OUT = 'timed_out'
+    COMPLETED = "completed"
+    TIMED_OUT = "timed_out"
 
 
 class BoxHostMountMode(str, enum.Enum):
-    NONE = 'none'
-    READ_ONLY = 'ro'
-    READ_WRITE = 'rw'
+    NONE = "none"
+    READ_ONLY = "ro"
+    READ_WRITE = "rw"
 
 
 class BoxManagedProcessStatus(str, enum.Enum):
-    RUNNING = 'running'
-    EXITED = 'exited'
+    RUNNING = "running"
+    EXITED = "exited"
 
 
 class BoxMountSpec(pydantic.BaseModel):
@@ -40,25 +40,25 @@ class BoxMountSpec(pydantic.BaseModel):
     mount_path: str
     mode: BoxHostMountMode = BoxHostMountMode.READ_WRITE
 
-    @pydantic.field_validator('host_path')
+    @pydantic.field_validator("host_path")
     @classmethod
     def validate_host_path(cls, value: str) -> str:
         value = value.strip()
         if not (posixpath.isabs(value) or ntpath.isabs(value)):
-            raise ValueError('host_path must be an absolute host path')
+            raise ValueError("host_path must be an absolute host path")
         return value
 
-    @pydantic.field_validator('mount_path')
+    @pydantic.field_validator("mount_path")
     @classmethod
     def validate_mount_path(cls, value: str) -> str:
         value = value.strip()
-        if not value.startswith('/'):
-            raise ValueError('mount_path must be an absolute path inside the sandbox')
+        if not value.startswith("/"):
+            raise ValueError("mount_path must be an absolute path inside the sandbox")
         return value
 
 
 class BoxSpec(pydantic.BaseModel):
-    cmd: str = ''
+    cmd: str = ""
     workdir: str = DEFAULT_BOX_MOUNT_PATH
     timeout_sec: int = 30
     network: BoxNetworkMode = BoxNetworkMode.OFF
@@ -77,106 +77,110 @@ class BoxSpec(pydantic.BaseModel):
     read_only_rootfs: bool = True
     workspace_quota_mb: int = 0
 
-    @pydantic.model_validator(mode='before')
+    @pydantic.model_validator(mode="before")
     @classmethod
     def populate_workdir_from_mount_path(cls, data):
         if not isinstance(data, dict):
             return data
-        if data.get('workdir') not in (None, ''):
+        if data.get("workdir") not in (None, ""):
             return data
-        mount_path = data.get('mount_path')
+        mount_path = data.get("mount_path")
         if isinstance(mount_path, str) and mount_path.strip():
             data = dict(data)
-            data['workdir'] = mount_path
+            data["workdir"] = mount_path
         return data
 
-    @pydantic.field_validator('cmd')
+    @pydantic.field_validator("cmd")
     @classmethod
     def validate_cmd(cls, value: str) -> str:
         return value.strip()
 
-    @pydantic.field_validator('workdir')
+    @pydantic.field_validator("workdir")
     @classmethod
     def validate_workdir(cls, value: str) -> str:
         value = value.strip()
-        if not value.startswith('/'):
-            raise ValueError('workdir must be an absolute path inside the sandbox')
+        if not value.startswith("/"):
+            raise ValueError("workdir must be an absolute path inside the sandbox")
         return value
 
-    @pydantic.field_validator('timeout_sec')
+    @pydantic.field_validator("timeout_sec")
     @classmethod
     def validate_timeout_sec(cls, value: int) -> int:
         if value <= 0:
-            raise ValueError('timeout_sec must be greater than 0')
+            raise ValueError("timeout_sec must be greater than 0")
         return value
 
-    @pydantic.field_validator('cpus')
+    @pydantic.field_validator("cpus")
     @classmethod
     def validate_cpus(cls, value: float) -> float:
         if value <= 0:
-            raise ValueError('cpus must be greater than 0')
+            raise ValueError("cpus must be greater than 0")
         return value
 
-    @pydantic.field_validator('memory_mb')
+    @pydantic.field_validator("memory_mb")
     @classmethod
     def validate_memory_mb(cls, value: int) -> int:
         if value < 32:
-            raise ValueError('memory_mb must be at least 32')
+            raise ValueError("memory_mb must be at least 32")
         return value
 
-    @pydantic.field_validator('pids_limit')
+    @pydantic.field_validator("pids_limit")
     @classmethod
     def validate_pids_limit(cls, value: int) -> int:
         if value < 1:
-            raise ValueError('pids_limit must be at least 1')
+            raise ValueError("pids_limit must be at least 1")
         return value
 
-    @pydantic.field_validator('workspace_quota_mb')
+    @pydantic.field_validator("workspace_quota_mb")
     @classmethod
     def validate_workspace_quota_mb(cls, value: int) -> int:
         if value < 0:
-            raise ValueError('workspace_quota_mb must be greater than or equal to 0')
+            raise ValueError("workspace_quota_mb must be greater than or equal to 0")
         return value
 
-    @pydantic.field_validator('session_id')
+    @pydantic.field_validator("session_id")
     @classmethod
     def validate_session_id(cls, value: str) -> str:
         value = value.strip()
         if not value:
-            raise ValueError('session_id must not be empty')
+            raise ValueError("session_id must not be empty")
         return value
 
-    @pydantic.field_validator('env')
+    @pydantic.field_validator("env")
     @classmethod
     def validate_env(cls, value: dict[str, str]) -> dict[str, str]:
         return {str(k): str(v) for k, v in value.items()}
 
-    @pydantic.field_validator('host_path')
+    @pydantic.field_validator("host_path")
     @classmethod
     def validate_host_path(cls, value: str | None) -> str | None:
         if value is None:
             return None
         value = value.strip()
         if not (posixpath.isabs(value) or ntpath.isabs(value)):
-            raise ValueError('host_path must be an absolute host path')
+            raise ValueError("host_path must be an absolute host path")
         return value
 
-    @pydantic.field_validator('mount_path')
+    @pydantic.field_validator("mount_path")
     @classmethod
     def validate_mount_path(cls, value: str) -> str:
         value = value.strip()
-        if not value.startswith('/'):
-            raise ValueError('mount_path must be an absolute path inside the sandbox')
+        if not value.startswith("/"):
+            raise ValueError("mount_path must be an absolute path inside the sandbox")
         return value
 
-    @pydantic.model_validator(mode='after')
-    def validate_host_mount_consistency(self) -> 'BoxSpec':
+    @pydantic.model_validator(mode="after")
+    def validate_host_mount_consistency(self) -> "BoxSpec":
         if self.host_path is None:
             return self
         if self.host_path_mode == BoxHostMountMode.NONE:
             return self
-        if self.workdir != self.mount_path and not self.workdir.startswith(f'{self.mount_path}/'):
-            raise ValueError('workdir must stay under mount_path when host_path is provided')
+        if self.workdir != self.mount_path and not self.workdir.startswith(
+            f"{self.mount_path}/"
+        ):
+            raise ValueError(
+                "workdir must stay under mount_path when host_path is provided"
+            )
         return self
 
 
@@ -205,8 +209,8 @@ class BoxProfile(pydantic.BaseModel):
 
 
 BUILTIN_PROFILES: dict[str, BoxProfile] = {
-    'default': BoxProfile(
-        name='default',
+    "default": BoxProfile(
+        name="default",
         network=BoxNetworkMode.OFF,
         host_path_mode=BoxHostMountMode.READ_WRITE,
         cpus=1.0,
@@ -215,8 +219,8 @@ BUILTIN_PROFILES: dict[str, BoxProfile] = {
         read_only_rootfs=True,
         max_timeout_sec=120,
     ),
-    'offline_readonly': BoxProfile(
-        name='offline_readonly',
+    "offline_readonly": BoxProfile(
+        name="offline_readonly",
         network=BoxNetworkMode.OFF,
         host_path_mode=BoxHostMountMode.READ_ONLY,
         cpus=0.5,
@@ -224,10 +228,10 @@ BUILTIN_PROFILES: dict[str, BoxProfile] = {
         pids_limit=64,
         read_only_rootfs=True,
         max_timeout_sec=60,
-        locked=frozenset({'network', 'host_path_mode', 'read_only_rootfs'}),
+        locked=frozenset({"network", "host_path_mode", "read_only_rootfs"}),
     ),
-    'network_basic': BoxProfile(
-        name='network_basic',
+    "network_basic": BoxProfile(
+        name="network_basic",
         network=BoxNetworkMode.ON,
         host_path_mode=BoxHostMountMode.READ_WRITE,
         cpus=1.0,
@@ -236,8 +240,8 @@ BUILTIN_PROFILES: dict[str, BoxProfile] = {
         read_only_rootfs=True,
         max_timeout_sec=120,
     ),
-    'network_extended': BoxProfile(
-        name='network_extended',
+    "network_extended": BoxProfile(
+        name="network_extended",
         network=BoxNetworkMode.ON,
         host_path_mode=BoxHostMountMode.READ_WRITE,
         cpus=2.0,
@@ -269,42 +273,42 @@ class BoxSessionInfo(pydantic.BaseModel):
 
 
 class BoxManagedProcessSpec(pydantic.BaseModel):
-    process_id: str = 'default'
+    process_id: str = "default"
     command: str
     args: list[str] = pydantic.Field(default_factory=list)
     env: dict[str, str] = pydantic.Field(default_factory=dict)
     cwd: str = DEFAULT_BOX_MOUNT_PATH
 
-    @pydantic.field_validator('command')
+    @pydantic.field_validator("command")
     @classmethod
     def validate_command(cls, value: str) -> str:
         value = value.strip()
         if not value:
-            raise ValueError('command must not be empty')
+            raise ValueError("command must not be empty")
         return value
 
-    @pydantic.field_validator('args')
+    @pydantic.field_validator("args")
     @classmethod
     def validate_args(cls, value: list[str]) -> list[str]:
         return [str(item) for item in value]
 
-    @pydantic.field_validator('env')
+    @pydantic.field_validator("env")
     @classmethod
     def validate_env(cls, value: dict[str, str]) -> dict[str, str]:
         return {str(k): str(v) for k, v in value.items()}
 
-    @pydantic.field_validator('cwd')
+    @pydantic.field_validator("cwd")
     @classmethod
     def validate_cwd(cls, value: str) -> str:
         value = value.strip()
-        if not value.startswith('/'):
-            raise ValueError('cwd must be an absolute path inside the sandbox')
+        if not value.startswith("/"):
+            raise ValueError("cwd must be an absolute path inside the sandbox")
         return value
 
 
 class BoxManagedProcessInfo(pydantic.BaseModel):
     session_id: str
-    process_id: str = 'default'
+    process_id: str = "default"
     status: BoxManagedProcessStatus
     command: str
     args: list[str]
@@ -314,7 +318,7 @@ class BoxManagedProcessInfo(pydantic.BaseModel):
     started_at: dt.datetime
     exited_at: dt.datetime | None = None
     exit_code: int | None = None
-    stderr_preview: str = ''
+    stderr_preview: str = ""
 
 
 class BoxExecutionResult(pydantic.BaseModel):
@@ -322,8 +326,8 @@ class BoxExecutionResult(pydantic.BaseModel):
     backend_name: str
     status: BoxExecutionStatus
     exit_code: int | None
-    stdout: str = ''
-    stderr: str = ''
+    stdout: str = ""
+    stderr: str = ""
     duration_ms: int
 
     @property

--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -12,7 +12,6 @@ import signal
 import uuid
 
 from .backend import BaseSandboxBackend, _CommandResult, _MAX_RAW_OUTPUT_BYTES
-from .errors import BoxError
 from .models import (
     BoxExecutionResult,
     BoxExecutionStatus,
@@ -26,22 +25,22 @@ from .security import validate_sandbox_security
 # System directories to mount read-only inside the sandbox.
 # Only well-known paths needed for running Python/Node/shell commands.
 _READONLY_SYSTEM_MOUNTS: list[str] = [
-    '/usr',
-    '/lib',
-    '/lib64',
-    '/bin',
-    '/sbin',
+    "/usr",
+    "/lib",
+    "/lib64",
+    "/bin",
+    "/sbin",
 ]
 
 # Specific /etc entries required for dynamic linking and TLS.
 _READONLY_ETC_ENTRIES: list[str] = [
-    '/etc/alternatives',
-    '/etc/ld.so.cache',
-    '/etc/ld.so.conf',
-    '/etc/ld.so.conf.d',
-    '/etc/ssl/certs',
-    '/etc/localtime',
-    '/etc/resolv.conf',  # needed when network=ON
+    "/etc/alternatives",
+    "/etc/ld.so.cache",
+    "/etc/ld.so.conf",
+    "/etc/ld.so.conf.d",
+    "/etc/ssl/certs",
+    "/etc/localtime",
+    "/etc/resolv.conf",  # needed when network=ON
 ]
 
 # Essential character devices bind-mounted into the sandbox's /dev.
@@ -53,15 +52,15 @@ _READONLY_ETC_ENTRIES: list[str] = [
 # anything (e.g. an stdio MCP server dies before the initialize handshake,
 # surfacing as a misleading "Connection closed / please check URL").
 _DEV_NODES: list[str] = [
-    '/dev/null',
-    '/dev/zero',
-    '/dev/full',
-    '/dev/random',
-    '/dev/urandom',
-    '/dev/tty',
+    "/dev/null",
+    "/dev/zero",
+    "/dev/full",
+    "/dev/random",
+    "/dev/urandom",
+    "/dev/tty",
 ]
 
-_DEFAULT_BASE_DIR = '/tmp/langbot-box-nsjail'
+_DEFAULT_BASE_DIR = "/tmp/langbot-box-nsjail"
 
 
 class NsjailBackend(BaseSandboxBackend):
@@ -72,12 +71,12 @@ class NsjailBackend(BaseSandboxBackend):
     bind-mounted into every invocation.
     """
 
-    name = 'nsjail'
+    name = "nsjail"
 
     def __init__(
         self,
         logger: logging.Logger,
-        nsjail_bin: str = 'nsjail',
+        nsjail_bin: str = "nsjail",
         base_dir: str = _DEFAULT_BASE_DIR,
     ):
         super().__init__(logger)
@@ -89,34 +88,35 @@ class NsjailBackend(BaseSandboxBackend):
 
     async def is_available(self) -> bool:
         if shutil.which(self._nsjail_bin) is None:
-            self.logger.info('nsjail binary not found in PATH')
+            self.logger.info("nsjail binary not found in PATH")
             return False
 
         # Quick sanity check – nsjail --help exits 0.
         try:
             proc = await asyncio.create_subprocess_exec(
-                self._nsjail_bin, '--help',
+                self._nsjail_bin,
+                "--help",
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )
             await asyncio.wait_for(proc.wait(), timeout=5)
             if proc.returncode != 0:
-                self.logger.info('nsjail --help returned non-zero')
+                self.logger.info("nsjail --help returned non-zero")
                 return False
         except Exception as exc:
-            self.logger.info(f'nsjail probe failed: {exc}')
+            self.logger.info(f"nsjail probe failed: {exc}")
             return False
 
         self._cgroup_v2_available = self._detect_cgroup_v2()
         if not self._cgroup_v2_available:
             self.logger.warning(
-                'nsjail cgroup v2 limits unavailable (private cgroup namespace '
-                'or read-only /sys/fs/cgroup); falling back to rlimit-based '
-                'limits WITHOUT a hard memory cap. RLIMIT_AS is intentionally '
-                'not used because it kills uv/node/etc. To enforce a memory '
-                'cap, run the Box container in the host cgroup namespace '
-                '(--cgroupns=host / compose `cgroup: host`) or set a '
-                'container-level memory limit.'
+                "nsjail cgroup v2 limits unavailable (private cgroup namespace "
+                "or read-only /sys/fs/cgroup); falling back to rlimit-based "
+                "limits WITHOUT a hard memory cap. RLIMIT_AS is intentionally "
+                "not used because it kills uv/node/etc. To enforce a memory "
+                "cap, run the Box container in the host cgroup namespace "
+                "(--cgroupns=host / compose `cgroup: host`) or set a "
+                "container-level memory limit."
             )
 
         self._base_dir.mkdir(parents=True, exist_ok=True)
@@ -126,14 +126,16 @@ class NsjailBackend(BaseSandboxBackend):
         validate_sandbox_security(spec)
 
         now = dt.datetime.now(dt.timezone.utc)
-        session_dir_name = f'{self.instance_id}_{spec.session_id}_{uuid.uuid4().hex[:8]}'
+        session_dir_name = (
+            f"{self.instance_id}_{spec.session_id}_{uuid.uuid4().hex[:8]}"
+        )
         session_dir = self._base_dir / session_dir_name
 
         # Per-session writable directories.
-        root_dir = session_dir / 'root'
-        workspace_dir = session_dir / 'workspace'
-        tmp_dir = session_dir / 'tmp'
-        home_dir = session_dir / 'home'
+        root_dir = session_dir / "root"
+        workspace_dir = session_dir / "workspace"
+        tmp_dir = session_dir / "tmp"
+        home_dir = session_dir / "home"
 
         for d in (root_dir, workspace_dir, tmp_dir, home_dir):
             d.mkdir(parents=True, exist_ok=True)
@@ -154,26 +156,26 @@ class NsjailBackend(BaseSandboxBackend):
         # If host_path is specified, we will use it directly instead of the
         # per-session workspace when building nsjail args (see _build_mounts).
         meta = {
-            'session_id': spec.session_id,
-            'instance_id': self.instance_id,
-            'host_path': spec.host_path,
-            'host_path_mode': spec.host_path_mode.value if spec.host_path else None,
-            'mount_path': spec.mount_path,
-            'network': spec.network.value,
-            'cpus': spec.cpus,
-            'memory_mb': spec.memory_mb,
-            'pids_limit': spec.pids_limit,
-            'created_at': now.isoformat(),
+            "session_id": spec.session_id,
+            "instance_id": self.instance_id,
+            "host_path": spec.host_path,
+            "host_path_mode": spec.host_path_mode.value if spec.host_path else None,
+            "mount_path": spec.mount_path,
+            "network": spec.network.value,
+            "cpus": spec.cpus,
+            "memory_mb": spec.memory_mb,
+            "pids_limit": spec.pids_limit,
+            "created_at": now.isoformat(),
         }
-        (session_dir / 'meta.json').write_text(json.dumps(meta, indent=2))
+        (session_dir / "meta.json").write_text(json.dumps(meta, indent=2))
 
         self.logger.info(
-            f'LangBot Box backend start_session: backend=nsjail '
-            f'session_id={spec.session_id} session_dir={session_dir} '
-            f'network={spec.network.value} '
-            f'host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={spec.mount_path} '
-            f'cpus={spec.cpus} memory_mb={spec.memory_mb} pids_limit={spec.pids_limit} '
-            f'workspace_quota_mb={spec.workspace_quota_mb}'
+            f"LangBot Box backend start_session: backend=nsjail "
+            f"session_id={spec.session_id} session_dir={session_dir} "
+            f"network={spec.network.value} "
+            f"host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={spec.mount_path} "
+            f"cpus={spec.cpus} memory_mb={spec.memory_mb} pids_limit={spec.pids_limit} "
+            f"workspace_quota_mb={spec.workspace_quota_mb}"
         )
 
         return BoxSessionInfo(
@@ -206,16 +208,18 @@ class NsjailBackend(BaseSandboxBackend):
 
         cmd_preview = spec.cmd.strip()
         if len(cmd_preview) > 400:
-            cmd_preview = f'{cmd_preview[:397]}...'
+            cmd_preview = f"{cmd_preview[:397]}..."
         self.logger.info(
-            f'LangBot Box backend exec: backend=nsjail '
-            f'session_id={session.session_id} session_dir={session_dir} '
-            f'workdir={spec.workdir} timeout_sec={spec.timeout_sec} '
-            f'env_keys={sorted(spec.env.keys())} cmd={cmd_preview}'
+            f"LangBot Box backend exec: backend=nsjail "
+            f"session_id={session.session_id} session_dir={session_dir} "
+            f"workdir={spec.workdir} timeout_sec={spec.timeout_sec} "
+            f"env_keys={sorted(spec.env.keys())} cmd={cmd_preview}"
         )
 
         result = await self._run_nsjail(args, timeout_sec=spec.timeout_sec)
-        duration_ms = int((dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000)
+        duration_ms = int(
+            (dt.datetime.now(dt.timezone.utc) - start).total_seconds() * 1000
+        )
 
         if result.timed_out:
             return BoxExecutionResult(
@@ -224,7 +228,8 @@ class NsjailBackend(BaseSandboxBackend):
                 status=BoxExecutionStatus.TIMED_OUT,
                 exit_code=None,
                 stdout=result.stdout,
-                stderr=result.stderr or f'Command timed out after {spec.timeout_sec} seconds.',
+                stderr=result.stderr
+                or f"Command timed out after {spec.timeout_sec} seconds.",
                 duration_ms=duration_ms,
             )
 
@@ -241,8 +246,8 @@ class NsjailBackend(BaseSandboxBackend):
     async def stop_session(self, session: BoxSessionInfo):
         session_dir = pathlib.Path(session.backend_session_id)
         self.logger.info(
-            f'LangBot Box backend stop_session: backend=nsjail '
-            f'session_id={session.session_id} session_dir={session_dir}'
+            f"LangBot Box backend stop_session: backend=nsjail "
+            f"session_id={session.session_id} session_dir={session_dir}"
         )
 
         # Kill any lingering nsjail processes whose cwd is inside session_dir.
@@ -252,7 +257,9 @@ class NsjailBackend(BaseSandboxBackend):
             if session_dir.exists():
                 shutil.rmtree(session_dir)
         except Exception as exc:
-            self.logger.warning(f'Failed to remove nsjail session dir {session_dir}: {exc}')
+            self.logger.warning(
+                f"Failed to remove nsjail session dir {session_dir}: {exc}"
+            )
 
     async def start_managed_process(
         self, session: BoxSessionInfo, spec
@@ -261,7 +268,9 @@ class NsjailBackend(BaseSandboxBackend):
 
         # Build a BoxSpec-like object so we can reuse _build_nsjail_args.
         # ManagedProcessSpec has command/args/cwd/env but not the full BoxSpec.
-        inner_cmd = ' '.join([shlex.quote(spec.command), *[shlex.quote(a) for a in spec.args]])
+        inner_cmd = " ".join(
+            [shlex.quote(spec.command), *[shlex.quote(a) for a in spec.args]]
+        )
         pseudo_spec = BoxSpec(
             cmd=inner_cmd,
             workdir=spec.cwd,
@@ -281,10 +290,10 @@ class NsjailBackend(BaseSandboxBackend):
         args = self._build_nsjail_args(session, pseudo_spec, session_dir)
 
         self.logger.info(
-            f'LangBot Box backend start_managed_process: backend=nsjail '
-            f'session_id={session.session_id} session_dir={session_dir} '
-            f'cwd={spec.cwd} env_keys={sorted(spec.env.keys())} '
-            f'command={spec.command} args={spec.args}'
+            f"LangBot Box backend start_managed_process: backend=nsjail "
+            f"session_id={session.session_id} session_dir={session_dir} "
+            f"cwd={spec.cwd} env_keys={sorted(spec.env.keys())} "
+            f"command={spec.command} args={spec.args}"
         )
 
         return await asyncio.create_subprocess_exec(
@@ -294,7 +303,7 @@ class NsjailBackend(BaseSandboxBackend):
             stderr=asyncio.subprocess.PIPE,
         )
 
-    async def cleanup_orphaned_containers(self, current_instance_id: str = ''):
+    async def cleanup_orphaned_containers(self, current_instance_id: str = ""):
         if not self._base_dir.exists():
             return
 
@@ -304,15 +313,17 @@ class NsjailBackend(BaseSandboxBackend):
 
             # Session dirs are named: <instance_id>_<session_id>_<suffix>
             # If it doesn't start with the current instance_id, it's orphaned.
-            if entry.name.startswith(f'{current_instance_id}_'):
+            if entry.name.startswith(f"{current_instance_id}_"):
                 continue
 
-            self.logger.info(f'Cleaning up orphaned nsjail session dir: {entry}')
+            self.logger.info(f"Cleaning up orphaned nsjail session dir: {entry}")
             try:
                 await self._kill_session_processes(entry)
                 shutil.rmtree(entry)
             except Exception as exc:
-                self.logger.warning(f'Failed to clean up orphaned nsjail dir {entry}: {exc}')
+                self.logger.warning(
+                    f"Failed to clean up orphaned nsjail dir {entry}: {exc}"
+                )
 
     # ── nsjail argument construction ──────────────────────────────────
 
@@ -325,7 +336,7 @@ class NsjailBackend(BaseSandboxBackend):
         args: list[str] = [self._nsjail_bin]
 
         # Mode: one-shot execution.
-        args.extend(['--mode', 'o'])
+        args.extend(["--mode", "o"])
 
         # nsjail enables the relevant clone namespaces by default. Some
         # versions do not expose positive --clone_new* flags, only disable
@@ -333,14 +344,14 @@ class NsjailBackend(BaseSandboxBackend):
 
         # Use a per-session chroot root so nsjail can create mount targets
         # without needing write access to the host root.
-        root_dir = session_dir / 'root'
+        root_dir = session_dir / "root"
         root_dir.mkdir(parents=True, exist_ok=True)
         self._ensure_chroot_mount_targets(root_dir, session, spec)
-        args.extend(['--chroot', str(root_dir)])
+        args.extend(["--chroot", str(root_dir)])
 
         # Network namespace.
         if spec.network != BoxNetworkMode.OFF:
-            args.append('--disable_clone_newnet')
+            args.append("--disable_clone_newnet")
 
         # Read-only system mounts.
         args.extend(self._build_readonly_mounts(spec.network))
@@ -349,8 +360,8 @@ class NsjailBackend(BaseSandboxBackend):
         args.extend(self._build_writable_mounts(session, spec, session_dir))
 
         # Isolated /proc and minimal /dev.
-        args.extend(['--mount', 'none:/proc:proc:rw'])
-        args.extend(['--mount', 'none:/dev:tmpfs:rw'])
+        args.extend(["--mount", "none:/proc:proc:rw"])
+        args.extend(["--mount", "none:/dev:tmpfs:rw"])
 
         # /dev is a fresh empty tmpfs, so bind in the essential character
         # devices. Without /dev/null in particular, uv's glibc/musl detection
@@ -359,28 +370,33 @@ class NsjailBackend(BaseSandboxBackend):
         # /dev/null behave normally.
         for dev in _DEV_NODES:
             if os.path.exists(dev):
-                args.extend(['--bindmount', f'{dev}:{dev}'])
+                args.extend(["--bindmount", f"{dev}:{dev}"])
 
         # Working directory.
-        args.extend(['--cwd', spec.workdir])
+        args.extend(["--cwd", spec.workdir])
 
         # Environment variables.
-        args.extend(['--env', 'PYTHONUNBUFFERED=1'])
-        args.extend(['--env', 'HOME=/home'])
-        args.extend(['--env', 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'])
+        args.extend(["--env", "PYTHONUNBUFFERED=1"])
+        args.extend(["--env", "HOME=/home"])
+        args.extend(
+            [
+                "--env",
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            ]
+        )
         for key, value in spec.env.items():
-            args.extend(['--env', f'{key}={value}'])
+            args.extend(["--env", f"{key}={value}"])
 
         # Resource limits.
         args.extend(self._build_resource_limits(spec))
 
         # Suppress nsjail's own log output.
-        args.append('--really_quiet')
+        args.append("--really_quiet")
 
         # The actual command.
         quoted_workdir = shlex.quote(spec.workdir)
-        user_cmd = f'mkdir -p {quoted_workdir} && cd {quoted_workdir} && {spec.cmd}'
-        args.extend(['--', '/bin/sh', '-lc', user_cmd])
+        user_cmd = f"mkdir -p {quoted_workdir} && cd {quoted_workdir} && {spec.cmd}"
+        args.extend(["--", "/bin/sh", "-lc", user_cmd])
 
         return args
 
@@ -389,14 +405,14 @@ class NsjailBackend(BaseSandboxBackend):
 
         for path in _READONLY_SYSTEM_MOUNTS:
             if os.path.exists(path):
-                args.extend(['--bindmount_ro', f'{path}:{path}'])
+                args.extend(["--bindmount_ro", f"{path}:{path}"])
 
         for path in _READONLY_ETC_ENTRIES:
             # /etc/resolv.conf is only needed when network is ON.
-            if path == '/etc/resolv.conf' and network == BoxNetworkMode.OFF:
+            if path == "/etc/resolv.conf" and network == BoxNetworkMode.OFF:
                 continue
             if os.path.exists(path):
-                args.extend(['--bindmount_ro', f'{path}:{path}'])
+                args.extend(["--bindmount_ro", f"{path}:{path}"])
 
         return args
 
@@ -411,24 +427,24 @@ class NsjailBackend(BaseSandboxBackend):
         # Workspace mount.
         if spec.host_path is not None and spec.host_path_mode != BoxHostMountMode.NONE:
             if spec.host_path_mode == BoxHostMountMode.READ_ONLY:
-                args.extend(['--bindmount_ro', f'{spec.host_path}:{spec.mount_path}'])
+                args.extend(["--bindmount_ro", f"{spec.host_path}:{spec.mount_path}"])
             else:
-                args.extend(['--bindmount', f'{spec.host_path}:{spec.mount_path}'])
+                args.extend(["--bindmount", f"{spec.host_path}:{spec.mount_path}"])
         else:
-            workspace_dir = session_dir / 'workspace'
-            args.extend(['--bindmount', f'{workspace_dir}:{spec.mount_path}'])
+            workspace_dir = session_dir / "workspace"
+            args.extend(["--bindmount", f"{workspace_dir}:{spec.mount_path}"])
 
         for mount in spec.extra_mounts:
             if mount.mode == BoxHostMountMode.READ_ONLY:
-                args.extend(['--bindmount_ro', f'{mount.host_path}:{mount.mount_path}'])
+                args.extend(["--bindmount_ro", f"{mount.host_path}:{mount.mount_path}"])
             elif mount.mode == BoxHostMountMode.READ_WRITE:
-                args.extend(['--bindmount', f'{mount.host_path}:{mount.mount_path}'])
+                args.extend(["--bindmount", f"{mount.host_path}:{mount.mount_path}"])
 
         # /tmp and /home are always per-session writable.
-        tmp_dir = session_dir / 'tmp'
-        home_dir = session_dir / 'home'
-        args.extend(['--bindmount', f'{tmp_dir}:/tmp'])
-        args.extend(['--bindmount', f'{home_dir}:/home'])
+        tmp_dir = session_dir / "tmp"
+        home_dir = session_dir / "home"
+        args.extend(["--bindmount", f"{tmp_dir}:/tmp"])
+        args.extend(["--bindmount", f"{home_dir}:/home"])
 
         return args
 
@@ -439,10 +455,10 @@ class NsjailBackend(BaseSandboxBackend):
         spec: BoxSpec,
     ) -> None:
         mount_paths = {
-            '/proc',
-            '/dev',
-            '/tmp',
-            '/home',
+            "/proc",
+            "/dev",
+            "/tmp",
+            "/home",
             spec.mount_path,
             session.mount_path,
         }
@@ -454,7 +470,7 @@ class NsjailBackend(BaseSandboxBackend):
         for mount_path in mount_paths:
             if not mount_path:
                 continue
-            target = root_dir / mount_path.lstrip('/')
+            target = root_dir / mount_path.lstrip("/")
             try:
                 if os.path.isfile(mount_path):
                     target.parent.mkdir(parents=True, exist_ok=True)
@@ -462,7 +478,9 @@ class NsjailBackend(BaseSandboxBackend):
                 else:
                     target.mkdir(parents=True, exist_ok=True)
             except Exception as exc:
-                self.logger.debug(f'Failed to prepare nsjail mount target {target}: {exc}')
+                self.logger.debug(
+                    f"Failed to prepare nsjail mount target {target}: {exc}"
+                )
 
     def _build_resource_limits(self, spec: BoxSpec) -> list[str]:
         args: list[str] = []
@@ -473,12 +491,12 @@ class NsjailBackend(BaseSandboxBackend):
             # nsjail tries to mkdir under /sys/fs/cgroup/<controller>/... (v1
             # paths) and aborts on a v2-only host. The writability of the v2
             # root is already verified in _detect_cgroup_v2().
-            args.append('--use_cgroupv2')
+            args.append("--use_cgroupv2")
             memory_bytes = spec.memory_mb * 1024 * 1024
-            args.extend(['--cgroup_mem_max', str(memory_bytes)])
-            args.extend(['--cgroup_pids_max', str(spec.pids_limit)])
+            args.extend(["--cgroup_mem_max", str(memory_bytes)])
+            args.extend(["--cgroup_pids_max", str(spec.pids_limit)])
             cpu_ms = int(spec.cpus * 1000)
-            args.extend(['--cgroup_cpu_ms_per_sec', str(cpu_ms)])
+            args.extend(["--cgroup_cpu_ms_per_sec", str(cpu_ms)])
         else:
             # rlimit fallback – used whenever cgroup v2 delegation is not usable
             # (private cgroup namespace -> EBUSY, or read-only /sys/fs/cgroup).
@@ -497,12 +515,12 @@ class NsjailBackend(BaseSandboxBackend):
             # compose `cgroup: host`); otherwise bound memory at the container
             # level (e.g. compose `mem_limit`). We still apply the pid cap,
             # which is a real rlimit that does not break runtimes.
-            args.extend(['--rlimit_nproc', str(spec.pids_limit)])
+            args.extend(["--rlimit_nproc", str(spec.pids_limit)])
 
         # Always set these rlimits regardless of cgroup mode. These are safe
         # for modern runtimes (unlike RLIMIT_AS).
-        args.extend(['--rlimit_fsize', '512'])    # max file size 512 MB
-        args.extend(['--rlimit_nofile', '256'])    # max open fds
+        args.extend(["--rlimit_fsize", "512"])  # max file size 512 MB
+        args.extend(["--rlimit_nofile", "256"])  # max open fds
 
         return args
 
@@ -566,12 +584,12 @@ class NsjailBackend(BaseSandboxBackend):
         host cgroup namespace (``--cgroupns=host`` / compose ``cgroup: host``);
         otherwise this returns False and the backend uses the rlimit fallback.
         """
-        cgroup_mount = pathlib.Path('/sys/fs/cgroup')
+        cgroup_mount = pathlib.Path("/sys/fs/cgroup")
         if not cgroup_mount.exists():
             return False
         # cgroup v2 has a single hierarchy with a cgroup.controllers file.
-        controllers = cgroup_mount / 'cgroup.controllers'
-        subtree_control = cgroup_mount / 'cgroup.subtree_control'
+        controllers = cgroup_mount / "cgroup.controllers"
+        subtree_control = cgroup_mount / "cgroup.subtree_control"
         if not controllers.exists() or not subtree_control.exists():
             return False
         # nsjail enables the controllers it needs (memory, pids, cpu) on the
@@ -581,7 +599,7 @@ class NsjailBackend(BaseSandboxBackend):
             available = set(controllers.read_text().split())
         except Exception:
             return False
-        wanted = [c for c in ('memory', 'pids', 'cpu') if c in available]
+        wanted = [c for c in ("memory", "pids", "cpu") if c in available]
         if not wanted:
             return False
         # Authoritative writability probe: re-arm a controller that is already
@@ -598,13 +616,13 @@ class NsjailBackend(BaseSandboxBackend):
             if probe_controller in enabled:
                 # Already delegated: re-writing the same enable is a harmless
                 # no-op that still exercises the write permission + EBUSY rule.
-                subtree_control.write_text(f'+{probe_controller}')
+                subtree_control.write_text(f"+{probe_controller}")
             else:
                 # Not yet delegated: enable then immediately disable to leave
                 # the host configuration untouched.
-                subtree_control.write_text(f'+{probe_controller}')
+                subtree_control.write_text(f"+{probe_controller}")
                 try:
-                    subtree_control.write_text(f'-{probe_controller}')
+                    subtree_control.write_text(f"-{probe_controller}")
                 except Exception:
                     pass
         except Exception:
@@ -618,7 +636,7 @@ class NsjailBackend(BaseSandboxBackend):
         session directory path.
         """
         session_path_str = str(session_dir)
-        proc_dir = pathlib.Path('/proc')
+        proc_dir = pathlib.Path("/proc")
         if not proc_dir.exists():
             return
 
@@ -626,11 +644,13 @@ class NsjailBackend(BaseSandboxBackend):
             if not pid_dir.name.isdigit():
                 continue
             try:
-                cmdline = (pid_dir / 'cmdline').read_bytes().decode('utf-8', errors='replace')
+                cmdline = (
+                    (pid_dir / "cmdline").read_bytes().decode("utf-8", errors="replace")
+                )
                 if self._nsjail_bin in cmdline and session_path_str in cmdline:
                     pid = int(pid_dir.name)
                     os.kill(pid, signal.SIGKILL)
-                    self.logger.info(f'Killed orphaned nsjail process {pid}')
+                    self.logger.info(f"Killed orphaned nsjail process {pid}")
             except (OSError, ValueError):
                 continue
 
@@ -638,9 +658,9 @@ class NsjailBackend(BaseSandboxBackend):
     def _clip_captured_bytes(
         data: bytes, total_size: int, limit: int = _MAX_RAW_OUTPUT_BYTES
     ) -> str:
-        text = data.decode('utf-8', errors='replace').strip()
+        text = data.decode("utf-8", errors="replace").strip()
         if total_size > limit:
-            text += f'\n... [raw output clipped at {limit} bytes, {total_size - limit} bytes discarded]'
+            text += f"\n... [raw output clipped at {limit} bytes, {total_size - limit} bytes discarded]"
         return text
 
     @staticmethod
@@ -649,7 +669,7 @@ class NsjailBackend(BaseSandboxBackend):
         limit: int = _MAX_RAW_OUTPUT_BYTES,
     ) -> tuple[bytes, int]:
         if stream is None:
-            return b'', 0
+            return b"", 0
 
         chunks = bytearray()
         total_size = 0

--- a/src/langbot_plugin/box/security.py
+++ b/src/langbot_plugin/box/security.py
@@ -8,32 +8,32 @@ from .models import BoxSpec
 
 _BLOCKED_HOST_PATHS_POSIX = frozenset(
     {
-        '/etc',
-        '/proc',
-        '/sys',
-        '/dev',
-        '/root',
-        '/boot',
-        '/run',
-        '/var/run',
-        '/run/docker.sock',
-        '/var/run/docker.sock',
+        "/etc",
+        "/proc",
+        "/sys",
+        "/dev",
+        "/root",
+        "/boot",
+        "/run",
+        "/var/run",
+        "/run/docker.sock",
+        "/var/run/docker.sock",
     }
 )
 
 _BLOCKED_HOST_PATHS_WINDOWS = frozenset(
     {
-        r'C:\Windows',
-        r'C:\Program Files',
-        r'C:\Program Files (x86)',
-        r'C:\ProgramData',
-        r'\\.\pipe\docker_engine',
+        r"C:\Windows",
+        r"C:\Program Files",
+        r"C:\Program Files (x86)",
+        r"C:\ProgramData",
+        r"\\.\pipe\docker_engine",
     }
 )
 
 BLOCKED_HOST_PATHS = (
     _BLOCKED_HOST_PATHS_POSIX | _BLOCKED_HOST_PATHS_WINDOWS
-    if sys.platform == 'win32'
+    if sys.platform == "win32"
     else _BLOCKED_HOST_PATHS_POSIX
 )
 
@@ -48,5 +48,9 @@ def validate_sandbox_security(spec: BoxSpec) -> None:
         sep = os.sep
         _norm = os.path.normcase
         for blocked in BLOCKED_HOST_PATHS:
-            if _norm(real) == _norm(blocked) or _norm(real).startswith(_norm(blocked) + sep):
-                raise BoxValidationError(f'host_path {spec.host_path} is blocked for security')
+            if _norm(real) == _norm(blocked) or _norm(real).startswith(
+                _norm(blocked) + sep
+            ):
+                raise BoxValidationError(
+                    f"host_path {spec.host_path} is blocked for security"
+                )

--- a/src/langbot_plugin/box/skill_store.py
+++ b/src/langbot_plugin/box/skill_store.py
@@ -14,35 +14,35 @@ import yaml
 
 
 _FRONTMATTER_FIELDS = (
-    'name',
-    'display_name',
-    'description',
+    "name",
+    "display_name",
+    "description",
 )
 
 _PUBLIC_SKILL_FIELDS = (
-    'name',
-    'display_name',
-    'description',
-    'instructions',
-    'package_root',
-    'entry_file',
-    'created_at',
-    'updated_at',
+    "name",
+    "display_name",
+    "description",
+    "instructions",
+    "package_root",
+    "entry_file",
+    "created_at",
+    "updated_at",
 )
 
 
 def parse_frontmatter(content: str) -> tuple[dict, str]:
-    if not content.startswith('---'):
+    if not content.startswith("---"):
         return {}, content
 
     lines = content.splitlines(keepends=True)
-    if not lines or lines[0].strip() != '---':
+    if not lines or lines[0].strip() != "---":
         return {}, content
 
     for index in range(1, len(lines)):
-        if lines[index].strip() == '---':
-            metadata_text = ''.join(lines[1:index])
-            instructions = ''.join(lines[index + 1 :]).lstrip('\n')
+        if lines[index].strip() == "---":
+            metadata_text = "".join(lines[1:index])
+            instructions = "".join(lines[index + 1 :]).lstrip("\n")
             metadata = yaml.safe_load(metadata_text) or {}
             if not isinstance(metadata, dict):
                 metadata = {}
@@ -64,8 +64,10 @@ def build_skill_md(metadata: dict, instructions: str) -> str:
     if not frontmatter:
         return instructions
 
-    frontmatter_text = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True, sort_keys=False).strip()
-    return f'---\n{frontmatter_text}\n---\n\n{instructions}'
+    frontmatter_text = yaml.dump(
+        frontmatter, default_flow_style=False, allow_unicode=True, sort_keys=False
+    ).strip()
+    return f"---\n{frontmatter_text}\n---\n\n{instructions}"
 
 
 class BoxSkillStore:
@@ -79,9 +81,9 @@ class BoxSkillStore:
 
     @property
     def root(self) -> str:
-        local_config = self._config.get('local') or {}
-        host_root = str(local_config.get('host_root') or './data/box').strip()
-        skills_root = str(local_config.get('skills_root') or 'skills').strip()
+        local_config = self._config.get("local") or {}
+        host_root = str(local_config.get("host_root") or "./data/box").strip()
+        skills_root = str(local_config.get("skills_root") or "skills").strip()
 
         host_root_path = Path(host_root).expanduser()
         if not host_root_path.is_absolute():
@@ -96,40 +98,42 @@ class BoxSkillStore:
     def list_skills(self) -> list[dict]:
         os.makedirs(self.root, exist_ok=True)
         skills: list[dict] = []
-        for package_root, entry_file in self._discover_skill_directories(self.root, max_depth=6):
+        for package_root, entry_file in self._discover_skill_directories(
+            self.root, max_depth=6
+        ):
             try:
                 skills.append(self._load_skill_package(package_root, entry_file))
             except Exception:
                 continue
-        skills.sort(key=lambda item: item.get('updated_at', ''), reverse=True)
+        skills.sort(key=lambda item: item.get("updated_at", ""), reverse=True)
         return [self._serialize_skill(skill) for skill in skills]
 
     def get_skill(self, skill_name: str) -> Optional[dict]:
         for skill in self.list_skills():
-            if skill.get('name') == skill_name:
+            if skill.get("name") == skill_name:
                 return skill
         return None
 
     def create_skill(self, data: dict) -> dict:
-        name = self._validate_skill_name(data.get('name', ''))
+        name = self._validate_skill_name(data.get("name", ""))
         if self.get_skill(name):
             raise ValueError(f'Skill with name "{name}" already exists')
 
-        package_root = self._normalize_package_root(data.get('package_root', ''))
+        package_root = self._normalize_package_root(data.get("package_root", ""))
         managed_root = self._managed_skill_path(name)
         target_root = managed_root
         imported_skill_data: dict | None = None
 
         if package_root and self._managed_install_root_for_package(package_root):
             if not os.path.isdir(package_root):
-                raise ValueError(f'Directory does not exist: {package_root}')
+                raise ValueError(f"Directory does not exist: {package_root}")
             target_root = package_root
             imported_skill_data = self._read_skill_package(target_root)
         elif package_root and package_root != managed_root:
             if not os.path.isdir(package_root):
-                raise ValueError(f'Directory does not exist: {package_root}')
+                raise ValueError(f"Directory does not exist: {package_root}")
             if os.path.exists(managed_root):
-                raise ValueError(f'Skill directory already exists: {managed_root}')
+                raise ValueError(f"Skill directory already exists: {managed_root}")
             os.makedirs(os.path.dirname(managed_root), exist_ok=True)
             shutil.copytree(package_root, managed_root)
             imported_skill_data = self._read_skill_package(managed_root)
@@ -137,11 +141,17 @@ class BoxSkillStore:
             os.makedirs(managed_root, exist_ok=True)
 
         metadata = {
-            'name': name,
-            'display_name': self._resolve_create_field(data, 'display_name', imported_skill_data, default=''),
-            'description': self._resolve_create_field(data, 'description', imported_skill_data, default=''),
+            "name": name,
+            "display_name": self._resolve_create_field(
+                data, "display_name", imported_skill_data, default=""
+            ),
+            "description": self._resolve_create_field(
+                data, "description", imported_skill_data, default=""
+            ),
         }
-        instructions = self._resolve_create_field(data, 'instructions', imported_skill_data, default='')
+        instructions = self._resolve_create_field(
+            data, "instructions", imported_skill_data, default=""
+        )
         self._write_skill_md(target_root, metadata, instructions)
 
         created = self.get_skill(name)
@@ -154,22 +164,30 @@ class BoxSkillStore:
         if not skill:
             raise ValueError(f'Skill "{skill_name}" not found')
 
-        requested_name = str(data.get('name', skill['name']) or skill['name']).strip()
-        if requested_name != skill['name']:
-            raise ValueError('Renaming skills is not supported')
+        requested_name = str(data.get("name", skill["name"]) or skill["name"]).strip()
+        if requested_name != skill["name"]:
+            raise ValueError("Renaming skills is not supported")
 
-        requested_package_root = str(data.get('package_root', '') or '').strip()
-        existing_package_root = self._normalize_package_root(skill['package_root'])
-        if requested_package_root and self._normalize_package_root(requested_package_root) != existing_package_root:
-            raise ValueError('Updating package_root is not supported; recreate the skill to import a different package')
+        requested_package_root = str(data.get("package_root", "") or "").strip()
+        existing_package_root = self._normalize_package_root(skill["package_root"])
+        if (
+            requested_package_root
+            and self._normalize_package_root(requested_package_root)
+            != existing_package_root
+        ):
+            raise ValueError(
+                "Updating package_root is not supported; recreate the skill to import a different package"
+            )
 
         metadata = {
-            'name': skill['name'],
-            'display_name': data.get('display_name', skill.get('display_name', '')),
-            'description': data.get('description', skill.get('description', '')),
+            "name": skill["name"],
+            "display_name": data.get("display_name", skill.get("display_name", "")),
+            "description": data.get("description", skill.get("description", "")),
         }
-        instructions = str(data.get('instructions', skill.get('instructions', '')) or '')
-        self._write_skill_md(skill['package_root'], metadata, instructions)
+        instructions = str(
+            data.get("instructions", skill.get("instructions", "")) or ""
+        )
+        self._write_skill_md(skill["package_root"], metadata, instructions)
 
         updated = self.get_skill(skill_name)
         if not updated:
@@ -181,25 +199,29 @@ class BoxSkillStore:
         if not skill:
             raise ValueError(f'Skill "{skill_name}" not found')
 
-        package_root = self._normalize_package_root(skill['package_root'])
+        package_root = self._normalize_package_root(skill["package_root"])
         managed_install_root = self._managed_install_root_for_package(package_root)
         if not managed_install_root:
-            raise ValueError('Only managed skills under the Box skills root can be deleted')
+            raise ValueError(
+                "Only managed skills under the Box skills root can be deleted"
+            )
 
         shutil.rmtree(managed_install_root, ignore_errors=True)
-        return {'deleted': skill_name}
+        return {"deleted": skill_name}
 
     def scan_directory(self, path: str) -> dict:
         if not os.path.isdir(path):
-            raise ValueError(f'Directory does not exist: {path}')
+            raise ValueError(f"Directory does not exist: {path}")
 
         discovered = self._discover_skill_directories(path, max_depth=2)
         if not discovered:
-            raise ValueError(f'No SKILL.md found in {path} or its subdirectories (max depth: 2)')
-        if len(discovered) > 1:
-            candidates = ', '.join(found_path for found_path, _entry in discovered)
             raise ValueError(
-                f'Multiple skill directories found in {path}. Please choose a more specific path: {candidates}'
+                f"No SKILL.md found in {path} or its subdirectories (max depth: 2)"
+            )
+        if len(discovered) > 1:
+            candidates = ", ".join(found_path for found_path, _entry in discovered)
+            raise ValueError(
+                f"Multiple skill directories found in {path}. Please choose a more specific path: {candidates}"
             )
 
         package_root, entry_file = discovered[0]
@@ -208,66 +230,80 @@ class BoxSkillStore:
     def list_skill_files(
         self,
         skill_name: str,
-        path: str = '.',
+        path: str = ".",
         include_hidden: bool = False,
         max_entries: int = 200,
     ) -> dict:
         skill = self._require_skill(skill_name)
-        target_dir, relative_path = self._resolve_skill_path(skill, path, expect_directory=True)
+        target_dir, relative_path = self._resolve_skill_path(
+            skill, path, expect_directory=True
+        )
         entries: list[dict] = []
         with os.scandir(target_dir) as iterator:
             for entry in sorted(iterator, key=lambda item: item.name):
-                if not include_hidden and entry.name.startswith('.'):
+                if not include_hidden and entry.name.startswith("."):
                     continue
-                entry_rel_path = entry.name if relative_path in ('', '.') else os.path.join(relative_path, entry.name)
+                entry_rel_path = (
+                    entry.name
+                    if relative_path in ("", ".")
+                    else os.path.join(relative_path, entry.name)
+                )
                 is_dir = entry.is_dir()
                 entries.append(
                     {
-                        'path': entry_rel_path.replace(os.sep, '/'),
-                        'name': entry.name,
-                        'is_dir': is_dir,
-                        'size': None if is_dir else entry.stat().st_size,
+                        "path": entry_rel_path.replace(os.sep, "/"),
+                        "name": entry.name,
+                        "is_dir": is_dir,
+                        "size": None if is_dir else entry.stat().st_size,
                     }
                 )
                 if len(entries) >= max_entries:
                     break
 
         return {
-            'skill': {'name': skill['name']},
-            'base_path': '.' if relative_path in ('', '.') else relative_path.replace(os.sep, '/'),
-            'entries': entries,
-            'truncated': len(entries) >= max_entries,
+            "skill": {"name": skill["name"]},
+            "base_path": "."
+            if relative_path in ("", ".")
+            else relative_path.replace(os.sep, "/"),
+            "entries": entries,
+            "truncated": len(entries) >= max_entries,
         }
 
     def read_skill_file(self, skill_name: str, path: str) -> dict:
         skill = self._require_skill(skill_name)
-        target_path, relative_path = self._resolve_skill_path(skill, path, expect_directory=False)
+        target_path, relative_path = self._resolve_skill_path(
+            skill, path, expect_directory=False
+        )
         if not os.path.isfile(target_path):
-            raise ValueError(f'Skill file not found: {relative_path}')
+            raise ValueError(f"Skill file not found: {relative_path}")
 
         try:
-            with open(target_path, 'r', encoding='utf-8') as f:
+            with open(target_path, "r", encoding="utf-8") as f:
                 content = f.read()
         except UnicodeDecodeError as exc:
-            raise ValueError(f'Skill file is not valid UTF-8 text: {relative_path}') from exc
+            raise ValueError(
+                f"Skill file is not valid UTF-8 text: {relative_path}"
+            ) from exc
 
         return {
-            'skill': {'name': skill['name']},
-            'path': relative_path.replace(os.sep, '/'),
-            'content': content,
+            "skill": {"name": skill["name"]},
+            "path": relative_path.replace(os.sep, "/"),
+            "content": content,
         }
 
     def write_skill_file(self, skill_name: str, path: str, content: str) -> dict:
         skill = self._require_skill(skill_name)
-        target_path, relative_path = self._resolve_skill_path(skill, path, expect_directory=False)
+        target_path, relative_path = self._resolve_skill_path(
+            skill, path, expect_directory=False
+        )
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
-        with open(target_path, 'w', encoding='utf-8') as f:
+        with open(target_path, "w", encoding="utf-8") as f:
             f.write(content)
 
         return {
-            'skill': {'name': skill['name']},
-            'path': relative_path.replace(os.sep, '/'),
-            'bytes_written': len(content.encode('utf-8')),
+            "skill": {"name": skill["name"]},
+            "path": relative_path.replace(os.sep, "/"),
+            "bytes_written": len(content.encode("utf-8")),
         }
 
     def preview_zip_upload(
@@ -275,13 +311,13 @@ class BoxSkillStore:
         *,
         file_bytes: bytes,
         filename: str,
-        source_subdir: str = '',
-        target_suffix: str = 'upload',
+        source_subdir: str = "",
+        target_suffix: str = "upload",
     ) -> list[dict]:
         if not file_bytes:
-            raise ValueError('Uploaded file is empty')
+            raise ValueError("Uploaded file is empty")
 
-        tmp_dir = tempfile.mkdtemp(prefix='langbot_box_skill_preview_')
+        tmp_dir = tempfile.mkdtemp(prefix="langbot_box_skill_preview_")
         try:
             skill_root = self._extract_uploaded_skill_to_temp(file_bytes, tmp_dir)
             skill_root = self._resolve_source_subdir_root(skill_root, source_subdir)
@@ -299,14 +335,14 @@ class BoxSkillStore:
         file_bytes: bytes,
         filename: str,
         source_paths: list[str] | None = None,
-        source_path: str = '',
-        source_subdir: str = '',
-        target_suffix: str = 'upload',
+        source_path: str = "",
+        source_subdir: str = "",
+        target_suffix: str = "upload",
     ) -> list[dict]:
         if not file_bytes:
-            raise ValueError('Uploaded file is empty')
+            raise ValueError("Uploaded file is empty")
 
-        tmp_dir = tempfile.mkdtemp(prefix='langbot_box_skill_upload_')
+        tmp_dir = tempfile.mkdtemp(prefix="langbot_box_skill_upload_")
         try:
             skill_root = self._extract_uploaded_skill_to_temp(file_bytes, tmp_dir)
             skill_root = self._resolve_source_subdir_root(skill_root, source_subdir)
@@ -317,10 +353,13 @@ class BoxSkillStore:
             )
             selected_previews = self._select_preview_candidates(
                 previews,
-                {'source_paths': source_paths or [], 'source_path': source_path},
+                {"source_paths": source_paths or [], "source_path": source_path},
             )
             scanned = self._install_preview_candidates(skill_root, selected_previews)
-            return [self.get_skill(skill['name']) or self._serialize_skill(skill) for skill in scanned]
+            return [
+                self.get_skill(skill["name"]) or self._serialize_skill(skill)
+                for skill in scanned
+            ]
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
@@ -332,46 +371,58 @@ class BoxSkillStore:
 
     @staticmethod
     def _serialize_skill(skill: dict) -> dict:
-        return {field: skill.get(field) for field in _PUBLIC_SKILL_FIELDS if field in skill}
+        return {
+            field: skill.get(field) for field in _PUBLIC_SKILL_FIELDS if field in skill
+        }
 
-    def _load_skill_package(self, package_root: str, entry_file: str = 'SKILL.md') -> dict:
+    def _load_skill_package(
+        self, package_root: str, entry_file: str = "SKILL.md"
+    ) -> dict:
         package_root = self._normalize_package_root(package_root)
         entry_path = os.path.join(package_root, entry_file)
-        with open(entry_path, 'r', encoding='utf-8') as f:
+        with open(entry_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         metadata, instructions = parse_frontmatter(content)
         dir_name = os.path.basename(os.path.normpath(package_root))
         stat = os.stat(entry_path)
         return {
-            'name': str(metadata.get('name') or dir_name).strip(),
-            'display_name': str(metadata.get('display_name') or metadata.get('name') or dir_name).strip(),
-            'description': str(metadata.get('description') or '').strip(),
-            'instructions': instructions,
-            'package_root': package_root,
-            'entry_file': entry_file,
-            'created_at': dt.datetime.fromtimestamp(stat.st_ctime, tz=dt.timezone.utc).isoformat(),
-            'updated_at': dt.datetime.fromtimestamp(stat.st_mtime, tz=dt.timezone.utc).isoformat(),
+            "name": str(metadata.get("name") or dir_name).strip(),
+            "display_name": str(
+                metadata.get("display_name") or metadata.get("name") or dir_name
+            ).strip(),
+            "description": str(metadata.get("description") or "").strip(),
+            "instructions": instructions,
+            "package_root": package_root,
+            "entry_file": entry_file,
+            "created_at": dt.datetime.fromtimestamp(
+                stat.st_ctime, tz=dt.timezone.utc
+            ).isoformat(),
+            "updated_at": dt.datetime.fromtimestamp(
+                stat.st_mtime, tz=dt.timezone.utc
+            ).isoformat(),
         }
 
     def _read_skill_package(self, package_root: str) -> dict:
         entry = self._find_skill_entry(package_root)
         if entry is None:
-            raise ValueError(f'No SKILL.md found in {package_root}')
+            raise ValueError(f"No SKILL.md found in {package_root}")
 
         skill = self._load_skill_package(entry[0], entry[1])
         return {
-            'entry_file': skill.get('entry_file', 'SKILL.md'),
-            'display_name': skill.get('display_name', ''),
-            'description': skill.get('description', ''),
-            'instructions': skill.get('instructions', ''),
+            "entry_file": skill.get("entry_file", "SKILL.md"),
+            "display_name": skill.get("display_name", ""),
+            "description": skill.get("description", ""),
+            "instructions": skill.get("instructions", ""),
         }
 
-    def _write_skill_md(self, package_root: str, metadata: dict, instructions: str) -> None:
+    def _write_skill_md(
+        self, package_root: str, metadata: dict, instructions: str
+    ) -> None:
         package_root = self._normalize_package_root(package_root)
         os.makedirs(package_root, exist_ok=True)
         content = build_skill_md(metadata, instructions)
-        with open(os.path.join(package_root, 'SKILL.md'), 'w', encoding='utf-8') as f:
+        with open(os.path.join(package_root, "SKILL.md"), "w", encoding="utf-8") as f:
             f.write(content)
 
     def _managed_skill_path(self, skill_name: str) -> str:
@@ -381,63 +432,77 @@ class BoxSkillStore:
         managed_root = self._normalize_package_root(self.root)
         package_root = self._normalize_package_root(package_root)
         if not package_root or package_root == managed_root:
-            return ''
+            return ""
 
-        prefix = f'{managed_root}{os.sep}'
+        prefix = f"{managed_root}{os.sep}"
         if not package_root.startswith(prefix):
-            return ''
+            return ""
 
         relative = os.path.relpath(package_root, managed_root)
         top_level = relative.split(os.sep, 1)[0]
-        if top_level in ('', '.', '..'):
-            return ''
+        if top_level in ("", ".", ".."):
+            return ""
         return os.path.join(managed_root, top_level)
 
-    def _build_preview_target_dir(self, base_target_name: str, source_path: str, suffix: str) -> str:
-        relative = str(source_path or '').strip().replace('\\', '/').strip('/')
-        leaf_name = relative.split('/')[-1] if relative else ''
+    def _build_preview_target_dir(
+        self, base_target_name: str, source_path: str, suffix: str
+    ) -> str:
+        relative = str(source_path or "").strip().replace("\\", "/").strip("/")
+        leaf_name = relative.split("/")[-1] if relative else ""
         target_name = base_target_name
         if leaf_name and leaf_name != base_target_name:
-            target_name = f'{base_target_name}-{leaf_name}'
+            target_name = f"{base_target_name}-{leaf_name}"
         if suffix:
-            target_name = f'{target_name}-{suffix}'
+            target_name = f"{target_name}-{suffix}"
         return os.path.join(self.root, target_name)
 
-    def _preview_skill_candidates(self, root_path: str, *, base_target_name: str, suffix: str) -> list[dict]:
+    def _preview_skill_candidates(
+        self, root_path: str, *, base_target_name: str, suffix: str
+    ) -> list[dict]:
         discovered = self._discover_skill_directories(root_path, max_depth=2)
         if not discovered:
-            raise ValueError(f'No SKILL.md found in {root_path} or its subdirectories (max depth: 2)')
+            raise ValueError(
+                f"No SKILL.md found in {root_path} or its subdirectories (max depth: 2)"
+            )
 
         previews: list[dict] = []
         for package_root, entry_file in discovered:
             skill = self._load_skill_package(package_root, entry_file)
             relative_path = os.path.relpath(package_root, root_path)
-            if relative_path in ('', '.'):
-                relative_path = ''
-            skill['source_path'] = relative_path.replace(os.sep, '/')
-            skill['package_root'] = self._build_preview_target_dir(base_target_name, relative_path, suffix)
+            if relative_path in ("", "."):
+                relative_path = ""
+            skill["source_path"] = relative_path.replace(os.sep, "/")
+            skill["package_root"] = self._build_preview_target_dir(
+                base_target_name, relative_path, suffix
+            )
             previews.append(skill)
 
-        previews.sort(key=lambda item: item['source_path'])
+        previews.sort(key=lambda item: item["source_path"])
         return [self._serialize_skill_with_source(preview) for preview in previews]
 
     @staticmethod
     def _serialize_skill_with_source(skill: dict) -> dict:
         data = BoxSkillStore._serialize_skill(skill)
-        if 'source_path' in skill:
-            data['source_path'] = skill['source_path']
+        if "source_path" in skill:
+            data["source_path"] = skill["source_path"]
         return data
 
-    def _select_preview_candidates(self, previews: list[dict], data: dict) -> list[dict]:
+    def _select_preview_candidates(
+        self, previews: list[dict], data: dict
+    ) -> list[dict]:
         normalized_paths: list[str] = []
-        raw_source_paths = data.get('source_paths', [])
+        raw_source_paths = data.get("source_paths", [])
         if isinstance(raw_source_paths, list):
             for source_path in raw_source_paths:
-                normalized = str(source_path or '').strip().replace('\\', '/').strip('/')
+                normalized = (
+                    str(source_path or "").strip().replace("\\", "/").strip("/")
+                )
                 if normalized not in normalized_paths:
                     normalized_paths.append(normalized)
 
-        legacy_source_path = str(data.get('source_path', '') or '').strip().replace('\\', '/').strip('/')
+        legacy_source_path = (
+            str(data.get("source_path", "") or "").strip().replace("\\", "/").strip("/")
+        )
         if legacy_source_path and legacy_source_path not in normalized_paths:
             normalized_paths.append(legacy_source_path)
 
@@ -445,36 +510,44 @@ class BoxSkillStore:
             return previews
 
         if not normalized_paths:
-            candidates = ', '.join(item['source_path'] or '.' for item in previews)
-            raise ValueError(f'Multiple skills found. Please choose one or more source_paths: {candidates}')
+            candidates = ", ".join(item["source_path"] or "." for item in previews)
+            raise ValueError(
+                f"Multiple skills found. Please choose one or more source_paths: {candidates}"
+            )
 
         selected: list[dict] = []
-        available = {preview['source_path']: preview for preview in previews}
+        available = {preview["source_path"]: preview for preview in previews}
         for normalized_path in normalized_paths:
             preview = available.get(normalized_path)
             if preview is None:
-                candidates = ', '.join(item['source_path'] or '.' for item in previews)
-                raise ValueError(f'Invalid source_path "{normalized_path}". Available: {candidates}')
+                candidates = ", ".join(item["source_path"] or "." for item in previews)
+                raise ValueError(
+                    f'Invalid source_path "{normalized_path}". Available: {candidates}'
+                )
             selected.append(preview)
 
         return selected
 
-    def _install_preview_candidates(self, root_path: str, selected_previews: list[dict]) -> list[dict]:
+    def _install_preview_candidates(
+        self, root_path: str, selected_previews: list[dict]
+    ) -> list[dict]:
         target_dirs: list[str] = []
         for preview in selected_previews:
-            target_dir = self._normalize_package_root(preview['package_root'])
+            target_dir = self._normalize_package_root(preview["package_root"])
             if target_dir in target_dirs:
-                raise ValueError(f'Duplicate target directory selected: {target_dir}')
+                raise ValueError(f"Duplicate target directory selected: {target_dir}")
             if os.path.exists(target_dir):
-                raise ValueError(f'Skill directory already exists: {target_dir}')
+                raise ValueError(f"Skill directory already exists: {target_dir}")
             target_dirs.append(target_dir)
 
         installed_scans: list[dict] = []
         created_dirs: list[str] = []
         try:
             for preview in selected_previews:
-                target_dir = self._normalize_package_root(preview['package_root'])
-                source_root = self._preview_source_root(root_path, preview['source_path'])
+                target_dir = self._normalize_package_root(preview["package_root"])
+                source_root = self._preview_source_root(
+                    root_path, preview["source_path"]
+                )
                 os.makedirs(os.path.dirname(target_dir), exist_ok=True)
                 shutil.copytree(source_root, target_dir)
                 created_dirs.append(target_dir)
@@ -487,12 +560,12 @@ class BoxSkillStore:
         return installed_scans
 
     def _extract_uploaded_skill_to_temp(self, file_bytes: bytes, tmp_dir: str) -> str:
-        extract_dir = os.path.join(tmp_dir, 'extracted')
+        extract_dir = os.path.join(tmp_dir, "extracted")
         try:
-            with zipfile.ZipFile(io.BytesIO(file_bytes), 'r') as zf:
+            with zipfile.ZipFile(io.BytesIO(file_bytes), "r") as zf:
                 self._safe_extract_zip(zf, extract_dir)
         except zipfile.BadZipFile as exc:
-            raise ValueError('Uploaded file must be a valid .zip archive') from exc
+            raise ValueError("Uploaded file must be a valid .zip archive") from exc
 
         entries = os.listdir(extract_dir)
         if len(entries) == 1 and os.path.isdir(os.path.join(extract_dir, entries[0])):
@@ -501,33 +574,43 @@ class BoxSkillStore:
 
     @staticmethod
     def _uploaded_skill_target_stem(filename: str) -> str:
-        stem = os.path.splitext(os.path.basename(str(filename or '').strip()))[0]
-        safe_stem = ''.join(ch if ch.isalnum() or ch in ('-', '_') else '-' for ch in stem).strip('-_')
-        return safe_stem or 'uploaded-skill'
+        stem = os.path.splitext(os.path.basename(str(filename or "").strip()))[0]
+        safe_stem = "".join(
+            ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in stem
+        ).strip("-_")
+        return safe_stem or "uploaded-skill"
 
     @staticmethod
     def _preview_source_root(root_path: str, source_path: str) -> str:
-        normalized = str(source_path or '').strip().replace('\\', '/').strip('/')
+        normalized = str(source_path or "").strip().replace("\\", "/").strip("/")
         if not normalized:
             return root_path
         return os.path.join(root_path, normalized)
 
     @staticmethod
     def _resolve_source_subdir_root(root_path: str, source_subdir: str) -> str:
-        normalized = str(source_subdir or '').strip().replace('\\', '/').strip('/')
+        normalized = str(source_subdir or "").strip().replace("\\", "/").strip("/")
         if not normalized:
             return root_path
 
         normalized_path = os.path.normpath(normalized)
-        if normalized_path.startswith('..') or normalized_path == '..' or os.path.isabs(normalized_path):
-            raise ValueError('source_subdir must stay within the uploaded archive')
+        if (
+            normalized_path.startswith("..")
+            or normalized_path == ".."
+            or os.path.isabs(normalized_path)
+        ):
+            raise ValueError("source_subdir must stay within the uploaded archive")
 
         target_root = os.path.realpath(os.path.join(root_path, normalized_path))
         archive_root = os.path.realpath(root_path)
-        if target_root != archive_root and not target_root.startswith(f'{archive_root}{os.sep}'):
-            raise ValueError('source_subdir must stay within the uploaded archive')
+        if target_root != archive_root and not target_root.startswith(
+            f"{archive_root}{os.sep}"
+        ):
+            raise ValueError("source_subdir must stay within the uploaded archive")
         if not os.path.isdir(target_root):
-            raise ValueError(f'source_subdir does not exist in the uploaded archive: {normalized}')
+            raise ValueError(
+                f"source_subdir does not exist in the uploaded archive: {normalized}"
+            )
         return target_root
 
     @staticmethod
@@ -537,54 +620,68 @@ class BoxSkillStore:
 
         for member in archive.infolist():
             member_name = member.filename
-            if not member_name or member_name.endswith('/'):
+            if not member_name or member_name.endswith("/"):
                 continue
 
             normalized = posixpath.normpath(member_name)
-            if normalized.startswith('../') or normalized == '..' or os.path.isabs(normalized):
-                raise ValueError(f'Archive contains an unsafe path: {member_name}')
+            if (
+                normalized.startswith("../")
+                or normalized == ".."
+                or os.path.isabs(normalized)
+            ):
+                raise ValueError(f"Archive contains an unsafe path: {member_name}")
 
             destination = os.path.realpath(os.path.join(target_root, normalized))
-            if destination != target_root and not destination.startswith(f'{target_root}{os.sep}'):
-                raise ValueError(f'Archive contains an unsafe path: {member_name}')
+            if destination != target_root and not destination.startswith(
+                f"{target_root}{os.sep}"
+            ):
+                raise ValueError(f"Archive contains an unsafe path: {member_name}")
 
         archive.extractall(target_root)
 
-    def _resolve_skill_path(self, skill: dict, path: str, *, expect_directory: bool) -> tuple[str, str]:
-        package_root = self._normalize_package_root(skill.get('package_root', ''))
+    def _resolve_skill_path(
+        self, skill: dict, path: str, *, expect_directory: bool
+    ) -> tuple[str, str]:
+        package_root = self._normalize_package_root(skill.get("package_root", ""))
         if not package_root:
             raise ValueError(f'Skill "{skill.get("name", "")}" has no package_root')
 
-        relative_path = str(path or '.').strip() or '.'
+        relative_path = str(path or ".").strip() or "."
         if os.path.isabs(relative_path):
-            raise ValueError('path must be relative to the skill package root')
+            raise ValueError("path must be relative to the skill package root")
 
         normalized_relative = os.path.normpath(relative_path)
-        if normalized_relative.startswith('..') or normalized_relative == '..':
-            raise ValueError('path must stay within the skill package root')
+        if normalized_relative.startswith("..") or normalized_relative == "..":
+            raise ValueError("path must stay within the skill package root")
 
         target_path = os.path.realpath(os.path.join(package_root, normalized_relative))
-        if target_path != package_root and not target_path.startswith(f'{package_root}{os.sep}'):
-            raise ValueError('path must stay within the skill package root')
+        if target_path != package_root and not target_path.startswith(
+            f"{package_root}{os.sep}"
+        ):
+            raise ValueError("path must stay within the skill package root")
 
         if expect_directory:
             if not os.path.isdir(target_path):
-                raise ValueError(f'Skill directory not found: {relative_path}')
+                raise ValueError(f"Skill directory not found: {relative_path}")
         else:
             parent_dir = os.path.dirname(target_path) or package_root
-            if parent_dir != package_root and not parent_dir.startswith(f'{package_root}{os.sep}'):
-                raise ValueError('path must stay within the skill package root')
+            if parent_dir != package_root and not parent_dir.startswith(
+                f"{package_root}{os.sep}"
+            ):
+                raise ValueError("path must stay within the skill package root")
 
         return target_path, normalized_relative
 
     @staticmethod
     def _find_skill_entry(path: str) -> Optional[tuple[str, str]]:
-        for candidate in ('SKILL.md', 'skill.md'):
+        for candidate in ("SKILL.md", "skill.md"):
             if os.path.isfile(os.path.join(path, candidate)):
                 return path, candidate
         return None
 
-    def _discover_skill_directories(self, root_path: str, max_depth: int = 2) -> list[tuple[str, str]]:
+    def _discover_skill_directories(
+        self, root_path: str, max_depth: int = 2
+    ) -> list[tuple[str, str]]:
         discovered: list[tuple[str, str]] = []
         queue: list[tuple[str, int]] = [(root_path, 0)]
         seen: set[str] = set()
@@ -605,7 +702,9 @@ class BoxSkillStore:
                 continue
 
             try:
-                entries = sorted(os.scandir(normalized_path), key=lambda entry: entry.name)
+                entries = sorted(
+                    os.scandir(normalized_path), key=lambda entry: entry.name
+                )
             except OSError:
                 continue
 
@@ -617,31 +716,35 @@ class BoxSkillStore:
 
     @staticmethod
     def _validate_skill_name(name: str) -> str:
-        name = str(name or '').strip()
+        name = str(name or "").strip()
         if not name:
-            raise ValueError('Skill name is required')
-        if not name.replace('-', '').replace('_', '').isalnum():
-            raise ValueError('Skill name can only contain letters, numbers, hyphens and underscores')
+            raise ValueError("Skill name is required")
+        if not name.replace("-", "").replace("_", "").isalnum():
+            raise ValueError(
+                "Skill name can only contain letters, numbers, hyphens and underscores"
+            )
         if len(name) > 64:
-            raise ValueError('Skill name cannot exceed 64 characters')
+            raise ValueError("Skill name cannot exceed 64 characters")
         return name
 
     @staticmethod
     def _normalize_package_root(package_root: str) -> str:
         package_root = str(package_root).strip()
         if not package_root:
-            return ''
+            return ""
         return os.path.realpath(os.path.abspath(package_root))
 
     @staticmethod
-    def _resolve_create_field(data: dict, field: str, imported_skill_data: dict | None, *, default: str) -> str:
+    def _resolve_create_field(
+        data: dict, field: str, imported_skill_data: dict | None, *, default: str
+    ) -> str:
         raw_value = data.get(field) if field in data else None
         if raw_value is None:
             if imported_skill_data is not None:
                 return str(imported_skill_data.get(field, default) or default)
             return default
 
-        value = str(raw_value or '')
+        value = str(raw_value or "")
         if imported_skill_data is not None and not value.strip():
             return str(imported_skill_data.get(field, default) or default)
         return value

--- a/src/langbot_plugin/cli/__init__.py
+++ b/src/langbot_plugin/cli/__init__.py
@@ -1,6 +1,6 @@
 import argparse
 import sys
-import asyncio
+
 from langbot_plugin.version import __version__
 from langbot_plugin.runtime import app as runtime_app
 from langbot_plugin.cli.commands.initplugin import init_plugin_process
@@ -10,7 +10,7 @@ from langbot_plugin.cli.commands.buildplugin import build_plugin_process
 from langbot_plugin.cli.commands.login import login_process
 from langbot_plugin.cli.commands.logout import logout_process
 from langbot_plugin.cli.commands.publish import publish_process
-from langbot_plugin.cli.i18n import cli_print, t
+from langbot_plugin.cli.i18n import cli_print
 
 """
 Usage:
@@ -45,10 +45,10 @@ def main():
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # help command
-    help_parser = subparsers.add_parser("help", help="Show the help of the CLI")
+    subparsers.add_parser("help", help="Show the help of the CLI")
 
     # ver command
-    ver_parser = subparsers.add_parser("ver", help="Show the version of the CLI")
+    subparsers.add_parser("ver", help="Show the version of the CLI")
 
     # init command
     init_parser = subparsers.add_parser("init", help="Initialize a new plugin")
@@ -94,7 +94,7 @@ def main():
     )
 
     # logout command
-    logout_parser = subparsers.add_parser("logout", help="Logout from LangBot account")
+    subparsers.add_parser("logout", help="Logout from LangBot account")
 
     # build command
     build_parser = subparsers.add_parser("build", help="Build the plugin to a zip file")
@@ -150,9 +150,7 @@ def main():
 
     # box command
     box_parser = subparsers.add_parser("box", help="Run the sandbox box runtime")
-    box_parser.add_argument(
-        "--host", default="0.0.0.0", help="Bind address"
-    )
+    box_parser.add_argument("--host", default="0.0.0.0", help="Bind address")
     box_parser.add_argument(
         "-s",
         "--stdio-control",

--- a/src/langbot_plugin/cli/i18n.py
+++ b/src/langbot_plugin/cli/i18n.py
@@ -48,7 +48,7 @@ class I18nManager:
         if not locale_str:
             try:
                 locale_str = locale.getlocale()[0] or locale.getdefaultlocale()[0] or ""
-            except:
+            except Exception:
                 locale_str = ""
 
         # Determine language from locale string
@@ -86,7 +86,7 @@ class I18nManager:
         if args:
             try:
                 return message.format(*args)
-            except:
+            except Exception:
                 return message
         return message
 

--- a/src/langbot_plugin/cli/run/handler.py
+++ b/src/langbot_plugin/cli/run/handler.py
@@ -23,7 +23,11 @@ from langbot_plugin.api.definition.components.command.command import Command
 from langbot_plugin.api.definition.components.knowledge_engine.engine import (
     KnowledgeEngine,
 )
-from langbot_plugin.api.definition.components.page import Page, PageRequest, PageResponse
+from langbot_plugin.api.definition.components.page import (
+    Page,
+    PageRequest,
+    PageResponse,
+)
 from langbot_plugin.api.definition.components.parser.parser import Parser
 from langbot_plugin.api.entities.builtin.rag.context import RetrievalContext
 from langbot_plugin.api.entities.builtin.rag.models import (
@@ -137,7 +141,9 @@ class PluginRuntimeHandler(Handler):
             file_key = data["file_key"]
             file_path = _resolve_asset_path(file_key)
             if file_path is None:
-                return ActionResponse.success({"file_file_key": None, "mime_type": None})
+                return ActionResponse.success(
+                    {"file_file_key": None, "mime_type": None}
+                )
 
             async with aiofiles.open(file_path, "rb") as f:
                 file_bytes = await f.read()
@@ -166,7 +172,9 @@ class PluginRuntimeHandler(Handler):
                     continue
                 if isinstance(component.component_instance, NoneComponent):
                     return ActionResponse.success(
-                        PageResponse.fail("Page component is not initialized").model_dump()
+                        PageResponse.fail(
+                            "Page component is not initialized"
+                        ).model_dump()
                     )
                 if not isinstance(component.component_instance, Page):
                     return ActionResponse.success(

--- a/src/langbot_plugin/entities/io/errors.py
+++ b/src/langbot_plugin/entities/io/errors.py
@@ -47,7 +47,9 @@ class DependencyInstallError(Exception):
 
     def __str__(self):
         prefix = f"Plugin {self.plugin} " if self.plugin else ""
-        return f"{prefix}failed to install {len(self.failed)} dependencies: {self.failed}"
+        return (
+            f"{prefix}failed to install {len(self.failed)} dependencies: {self.failed}"
+        )
 
 
 class DependencyVerificationError(Exception):

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -175,7 +175,10 @@ def _resolve_import_names(pkg_name: str) -> set[str]:
     if _dist_to_packages is None:
         _dist_to_packages = {}
         try:
-            for top_pkg, dist_names in importlib.metadata.packages_distributions().items():
+            for (
+                top_pkg,
+                dist_names,
+            ) in importlib.metadata.packages_distributions().items():
                 for dist_name in dist_names:
                     key = dist_name.lower().replace("_", "-")
                     _dist_to_packages.setdefault(key, set()).add(top_pkg)

--- a/src/langbot_plugin/runtime/io/controllers/ws/client.py
+++ b/src/langbot_plugin/runtime/io/controllers/ws/client.py
@@ -36,7 +36,9 @@ class WebSocketClientController(Controller):
             # fails with "did not receive a valid HTTP response". This breaks
             # Docker deployments on hosts that inject a proxy into containers
             # (e.g. Docker Desktop with a configured proxy).
-            async with websockets.connect(self.ws_url, open_timeout=10, proxy=None) as websocket:
+            async with websockets.connect(
+                self.ws_url, open_timeout=10, proxy=None
+            ) as websocket:
                 connection = ws_connection.WebSocketConnection(websocket)
                 await new_connection_callback(connection)
         except Exception as e:

--- a/src/langbot_plugin/runtime/io/handlers/control.py
+++ b/src/langbot_plugin/runtime/io/handlers/control.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any, AsyncGenerator
 
-logger = logging.getLogger(__name__)
-
-from langbot_plugin.runtime.io import handler, connection
+from langbot_plugin.runtime.io import connection, handler
 from langbot_plugin.entities.io.actions.enums import (
     CommonAction,
     LangBotToRuntimeAction,
@@ -15,6 +13,8 @@ from langbot_plugin.runtime import context as context_module
 from langbot_plugin.api.entities.context import EventContext
 from langbot_plugin.api.entities.builtin.command.context import ExecuteContext
 from langbot_plugin.runtime.plugin import mgr as plugin_mgr_module
+
+logger = logging.getLogger(__name__)
 
 
 class ControlConnectionHandler(handler.Handler):
@@ -145,7 +145,13 @@ class ControlConnectionHandler(handler.Handler):
         async def page_api(
             data: dict[str, Any],
         ) -> handler.ActionResponse:
-            for field in ("plugin_author", "plugin_name", "page_id", "endpoint", "method"):
+            for field in (
+                "plugin_author",
+                "plugin_name",
+                "page_id",
+                "endpoint",
+                "method",
+            ):
                 if field not in data:
                     return handler.ActionResponse.success(
                         {"data": None, "error": f"Missing required field: {field}"}

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -66,10 +66,7 @@ class PluginConnectionHandler(handler.Handler):
         # Capture the plugin subprocess's stderr (Python `logging` output) into
         # a per-plugin ring buffer so LangBot can show logs on the detail page.
         self.log_buffer = PluginLogBuffer()
-        if (
-            self.stdio_process is not None
-            and self.stdio_process.stderr is not None
-        ):
+        if self.stdio_process is not None and self.stdio_process.stderr is not None:
             self.log_buffer.start_reader(self.stdio_process.stderr)
 
         @self.action(PluginToRuntimeAction.REGISTER_PLUGIN)
@@ -556,9 +553,7 @@ class PluginConnectionHandler(handler.Handler):
                     return handler.ActionResponse.success(
                         {"tool": tool.to_plain_dict()}
                     )
-            return handler.ActionResponse.error(
-                message=f"Tool not found: {tool_name}"
-            )
+            return handler.ActionResponse.error(message=f"Tool not found: {tool_name}")
 
         @self.action(PluginToRuntimeAction.CALL_TOOL)
         async def call_tool_from_plugin(data: dict[str, Any]) -> handler.ActionResponse:
@@ -569,9 +564,7 @@ class PluginConnectionHandler(handler.Handler):
             resp = await self.context.plugin_mgr.call_tool(
                 tool_name, tool_parameters, session, query_id
             )
-            return handler.ActionResponse.success(
-                {"tool_response": resp}
-            )
+            return handler.ActionResponse.success({"tool_response": resp})
 
         @self.action(PluginToRuntimeAction.LIST_PLUGINS_MANIFEST)
         async def list_plugins_manifest(data: dict[str, Any]) -> handler.ActionResponse:

--- a/src/langbot_plugin/runtime/plugin/logbuffer.py
+++ b/src/langbot_plugin/runtime/plugin/logbuffer.py
@@ -83,11 +83,7 @@ class PluginLogBuffer:
         if level:
             min_no = logging.getLevelName(level)
             if isinstance(min_no, int):
-                entries = [
-                    e
-                    for e in entries
-                    if _level_no(e["level"]) >= min_no
-                ]
+                entries = [e for e in entries if _level_no(e["level"]) >= min_no]
 
         if limit and limit > 0:
             entries = entries[-limit:]

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -353,9 +353,11 @@ class PluginManager:
                     },
                 }
 
-                returncode, downloaded_bytes, error_msg = (
-                    await pkgmgr_helper.install_with_retry(dep, max_retries=3)
-                )
+                (
+                    returncode,
+                    downloaded_bytes,
+                    error_msg,
+                ) = await pkgmgr_helper.install_with_retry(dep, max_retries=3)
                 total_downloaded += downloaded_bytes
 
                 if returncode != 0:
@@ -495,7 +497,9 @@ class PluginManager:
 
         # refresh plugin container from plugin (components may have changed)
         plugin_container_data = await handler.get_plugin_container()
-        refreshed = runtime_plugin_container.PluginContainer.from_dict(plugin_container_data)
+        refreshed = runtime_plugin_container.PluginContainer.from_dict(
+            plugin_container_data
+        )
         plugin_container.components = refreshed.components
         plugin_container.manifest = refreshed.manifest
         plugin_container.status = refreshed.status
@@ -743,9 +747,7 @@ class PluginManager:
         """
         plugin = self.find_plugin(plugin_author, plugin_name)
         if plugin is not None and plugin._runtime_plugin_handler is not None:
-            log_buffer = getattr(
-                plugin._runtime_plugin_handler, "log_buffer", None
-            )
+            log_buffer = getattr(plugin._runtime_plugin_handler, "log_buffer", None)
             if log_buffer is not None:
                 return log_buffer.get_logs(limit=limit, level=level)
         return []

--- a/tests/api/definition/components/test_components.py
+++ b/tests/api/definition/components/test_components.py
@@ -9,7 +9,11 @@ from langbot_plugin.api.definition.components.knowledge_engine.engine import (
     KnowledgeEngine,
     KnowledgeEngineCapability,
 )
-from langbot_plugin.api.definition.components.page import Page, PageRequest, PageResponse
+from langbot_plugin.api.definition.components.page import (
+    Page,
+    PageRequest,
+    PageResponse,
+)
 from langbot_plugin.api.definition.components.parser.parser import Parser
 from langbot_plugin.api.definition.components.tool.tool import Tool
 from langbot_plugin.api.entities.builtin.command.context import CommandReturn
@@ -42,9 +46,10 @@ def test_command_subcommand_decorator_records_metadata():
     async def handler(_ctx):
         yield CommandReturn(text="ok")
 
-    assert command.subcommand("run", help="Run", usage="/run", aliases=["r"])(
-        handler
-    ) is handler
+    assert (
+        command.subcommand("run", help="Run", usage="/run", aliases=["r"])(handler)
+        is handler
+    )
 
     registered = command.registered_subcommands["run"]
     assert registered.help == "Run"
@@ -85,7 +90,9 @@ async def test_page_default_handle_api_returns_not_implemented_failure():
 
 
 def test_knowledge_engine_default_capabilities():
-    assert KnowledgeEngine.get_capabilities() == [KnowledgeEngineCapability.DOC_INGESTION]
+    assert KnowledgeEngine.get_capabilities() == [
+        KnowledgeEngineCapability.DOC_INGESTION
+    ]
 
 
 def test_abstract_component_kinds_are_stable():

--- a/tests/api/entities/builtin/test_rag_models.py
+++ b/tests/api/entities/builtin/test_rag_models.py
@@ -47,11 +47,14 @@ def test_rag_file_and_parse_models_keep_metadata_isolated():
     assert FileObject(metadata=first, storage_path="files/a.txt").storage_path == (
         "files/a.txt"
     )
-    assert ParseContext(
-        file_content=b"abc",
-        mime_type="text/plain",
-        filename="a.txt",
-    ).metadata == {}
+    assert (
+        ParseContext(
+            file_content=b"abc",
+            mime_type="text/plain",
+            filename="a.txt",
+        ).metadata
+        == {}
+    )
 
 
 def test_rag_text_models_and_parse_result_defaults():

--- a/tests/api/entities/test_context.py
+++ b/tests/api/entities/test_context.py
@@ -4,7 +4,9 @@ from langbot_plugin.api.entities import context as context_module
 from langbot_plugin.api.definition.abstract.platform.adapter import (
     AbstractMessagePlatformAdapter,
 )
-from langbot_plugin.api.definition.abstract.platform.event_logger import AbstractEventLogger
+from langbot_plugin.api.definition.abstract.platform.event_logger import (
+    AbstractEventLogger,
+)
 from langbot_plugin.api.entities.builtin.pipeline.query import Query
 from langbot_plugin.api.entities.builtin.platform.message import MessageChain, Plain
 from langbot_plugin.api.entities.builtin.platform.events import FriendMessage

--- a/tests/api/proxies/test_query_based_api.py
+++ b/tests/api/proxies/test_query_based_api.py
@@ -50,7 +50,9 @@ async def test_query_based_proxy_query_var_helpers():
             PluginToRuntimeAction.CREATE_NEW_CONVERSATION: {"uuid": "conv"},
         }
     )
-    proxy = QueryBasedAPIProxy.model_construct(query_id=7, plugin_runtime_handler=handler)
+    proxy = QueryBasedAPIProxy.model_construct(
+        query_id=7, plugin_runtime_handler=handler
+    )
 
     assert await proxy.get_bot_uuid() == "bot"
     await proxy.set_query_var("k", "v")
@@ -77,7 +79,9 @@ async def test_query_based_proxy_pipeline_knowledge_helpers():
             },
         }
     )
-    proxy = QueryBasedAPIProxy.model_construct(query_id=7, plugin_runtime_handler=handler)
+    proxy = QueryBasedAPIProxy.model_construct(
+        query_id=7, plugin_runtime_handler=handler
+    )
 
     assert await proxy.list_pipeline_knowledge_bases() == [{"uuid": "kb"}]
     assert await proxy.retrieve_knowledge("kb", "query", top_k=3) == [

--- a/tests/box/test_backend.py
+++ b/tests/box/test_backend.py
@@ -34,26 +34,26 @@ from langbot_plugin.box.models import (
 
 @pytest.fixture
 def logger():
-    return logging.getLogger('test.docker')
+    return logging.getLogger("test.docker")
 
 
 @pytest.fixture
 def backend(logger):
     b = DockerBackend(logger=logger)
-    b.instance_id = 'inst-test'
+    b.instance_id = "inst-test"
     return b
 
 
 @pytest.fixture
 def session():
     return BoxSessionInfo(
-        session_id='sess1',
-        backend_name='docker',
-        backend_session_id='langbot-box-sess1-abcd1234',
-        image='rockchin/langbot-sandbox:latest',
+        session_id="sess1",
+        backend_name="docker",
+        backend_session_id="langbot-box-sess1-abcd1234",
+        image="rockchin/langbot-sandbox:latest",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
 
 
@@ -64,12 +64,14 @@ class _FakeStream:
         if chunk_size is None:
             self._chunks = [data] if data else []
         else:
-            self._chunks = [data[i:i + chunk_size] for i in range(0, len(data), chunk_size)]
+            self._chunks = [
+                data[i : i + chunk_size] for i in range(0, len(data), chunk_size)
+            ]
         self._index = 0
 
     async def read(self, _n: int = -1) -> bytes:
         if self._index >= len(self._chunks):
-            return b''
+            return b""
         chunk = self._chunks[self._index]
         self._index += 1
         return chunk
@@ -78,7 +80,13 @@ class _FakeStream:
 class _FakeProcess:
     """Fake asyncio subprocess used by ``_run_command`` / managed processes."""
 
-    def __init__(self, returncode: int = 0, stdout: bytes = b'', stderr: bytes = b'', hang: bool = False):
+    def __init__(
+        self,
+        returncode: int = 0,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        hang: bool = False,
+    ):
         self.returncode = returncode
         self.stdout = _FakeStream(stdout)
         self.stderr = _FakeStream(stderr)
@@ -97,13 +105,13 @@ class _FakeProcess:
         self._hang = False
 
     async def communicate(self, _input=None):
-        return (b'', b'')
+        return (b"", b"")
 
 
 def _patch_exec(proc: _FakeProcess):
     """Patch ``asyncio.create_subprocess_exec`` to return *proc* and capture argv."""
     mock_exec = mock.AsyncMock(return_value=proc)
-    return mock.patch('asyncio.create_subprocess_exec', mock_exec), mock_exec
+    return mock.patch("asyncio.create_subprocess_exec", mock_exec), mock_exec
 
 
 def _argv_of(mock_exec: mock.AsyncMock, call_index: int = 0) -> list[str]:
@@ -122,8 +130,8 @@ def _all_values_after(argv: list[str], flag: str) -> list[str]:
 
 
 def test_backend_name_and_command(backend):
-    assert backend.name == 'docker'
-    assert backend.command == 'docker'
+    assert backend.name == "docker"
+    assert backend.command == "docker"
 
 
 # ── is_available ──────────────────────────────────────────────────────
@@ -131,26 +139,26 @@ def test_backend_name_and_command(backend):
 
 @pytest.mark.anyio
 async def test_is_available_no_binary(backend):
-    with mock.patch('shutil.which', return_value=None):
+    with mock.patch("shutil.which", return_value=None):
         assert await backend.is_available() is False
 
 
 @pytest.mark.anyio
 async def test_is_available_binary_ok(backend):
-    proc = _FakeProcess(returncode=0, stdout=b'docker info ok')
+    proc = _FakeProcess(returncode=0, stdout=b"docker info ok")
     patcher, mock_exec = _patch_exec(proc)
-    with mock.patch('shutil.which', return_value='/usr/bin/docker'), patcher:
+    with mock.patch("shutil.which", return_value="/usr/bin/docker"), patcher:
         assert await backend.is_available() is True
 
     argv = _argv_of(mock_exec)
-    assert argv == ['docker', 'info']
+    assert argv == ["docker", "info"]
 
 
 @pytest.mark.anyio
 async def test_is_available_info_nonzero(backend):
-    proc = _FakeProcess(returncode=1, stderr=b'cannot connect')
+    proc = _FakeProcess(returncode=1, stderr=b"cannot connect")
     patcher, _ = _patch_exec(proc)
-    with mock.patch('shutil.which', return_value='/usr/bin/docker'), patcher:
+    with mock.patch("shutil.which", return_value="/usr/bin/docker"), patcher:
         assert await backend.is_available() is False
 
 
@@ -159,9 +167,9 @@ async def test_is_available_info_nonzero(backend):
 
 @pytest.mark.anyio
 async def test_start_session_basic_argv_and_info(backend):
-    proc = _FakeProcess(returncode=0, stdout=b'containerid\n')
+    proc = _FakeProcess(returncode=0, stdout=b"containerid\n")
     patcher, mock_exec = _patch_exec(proc)
-    spec = BoxSpec(session_id='My Session!', cmd='echo hi')
+    spec = BoxSpec(session_id="My Session!", cmd="echo hi")
 
     with patcher:
         info = await backend.start_session(spec)
@@ -169,36 +177,36 @@ async def test_start_session_basic_argv_and_info(backend):
     argv = _argv_of(mock_exec)
 
     # Base command.
-    assert argv[:3] == ['docker', 'run', '-d']
+    assert argv[:3] == ["docker", "run", "-d"]
     # Non-persistent -> --rm.
-    assert '--rm' in argv
+    assert "--rm" in argv
 
     # Name + labels.
-    container_name = _value_after(argv, '--name')
-    assert container_name.startswith('langbot-box-')
-    labels = _all_values_after(argv, '--label')
-    assert 'langbot.box=true' in labels
-    assert f'langbot.session_id={spec.session_id}' in labels
-    assert 'langbot.box.instance_id=inst-test' in labels
+    container_name = _value_after(argv, "--name")
+    assert container_name.startswith("langbot-box-")
+    labels = _all_values_after(argv, "--label")
+    assert "langbot.box=true" in labels
+    assert f"langbot.session_id={spec.session_id}" in labels
+    assert "langbot.box.instance_id=inst-test" in labels
 
     # Network OFF -> --network none.
-    assert _value_after(argv, '--network') == 'none'
+    assert _value_after(argv, "--network") == "none"
 
     # Resource limits.
-    assert _value_after(argv, '--cpus') == '1.0'
-    assert _value_after(argv, '--memory') == '512m'
-    assert _value_after(argv, '--pids-limit') == '128'
+    assert _value_after(argv, "--cpus") == "1.0"
+    assert _value_after(argv, "--memory") == "512m"
+    assert _value_after(argv, "--pids-limit") == "128"
 
     # read_only_rootfs default True -> --read-only + tmpfs.
-    assert '--read-only' in argv
-    assert _value_after(argv, '--tmpfs') == '/tmp:size=64m'
+    assert "--read-only" in argv
+    assert _value_after(argv, "--tmpfs") == "/tmp:size=64m"
 
     # Tail: image then the long-running shell.
-    assert argv[-4:] == [spec.image, 'sh', '-lc', 'while true; do sleep 3600; done']
+    assert argv[-4:] == [spec.image, "sh", "-lc", "while true; do sleep 3600; done"]
 
     # Returned session info.
     assert info.session_id == spec.session_id
-    assert info.backend_name == 'docker'
+    assert info.backend_name == "docker"
     assert info.backend_session_id == container_name
     assert info.image == spec.image
     assert info.network == BoxNetworkMode.OFF
@@ -211,13 +219,13 @@ async def test_start_session_basic_argv_and_info(backend):
 async def test_start_session_persistent_no_rm(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
-    spec = BoxSpec(session_id='persist', cmd='x', persistent=True)
+    spec = BoxSpec(session_id="persist", cmd="x", persistent=True)
 
     with patcher:
         info = await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    assert '--rm' not in argv
+    assert "--rm" not in argv
     assert info.persistent is True
 
 
@@ -225,14 +233,14 @@ async def test_start_session_persistent_no_rm(backend):
 async def test_start_session_network_on_omits_network_flag(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
-    spec = BoxSpec(session_id='net', cmd='x', network=BoxNetworkMode.ON)
+    spec = BoxSpec(session_id="net", cmd="x", network=BoxNetworkMode.ON)
 
     with patcher:
         info = await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
     # ON mode leaves Docker's default network in place: no --network none.
-    assert '--network' not in argv
+    assert "--network" not in argv
     assert info.network == BoxNetworkMode.ON
 
 
@@ -240,14 +248,14 @@ async def test_start_session_network_on_omits_network_flag(backend):
 async def test_start_session_writable_rootfs_no_readonly(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
-    spec = BoxSpec(session_id='rw-root', cmd='x', read_only_rootfs=False)
+    spec = BoxSpec(session_id="rw-root", cmd="x", read_only_rootfs=False)
 
     with patcher:
         info = await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    assert '--read-only' not in argv
-    assert '--tmpfs' not in argv
+    assert "--read-only" not in argv
+    assert "--tmpfs" not in argv
     assert info.read_only_rootfs is False
 
 
@@ -256,8 +264,8 @@ async def test_start_session_custom_resource_limits(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='res',
-        cmd='x',
+        session_id="res",
+        cmd="x",
         cpus=2.5,
         memory_mb=1024,
         pids_limit=256,
@@ -267,9 +275,9 @@ async def test_start_session_custom_resource_limits(backend):
         info = await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    assert _value_after(argv, '--cpus') == '2.5'
-    assert _value_after(argv, '--memory') == '1024m'
-    assert _value_after(argv, '--pids-limit') == '256'
+    assert _value_after(argv, "--cpus") == "2.5"
+    assert _value_after(argv, "--memory") == "1024m"
+    assert _value_after(argv, "--pids-limit") == "256"
     assert info.cpus == 2.5
     assert info.memory_mb == 1024
     assert info.pids_limit == 256
@@ -280,23 +288,23 @@ async def test_start_session_host_path_mount(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='hp',
-        cmd='ls',
-        host_path='/data/project',
+        session_id="hp",
+        cmd="ls",
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/project',
-        workdir='/project',
+        mount_path="/project",
+        workdir="/project",
     )
 
     with patcher:
         info = await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    binds = _all_values_after(argv, '-v')
-    assert '/data/project:/project:rw' in binds
-    assert info.host_path == '/data/project'
+    binds = _all_values_after(argv, "-v")
+    assert "/data/project:/project:rw" in binds
+    assert info.host_path == "/data/project"
     assert info.host_path_mode == BoxHostMountMode.READ_WRITE
-    assert info.mount_path == '/project'
+    assert info.mount_path == "/project"
 
 
 @pytest.mark.anyio
@@ -304,9 +312,9 @@ async def test_start_session_host_path_readonly_mount(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='hp-ro',
-        cmd='cat f',
-        host_path='/data/source',
+        session_id="hp-ro",
+        cmd="cat f",
+        host_path="/data/source",
         host_path_mode=BoxHostMountMode.READ_ONLY,
     )
 
@@ -314,8 +322,8 @@ async def test_start_session_host_path_readonly_mount(backend):
         await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    binds = _all_values_after(argv, '-v')
-    assert '/data/source:/workspace:ro' in binds
+    binds = _all_values_after(argv, "-v")
+    assert "/data/source:/workspace:ro" in binds
 
 
 @pytest.mark.anyio
@@ -323,9 +331,9 @@ async def test_start_session_host_path_none_skips_mount(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='hp-none',
-        cmd='ls',
-        host_path='/data',
+        session_id="hp-none",
+        cmd="ls",
+        host_path="/data",
         host_path_mode=BoxHostMountMode.NONE,
     )
 
@@ -333,7 +341,7 @@ async def test_start_session_host_path_none_skips_mount(backend):
         await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    assert '-v' not in argv
+    assert "-v" not in argv
 
 
 @pytest.mark.anyio
@@ -341,17 +349,17 @@ async def test_start_session_extra_mounts(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='extra',
-        cmd='ls',
+        session_id="extra",
+        cmd="ls",
         extra_mounts=[
             BoxMountSpec(
-                host_path='/data/skills/demo',
-                mount_path='/workspace/.skills/demo',
+                host_path="/data/skills/demo",
+                mount_path="/workspace/.skills/demo",
                 mode=BoxHostMountMode.READ_WRITE,
             ),
             BoxMountSpec(
-                host_path='/data/config',
-                mount_path='/etc/app',
+                host_path="/data/config",
+                mount_path="/etc/app",
                 mode=BoxHostMountMode.READ_ONLY,
             ),
         ],
@@ -361,9 +369,9 @@ async def test_start_session_extra_mounts(backend):
         await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    binds = _all_values_after(argv, '-v')
-    assert '/data/skills/demo:/workspace/.skills/demo:rw' in binds
-    assert '/data/config:/etc/app:ro' in binds
+    binds = _all_values_after(argv, "-v")
+    assert "/data/skills/demo:/workspace/.skills/demo:rw" in binds
+    assert "/data/config:/etc/app:ro" in binds
 
 
 @pytest.mark.anyio
@@ -371,12 +379,12 @@ async def test_start_session_extra_mount_none_mode_skipped(backend):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='extra-none',
-        cmd='ls',
+        session_id="extra-none",
+        cmd="ls",
         extra_mounts=[
             BoxMountSpec(
-                host_path='/data/skip',
-                mount_path='/mnt/skip',
+                host_path="/data/skip",
+                mount_path="/mnt/skip",
                 mode=BoxHostMountMode.NONE,
             ),
         ],
@@ -386,14 +394,14 @@ async def test_start_session_extra_mount_none_mode_skipped(backend):
         await backend.start_session(spec)
 
     argv = _argv_of(mock_exec)
-    assert '/data/skip:/mnt/skip:none' not in _all_values_after(argv, '-v')
+    assert "/data/skip:/mnt/skip:none" not in _all_values_after(argv, "-v")
 
 
 @pytest.mark.anyio
 async def test_start_session_workspace_quota_passthrough(backend):
     proc = _FakeProcess(returncode=0)
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='quota', cmd='x', workspace_quota_mb=2048)
+    spec = BoxSpec(session_id="quota", cmd="x", workspace_quota_mb=2048)
 
     with patcher:
         info = await backend.start_session(spec)
@@ -407,11 +415,14 @@ async def test_start_session_workspace_quota_passthrough(backend):
 async def test_start_session_calls_security_validation(backend):
     proc = _FakeProcess(returncode=0)
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='sec', cmd='x')
+    spec = BoxSpec(session_id="sec", cmd="x")
 
-    with patcher, mock.patch(
-        'langbot_plugin.box.backend.validate_sandbox_security'
-    ) as mock_validate:
+    with (
+        patcher,
+        mock.patch(
+            "langbot_plugin.box.backend.validate_sandbox_security"
+        ) as mock_validate,
+    ):
         await backend.start_session(spec)
 
     mock_validate.assert_called_once_with(spec)
@@ -426,18 +437,23 @@ async def test_start_session_blocked_host_path_raises(backend):
     directly to assert ``start_session`` propagates the rejection.
     """
     spec = BoxSpec(
-        session_id='blocked',
-        cmd='x',
-        host_path='/data/safe',
+        session_id="blocked",
+        cmd="x",
+        host_path="/data/safe",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/data/safe',
+        mount_path="/data/safe",
     )
 
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
-    with patcher, mock.patch(
-        'langbot_plugin.box.backend.validate_sandbox_security',
-        side_effect=BoxValidationError('host_path /data/safe is blocked for security'),
+    with (
+        patcher,
+        mock.patch(
+            "langbot_plugin.box.backend.validate_sandbox_security",
+            side_effect=BoxValidationError(
+                "host_path /data/safe is blocked for security"
+            ),
+        ),
     ):
         with pytest.raises(BoxValidationError):
             await backend.start_session(spec)
@@ -453,13 +469,13 @@ def test_validate_sandbox_security_rejects_blocked_path():
     # Use a path that realpath leaves untouched on every platform by mocking
     # realpath so the test is OS-independent.
     spec = BoxSpec(
-        session_id='sec-real',
-        cmd='x',
-        host_path='/proc',
+        session_id="sec-real",
+        cmd="x",
+        host_path="/proc",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/proc',
+        mount_path="/proc",
     )
-    with mock.patch('os.path.realpath', return_value='/proc'):
+    with mock.patch("os.path.realpath", return_value="/proc"):
         with pytest.raises(BoxValidationError):
             validate_sandbox_security(spec)
 
@@ -469,28 +485,28 @@ def test_validate_sandbox_security_allows_safe_path():
     from langbot_plugin.box.security import validate_sandbox_security
 
     spec = BoxSpec(
-        session_id='sec-ok',
-        cmd='x',
-        host_path='/data/project',
+        session_id="sec-ok",
+        cmd="x",
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/data/project',
+        mount_path="/data/project",
     )
-    with mock.patch('os.path.realpath', return_value='/data/project'):
+    with mock.patch("os.path.realpath", return_value="/data/project"):
         validate_sandbox_security(spec)  # should not raise
 
 
 @pytest.mark.anyio
 async def test_start_session_check_failure_raises_boxerror(backend):
-    proc = _FakeProcess(returncode=125, stderr=b'docker: image not found')
+    proc = _FakeProcess(returncode=125, stderr=b"docker: image not found")
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='fail', cmd='x')
+    spec = BoxSpec(session_id="fail", cmd="x")
 
     with patcher:
         with pytest.raises(BoxError) as exc:
             await backend.start_session(spec)
 
-    assert 'docker backend error' in str(exc.value)
-    assert 'image not found' in str(exc.value)
+    assert "docker backend error" in str(exc.value)
+    assert "image not found" in str(exc.value)
 
 
 # ── exec ──────────────────────────────────────────────────────────────
@@ -498,13 +514,13 @@ async def test_start_session_check_failure_raises_boxerror(backend):
 
 @pytest.mark.anyio
 async def test_exec_argv_and_completed(backend, session):
-    proc = _FakeProcess(returncode=0, stdout=b'hello\n', stderr=b'')
+    proc = _FakeProcess(returncode=0, stdout=b"hello\n", stderr=b"")
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxSpec(
-        session_id='sess1',
-        cmd='echo hello',
-        workdir='/workspace',
-        env={'FOO': 'bar', 'BAZ': 'qux'},
+        session_id="sess1",
+        cmd="echo hello",
+        workdir="/workspace",
+        env={"FOO": "bar", "BAZ": "qux"},
         timeout_sec=15,
     )
 
@@ -512,24 +528,24 @@ async def test_exec_argv_and_completed(backend, session):
         result = await backend.exec(session, spec)
 
     argv = _argv_of(mock_exec)
-    assert argv[:2] == ['docker', 'exec']
+    assert argv[:2] == ["docker", "exec"]
 
     # Env flags.
-    env_values = _all_values_after(argv, '-e')
-    assert 'FOO=bar' in env_values
-    assert 'BAZ=qux' in env_values
+    env_values = _all_values_after(argv, "-e")
+    assert "FOO=bar" in env_values
+    assert "BAZ=qux" in env_values
 
     # Container id then shell invocation.
     assert argv[-4] == session.backend_session_id
-    assert argv[-3:-1] == ['sh', '-lc']
-    assert argv[-1] == backend._build_exec_command('/workspace', 'echo hello')
+    assert argv[-3:-1] == ["sh", "-lc"]
+    assert argv[-1] == backend._build_exec_command("/workspace", "echo hello")
 
     assert result.status == BoxExecutionStatus.COMPLETED
     assert result.exit_code == 0
-    assert result.stdout == 'hello'
-    assert result.stderr == ''
-    assert result.backend_name == 'docker'
-    assert result.session_id == 'sess1'
+    assert result.stdout == "hello"
+    assert result.stderr == ""
+    assert result.backend_name == "docker"
+    assert result.session_id == "sess1"
     assert result.ok is True
     assert result.duration_ms >= 0
 
@@ -537,10 +553,10 @@ async def test_exec_argv_and_completed(backend, session):
 @pytest.mark.anyio
 async def test_exec_truncates_long_cmd_preview_in_log(backend, session):
     # A very long command exercises the >400 char preview-truncation branch.
-    long_cmd = 'echo ' + ('a' * 500)
-    proc = _FakeProcess(returncode=0, stdout=b'ok')
+    long_cmd = "echo " + ("a" * 500)
+    proc = _FakeProcess(returncode=0, stdout=b"ok")
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='sess1', cmd=long_cmd)
+    spec = BoxSpec(session_id="sess1", cmd=long_cmd)
 
     with patcher:
         result = await backend.exec(session, spec)
@@ -555,28 +571,28 @@ async def test_exec_handles_none_streams(backend, session):
     proc.stdout = None
     proc.stderr = None
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='sess1', cmd='echo hi')
+    spec = BoxSpec(session_id="sess1", cmd="echo hi")
 
     with patcher:
         result = await backend.exec(session, spec)
 
-    assert result.stdout == ''
-    assert result.stderr == ''
+    assert result.stdout == ""
+    assert result.stderr == ""
     assert result.exit_code == 0
 
 
 @pytest.mark.anyio
 async def test_exec_nonzero_exit(backend, session):
-    proc = _FakeProcess(returncode=2, stdout=b'', stderr=b'boom')
+    proc = _FakeProcess(returncode=2, stdout=b"", stderr=b"boom")
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='sess1', cmd='false')
+    spec = BoxSpec(session_id="sess1", cmd="false")
 
     with patcher:
         result = await backend.exec(session, spec)
 
     assert result.status == BoxExecutionStatus.COMPLETED
     assert result.exit_code == 2
-    assert result.stderr == 'boom'
+    assert result.stderr == "boom"
     assert result.ok is False
 
 
@@ -584,7 +600,7 @@ async def test_exec_nonzero_exit(backend, session):
 async def test_exec_timeout(backend, session):
     proc = _FakeProcess(returncode=0, hang=True)
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='sess1', cmd='sleep 100', timeout_sec=1)
+    spec = BoxSpec(session_id="sess1", cmd="sleep 100", timeout_sec=1)
 
     # Make wait_for time out immediately rather than waiting 1s.
     async def fake_wait_for(awaitable, timeout):
@@ -593,12 +609,12 @@ async def test_exec_timeout(backend, session):
             awaitable.close()
         raise asyncio.TimeoutError
 
-    with patcher, mock.patch('asyncio.wait_for', side_effect=fake_wait_for):
+    with patcher, mock.patch("asyncio.wait_for", side_effect=fake_wait_for):
         result = await backend.exec(session, spec)
 
     assert result.status == BoxExecutionStatus.TIMED_OUT
     assert result.exit_code is None
-    assert 'timed out' in result.stderr.lower()
+    assert "timed out" in result.stderr.lower()
     assert proc.killed is True
 
 
@@ -606,38 +622,38 @@ async def test_exec_timeout(backend, session):
 
 
 def test_build_exec_command(backend):
-    cmd = backend._build_exec_command('/workspace/sub', 'python run.py')
+    cmd = backend._build_exec_command("/workspace/sub", "python run.py")
     assert cmd == "mkdir -p /workspace/sub && cd /workspace/sub && python run.py"
 
 
 def test_build_exec_command_quotes_workdir_with_spaces(backend):
-    cmd = backend._build_exec_command('/work space', 'ls')
+    cmd = backend._build_exec_command("/work space", "ls")
     assert "'/work space'" in cmd
-    assert cmd.endswith('&& ls')
+    assert cmd.endswith("&& ls")
 
 
 def test_build_spawn_command_quotes_args(backend):
-    cmd = backend._build_spawn_command('/workspace', 'python', ['-c', 'print(1)'])
-    assert cmd.startswith('mkdir -p /workspace && cd /workspace && exec ')
+    cmd = backend._build_spawn_command("/workspace", "python", ["-c", "print(1)"])
+    assert cmd.startswith("mkdir -p /workspace && cd /workspace && exec ")
     assert "python -c 'print(1)'" in cmd
 
 
 def test_build_container_name_normalizes(backend):
-    name = backend._build_container_name('My Session!@#')
-    assert name.startswith('langbot-box-')
+    name = backend._build_container_name("My Session!@#")
+    assert name.startswith("langbot-box-")
     # Illegal chars collapsed to hyphens, lowercased; suffix is 8 hex chars.
-    body = name[len('langbot-box-'):]
-    stem, _, suffix = body.rpartition('-')
+    body = name[len("langbot-box-") :]
+    stem, _, suffix = body.rpartition("-")
     assert len(suffix) == 8
-    assert all(c in '0123456789abcdef' for c in suffix)
-    assert stem == 'my-session'
+    assert all(c in "0123456789abcdef" for c in suffix)
+    assert stem == "my-session"
 
 
 def test_build_container_name_empty_fallback(backend):
-    name = backend._build_container_name('!!!')
-    body = name[len('langbot-box-'):]
-    stem, _, _ = body.rpartition('-')
-    assert stem == 'session'
+    name = backend._build_container_name("!!!")
+    body = name[len("langbot-box-") :]
+    stem, _, _ = body.rpartition("-")
+    assert stem == "session"
 
 
 # ── stop_session ──────────────────────────────────────────────────────
@@ -652,7 +668,7 @@ async def test_stop_session_argv(backend, session):
         await backend.stop_session(session)
 
     argv = _argv_of(mock_exec)
-    assert argv == ['docker', 'rm', '-f', session.backend_session_id]
+    assert argv == ["docker", "rm", "-f", session.backend_session_id]
 
 
 # ── is_session_alive ──────────────────────────────────────────────────
@@ -660,7 +676,7 @@ async def test_stop_session_argv(backend, session):
 
 @pytest.mark.anyio
 async def test_is_session_alive_true(backend, session):
-    proc = _FakeProcess(returncode=0, stdout=b'true\n')
+    proc = _FakeProcess(returncode=0, stdout=b"true\n")
     patcher, mock_exec = _patch_exec(proc)
 
     with patcher:
@@ -668,10 +684,10 @@ async def test_is_session_alive_true(backend, session):
 
     argv = _argv_of(mock_exec)
     assert argv == [
-        'docker',
-        'inspect',
-        '-f',
-        '{{.State.Running}}',
+        "docker",
+        "inspect",
+        "-f",
+        "{{.State.Running}}",
         session.backend_session_id,
     ]
     assert alive is True
@@ -679,7 +695,7 @@ async def test_is_session_alive_true(backend, session):
 
 @pytest.mark.anyio
 async def test_is_session_alive_false_when_stopped(backend, session):
-    proc = _FakeProcess(returncode=0, stdout=b'false\n')
+    proc = _FakeProcess(returncode=0, stdout=b"false\n")
     patcher, _ = _patch_exec(proc)
     with patcher:
         assert await backend.is_session_alive(session) is False
@@ -687,7 +703,7 @@ async def test_is_session_alive_false_when_stopped(backend, session):
 
 @pytest.mark.anyio
 async def test_is_session_alive_false_when_missing(backend, session):
-    proc = _FakeProcess(returncode=1, stderr=b'No such object')
+    proc = _FakeProcess(returncode=1, stderr=b"No such object")
     patcher, _ = _patch_exec(proc)
     with patcher:
         assert await backend.is_session_alive(session) is False
@@ -701,47 +717,47 @@ async def test_cleanup_orphaned_removes_other_instances(backend):
     ps_proc = _FakeProcess(
         returncode=0,
         # Includes a blank line (skipped) plus an unlabeled container ('ccc').
-        stdout=b'aaa\tother-instance\n\nbbb\tinst-test\nccc\t\n',
+        stdout=b"aaa\tother-instance\n\nbbb\tinst-test\nccc\t\n",
     )
     rm_proc = _FakeProcess(returncode=0)
     mock_exec = mock.AsyncMock(side_effect=[ps_proc, rm_proc])
 
-    with mock.patch('asyncio.create_subprocess_exec', mock_exec):
-        await backend.cleanup_orphaned_containers('inst-test')
+    with mock.patch("asyncio.create_subprocess_exec", mock_exec):
+        await backend.cleanup_orphaned_containers("inst-test")
 
     # First call lists containers.
     ps_argv = _argv_of(mock_exec, 0)
-    assert ps_argv[:4] == ['docker', 'ps', '-a', '--filter']
-    assert 'label=langbot.box=true' in ps_argv
+    assert ps_argv[:4] == ["docker", "ps", "-a", "--filter"]
+    assert "label=langbot.box=true" in ps_argv
 
     # Second call removes only the non-matching / unlabeled containers.
     rm_argv = _argv_of(mock_exec, 1)
-    assert rm_argv[:3] == ['docker', 'rm', '-f']
-    assert set(rm_argv[3:]) == {'aaa', 'ccc'}
-    assert 'bbb' not in rm_argv
+    assert rm_argv[:3] == ["docker", "rm", "-f"]
+    assert set(rm_argv[3:]) == {"aaa", "ccc"}
+    assert "bbb" not in rm_argv
 
 
 @pytest.mark.anyio
 async def test_cleanup_orphaned_handles_line_without_label_field(backend):
     # 'ddd' has no tab separator at all -> empty label, treated as orphan.
-    ps_proc = _FakeProcess(returncode=0, stdout=b'ddd\n')
+    ps_proc = _FakeProcess(returncode=0, stdout=b"ddd\n")
     rm_proc = _FakeProcess(returncode=0)
     mock_exec = mock.AsyncMock(side_effect=[ps_proc, rm_proc])
 
-    with mock.patch('asyncio.create_subprocess_exec', mock_exec):
-        await backend.cleanup_orphaned_containers('inst-test')
+    with mock.patch("asyncio.create_subprocess_exec", mock_exec):
+        await backend.cleanup_orphaned_containers("inst-test")
 
     rm_argv = _argv_of(mock_exec, 1)
-    assert rm_argv == ['docker', 'rm', '-f', 'ddd']
+    assert rm_argv == ["docker", "rm", "-f", "ddd"]
 
 
 @pytest.mark.anyio
 async def test_cleanup_orphaned_noop_when_nothing_listed(backend):
-    ps_proc = _FakeProcess(returncode=0, stdout=b'')
+    ps_proc = _FakeProcess(returncode=0, stdout=b"")
     mock_exec = mock.AsyncMock(return_value=ps_proc)
 
-    with mock.patch('asyncio.create_subprocess_exec', mock_exec):
-        await backend.cleanup_orphaned_containers('inst-test')
+    with mock.patch("asyncio.create_subprocess_exec", mock_exec):
+        await backend.cleanup_orphaned_containers("inst-test")
 
     # Only the listing call happened; no rm.
     assert mock_exec.call_count == 1
@@ -749,22 +765,22 @@ async def test_cleanup_orphaned_noop_when_nothing_listed(backend):
 
 @pytest.mark.anyio
 async def test_cleanup_orphaned_noop_when_all_current(backend):
-    ps_proc = _FakeProcess(returncode=0, stdout=b'bbb\tinst-test\n')
+    ps_proc = _FakeProcess(returncode=0, stdout=b"bbb\tinst-test\n")
     mock_exec = mock.AsyncMock(return_value=ps_proc)
 
-    with mock.patch('asyncio.create_subprocess_exec', mock_exec):
-        await backend.cleanup_orphaned_containers('inst-test')
+    with mock.patch("asyncio.create_subprocess_exec", mock_exec):
+        await backend.cleanup_orphaned_containers("inst-test")
 
     assert mock_exec.call_count == 1
 
 
 @pytest.mark.anyio
 async def test_cleanup_orphaned_ps_failure_is_noop(backend):
-    ps_proc = _FakeProcess(returncode=1, stderr=b'daemon down')
+    ps_proc = _FakeProcess(returncode=1, stderr=b"daemon down")
     mock_exec = mock.AsyncMock(return_value=ps_proc)
 
-    with mock.patch('asyncio.create_subprocess_exec', mock_exec):
-        await backend.cleanup_orphaned_containers('inst-test')
+    with mock.patch("asyncio.create_subprocess_exec", mock_exec):
+        await backend.cleanup_orphaned_containers("inst-test")
 
     assert mock_exec.call_count == 1
 
@@ -777,10 +793,10 @@ async def test_start_managed_process_argv(backend, session):
     proc = _FakeProcess(returncode=0)
     patcher, mock_exec = _patch_exec(proc)
     spec = BoxManagedProcessSpec(
-        command='python',
-        args=['-m', 'http.server'],
-        env={'PORT': '8000'},
-        cwd='/workspace',
+        command="python",
+        args=["-m", "http.server"],
+        env={"PORT": "8000"},
+        cwd="/workspace",
     )
 
     with patcher:
@@ -788,78 +804,80 @@ async def test_start_managed_process_argv(backend, session):
 
     assert returned is proc
     argv = _argv_of(mock_exec)
-    assert argv[:3] == ['docker', 'exec', '-i']
-    assert 'PORT=8000' in _all_values_after(argv, '-e')
+    assert argv[:3] == ["docker", "exec", "-i"]
+    assert "PORT=8000" in _all_values_after(argv, "-e")
     assert argv[-4] == session.backend_session_id
-    assert argv[-3:-1] == ['sh', '-lc']
-    assert argv[-1] == backend._build_spawn_command('/workspace', 'python', ['-m', 'http.server'])
+    assert argv[-3:-1] == ["sh", "-lc"]
+    assert argv[-1] == backend._build_spawn_command(
+        "/workspace", "python", ["-m", "http.server"]
+    )
 
     # Managed processes wire up stdio pipes.
     kwargs = mock_exec.call_args.kwargs
-    assert kwargs['stdin'] == asyncio.subprocess.PIPE
-    assert kwargs['stdout'] == asyncio.subprocess.PIPE
-    assert kwargs['stderr'] == asyncio.subprocess.PIPE
+    assert kwargs["stdin"] == asyncio.subprocess.PIPE
+    assert kwargs["stdout"] == asyncio.subprocess.PIPE
+    assert kwargs["stderr"] == asyncio.subprocess.PIPE
 
 
 # ── output clipping ───────────────────────────────────────────────────
 
 
 def test_clip_captured_bytes_within_limit():
-    data = b'  hello world  '
-    assert DockerBackend._clip_captured_bytes(data, len(data)) == 'hello world'
+    data = b"  hello world  "
+    assert DockerBackend._clip_captured_bytes(data, len(data)) == "hello world"
 
 
 def test_clip_captured_bytes_exceeds_limit():
-    result = DockerBackend._clip_captured_bytes(b'hello', 2_000_000, limit=1_000_000)
-    assert 'clipped' in result
-    assert '1000000' in result
+    result = DockerBackend._clip_captured_bytes(b"hello", 2_000_000, limit=1_000_000)
+    assert "clipped" in result
+    assert "1000000" in result
 
 
 @pytest.mark.anyio
 async def test_read_stream_none_returns_empty():
-    assert await DockerBackend._read_stream(None) == (b'', 0)
+    assert await DockerBackend._read_stream(None) == (b"", 0)
 
 
 @pytest.mark.anyio
 async def test_read_stream_caps_at_limit_across_chunks():
     # Two 4-byte chunks with a 5-byte limit: the second chunk arrives after
     # the cap is already reached, exercising the 'remaining <= 0' branch.
-    stream = _FakeStream(b'aaaabbbb', chunk_size=4)
+    stream = _FakeStream(b"aaaabbbb", chunk_size=4)
     data, total = await DockerBackend._read_stream(stream, limit=5)
     assert total == 8
     assert len(data) == 5
-    assert data == b'aaaab'
+    assert data == b"aaaab"
 
 
 @pytest.mark.anyio
 async def test_exec_clips_large_stdout(backend, session):
-    big = b'x' * (2 * 1024 * 1024)  # 2 MB, over the 1 MB cap
+    big = b"x" * (2 * 1024 * 1024)  # 2 MB, over the 1 MB cap
     proc = _FakeProcess(returncode=0, stdout=big)
     patcher, _ = _patch_exec(proc)
-    spec = BoxSpec(session_id='sess1', cmd='cat big')
+    spec = BoxSpec(session_id="sess1", cmd="cat big")
 
     with patcher:
         result = await backend.exec(session, spec)
 
-    assert 'clipped' in result.stdout
+    assert "clipped" in result.stdout
 
 
 # ── error formatting ──────────────────────────────────────────────────
 
 
 def test_format_cli_error_collapses_and_truncates(backend):
-    msg = backend._format_cli_error('  some   long\n\nerror  ')
-    assert msg == 'docker backend error: some long error'
+    msg = backend._format_cli_error("  some   long\n\nerror  ")
+    assert msg == "docker backend error: some long error"
 
-    long = 'e' * 400
+    long = "e" * 400
     truncated = backend._format_cli_error(long)
-    assert truncated.endswith('...')
-    assert len(truncated) <= len('docker backend error: ') + 300
+    assert truncated.endswith("...")
+    assert len(truncated) <= len("docker backend error: ") + 300
 
 
 # ── _CommandResult dataclass ──────────────────────────────────────────
 
 
 def test_command_result_defaults():
-    r = _CommandResult(return_code=0, stdout='out', stderr='err')
+    r = _CommandResult(return_code=0, stdout="out", stderr="err")
     assert r.timed_out is False

--- a/tests/box/test_backend_selection.py
+++ b/tests/box/test_backend_selection.py
@@ -15,7 +15,7 @@ from langbot_plugin.box.runtime import BoxRuntime
 
 @pytest.fixture
 def logger():
-    return logging.getLogger('test.runtime')
+    return logging.getLogger("test.runtime")
 
 
 class MockBackend(BaseSandboxBackend):
@@ -38,7 +38,7 @@ class MockBackend(BaseSandboxBackend):
         return BoxSessionInfo(
             session_id=spec.session_id,
             backend_name=self.name,
-            backend_session_id=f'{self.name}-{self.started_sessions}',
+            backend_session_id=f"{self.name}-{self.started_sessions}",
             image=spec.image,
             network=spec.network,
             host_path=spec.host_path,
@@ -66,21 +66,22 @@ class MockBackend(BaseSandboxBackend):
 
 # ── E2B backend creation ────────────────────────────────────────────────
 
+
 def test_e2b_backend_created_if_package_installed(logger):
     """E2B backend is created when package is installed."""
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger)
         # E2B backend exists (package installed)
         e2b_backend = runtime.backends[2]
         assert e2b_backend is not None
-        assert e2b_backend.name == 'e2b'
+        assert e2b_backend.name == "e2b"
 
 
 def test_e2b_backend_none_if_package_not_installed(logger):
     """E2B backend is None when package is not installed."""
     with (
-        mock.patch('os.getenv', return_value=''),
-        mock.patch.object(BoxRuntime, '_create_e2b_backend', return_value=None),
+        mock.patch("os.getenv", return_value=""),
+        mock.patch.object(BoxRuntime, "_create_e2b_backend", return_value=None),
     ):
         runtime = BoxRuntime(logger)
         # Third backend is None (package not installed)
@@ -92,7 +93,7 @@ def test_e2b_backend_none_if_package_not_installed(logger):
 
 def test_e2b_import_failure_returns_none(logger):
     """Import failure for e2b package returns None, not fatal."""
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         # _create_e2b_backend handles ImportError internally
         runtime = BoxRuntime(logger)
         # Should have Docker, nsjail, and E2B (if package installed) or None
@@ -102,33 +103,34 @@ def test_e2b_import_failure_returns_none(logger):
 
 # ── box.backend configuration ──────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_box_backend_config_forces_specific_backend(logger):
     """box.backend config forces selection of named backend."""
-    backend_e2b = MockBackend(logger, 'e2b', available=True)
-    backend_docker = MockBackend(logger, 'docker', available=True)
-    backend_nsjail = MockBackend(logger, 'nsjail', available=False)
+    backend_e2b = MockBackend(logger, "e2b", available=True)
+    backend_docker = MockBackend(logger, "docker", available=True)
+    backend_nsjail = MockBackend(logger, "nsjail", available=False)
 
     runtime = BoxRuntime(logger, backends=[backend_e2b, backend_docker, backend_nsjail])
-    runtime.init({'backend': 'docker'})
+    runtime.init({"backend": "docker"})
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
-    assert selected.name == 'docker'
+    assert selected.name == "docker"
     assert selected is backend_docker
 
 
 @pytest.mark.anyio
 async def test_box_backend_config_unavailable_returns_none(logger):
     """When box.backend specifies unavailable backend, returns None."""
-    backend_e2b = MockBackend(logger, 'e2b', available=False)
-    backend_docker = MockBackend(logger, 'docker', available=True)
+    backend_e2b = MockBackend(logger, "e2b", available=False)
+    backend_docker = MockBackend(logger, "docker", available=True)
 
     runtime = BoxRuntime(logger, backends=[backend_e2b, backend_docker])
-    runtime.init({'backend': 'e2b'})
+    runtime.init({"backend": "e2b"})
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
     assert selected is None
@@ -137,12 +139,12 @@ async def test_box_backend_config_unavailable_returns_none(logger):
 @pytest.mark.anyio
 async def test_box_backend_config_not_found_returns_none(logger):
     """When box.backend specifies unknown backend name, returns None."""
-    backend_docker = MockBackend(logger, 'docker', available=True)
+    backend_docker = MockBackend(logger, "docker", available=True)
 
     runtime = BoxRuntime(logger, backends=[backend_docker])
-    runtime.init({'backend': 'unknown'})
+    runtime.init({"backend": "unknown"})
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
     assert selected is None
@@ -151,13 +153,13 @@ async def test_box_backend_config_not_found_returns_none(logger):
 @pytest.mark.anyio
 async def test_box_backend_config_no_fallback(logger):
     """When box.backend is set but backend unavailable, does NOT fallback."""
-    backend_e2b = MockBackend(logger, 'e2b', available=False)
-    backend_docker = MockBackend(logger, 'docker', available=True)
+    backend_e2b = MockBackend(logger, "e2b", available=False)
+    backend_docker = MockBackend(logger, "docker", available=True)
 
     runtime = BoxRuntime(logger, backends=[backend_e2b, backend_docker])
-    runtime.init({'backend': 'e2b'})
+    runtime.init({"backend": "e2b"})
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
     # Should return None, not fallback to docker
@@ -167,13 +169,15 @@ async def test_box_backend_config_no_fallback(logger):
 @pytest.mark.anyio
 async def test_box_backend_env_var_is_ignored(logger):
     """BOX_BACKEND is not an independent override; use box.backend instead."""
-    backend_docker = MockBackend(logger, 'docker', available=True)
-    backend_e2b = MockBackend(logger, 'e2b', available=True)
+    backend_docker = MockBackend(logger, "docker", available=True)
+    backend_e2b = MockBackend(logger, "e2b", available=True)
 
     runtime = BoxRuntime(logger, backends=[backend_docker, backend_e2b])
-    runtime.init({'backend': 'docker'})
+    runtime.init({"backend": "docker"})
 
-    with mock.patch('os.getenv', side_effect=lambda k: 'e2b' if k == 'BOX_BACKEND' else None):
+    with mock.patch(
+        "os.getenv", side_effect=lambda k: "e2b" if k == "BOX_BACKEND" else None
+    ):
         selected = await runtime._select_backend()
 
     assert selected is backend_docker
@@ -181,30 +185,31 @@ async def test_box_backend_env_var_is_ignored(logger):
 
 # ── Auto-detect backend selection ───────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_auto_detect_first_available(logger):
     """Without box.backend, selects first available backend."""
-    backend_e2b = MockBackend(logger, 'e2b', available=False)
-    backend_docker = MockBackend(logger, 'docker', available=True)
-    backend_nsjail = MockBackend(logger, 'nsjail', available=False)
+    backend_e2b = MockBackend(logger, "e2b", available=False)
+    backend_docker = MockBackend(logger, "docker", available=True)
+    backend_nsjail = MockBackend(logger, "nsjail", available=False)
 
     runtime = BoxRuntime(logger, backends=[backend_e2b, backend_docker, backend_nsjail])
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
-    assert selected.name == 'docker'
+    assert selected.name == "docker"
 
 
 @pytest.mark.anyio
 async def test_auto_detect_none_when_all_unavailable(logger):
     """Returns None when all backends are unavailable."""
-    backend_docker = MockBackend(logger, 'docker', available=False)
-    backend_nsjail = MockBackend(logger, 'nsjail', available=False)
+    backend_docker = MockBackend(logger, "docker", available=False)
+    backend_nsjail = MockBackend(logger, "nsjail", available=False)
 
     runtime = BoxRuntime(logger, backends=[backend_docker, backend_nsjail])
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
     assert selected is None
@@ -213,16 +218,16 @@ async def test_auto_detect_none_when_all_unavailable(logger):
 @pytest.mark.anyio
 async def test_init_config_reselects_backend_before_sessions(logger):
     """INIT config from LangBot can change the selected backend."""
-    backend_docker = MockBackend(logger, 'docker', available=True)
-    backend_e2b = MockBackend(logger, 'e2b', available=True)
+    backend_docker = MockBackend(logger, "docker", available=True)
+    backend_e2b = MockBackend(logger, "e2b", available=True)
 
     runtime = BoxRuntime(logger, backends=[backend_docker, backend_e2b])
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         await runtime.initialize()
         assert runtime._backend is backend_docker
 
-        runtime.init({'backend': 'e2b'})
+        runtime.init({"backend": "e2b"})
         assert runtime._backend is None
 
         selected = await runtime._get_backend()
@@ -233,43 +238,46 @@ async def test_init_config_reselects_backend_before_sessions(logger):
 @pytest.mark.anyio
 async def test_create_session_recreates_disappeared_backend_session(logger):
     """A stale in-memory session is dropped if its backend session vanished."""
-    backend = MockBackend(logger, 'docker', available=True)
+    backend = MockBackend(logger, "docker", available=True)
     runtime = BoxRuntime(logger, backends=[backend])
-    spec = BoxSpec(session_id='mcp-shared', cmd='true', persistent=True, read_only_rootfs=False)
+    spec = BoxSpec(
+        session_id="mcp-shared", cmd="true", persistent=True, read_only_rootfs=False
+    )
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         first = await runtime.create_session(spec)
         backend._alive = False
         second = await runtime.create_session(spec)
 
-    assert first['backend_session_id'] == 'docker-1'
-    assert second['backend_session_id'] == 'docker-2'
+    assert first["backend_session_id"] == "docker-1"
+    assert second["backend_session_id"] == "docker-2"
     assert backend.started_sessions == 2
     assert backend.stopped_sessions == 1
 
 
 # ── Custom backends list ────────────────────────────────────────────────
 
+
 def test_custom_backends_list_preserved(logger):
     """Providing custom backends list overrides auto-detection."""
-    custom_backend = MockBackend(logger, 'custom', available=True)
+    custom_backend = MockBackend(logger, "custom", available=True)
 
     runtime = BoxRuntime(logger, backends=[custom_backend])
 
     assert len(runtime.backends) == 1
-    assert runtime.backends[0].name == 'custom'
+    assert runtime.backends[0].name == "custom"
 
 
 @pytest.mark.anyio
 async def test_custom_backends_with_box_backend_config(logger):
     """box.backend works with custom backends list."""
-    backend_a = MockBackend(logger, 'a', available=True)
-    backend_b = MockBackend(logger, 'b', available=True)
+    backend_a = MockBackend(logger, "a", available=True)
+    backend_b = MockBackend(logger, "b", available=True)
 
     runtime = BoxRuntime(logger, backends=[backend_a, backend_b])
-    runtime.init({'backend': 'b'})
+    runtime.init({"backend": "b"})
 
-    with mock.patch('os.getenv', return_value=None):
+    with mock.patch("os.getenv", return_value=None):
         selected = await runtime._select_backend()
 
-    assert selected.name == 'b'
+    assert selected.name == "b"

--- a/tests/box/test_client.py
+++ b/tests/box/test_client.py
@@ -41,7 +41,7 @@ from langbot_plugin.box.models import (
 
 @pytest.fixture
 def logger():
-    return logging.getLogger('test.box.client')
+    return logging.getLogger("test.box.client")
 
 
 @pytest.fixture
@@ -49,7 +49,7 @@ def handler():
     """A mocked Handler whose async call_action / send_file we control per-test."""
     h = mock.MagicMock()
     h.call_action = mock.AsyncMock()
-    h.send_file = mock.AsyncMock(return_value='file-key-abc')
+    h.send_file = mock.AsyncMock(return_value="file-key-abc")
     return h
 
 
@@ -62,15 +62,15 @@ def client(logger, handler):
 
 def _managed_process_payload(**overrides) -> dict:
     payload = {
-        'session_id': 'sess-1',
-        'process_id': 'default',
-        'status': 'running',
-        'command': 'python',
-        'args': ['app.py'],
-        'cwd': '/workspace',
-        'env_keys': ['FOO'],
-        'attached': False,
-        'started_at': '2024-01-01T00:00:00+00:00',
+        "session_id": "sess-1",
+        "process_id": "default",
+        "status": "running",
+        "command": "python",
+        "args": ["app.py"],
+        "cwd": "/workspace",
+        "env_keys": ["FOO"],
+        "attached": False,
+        "started_at": "2024-01-01T00:00:00+00:00",
     }
     payload.update(overrides)
     return payload
@@ -95,32 +95,32 @@ def test_set_handler_makes_property_accessible(logger, handler):
 
 
 @pytest.mark.parametrize(
-    ('prefix', 'expected'),
+    ("prefix", "expected"),
     [
-        ('BoxValidationError:', BoxValidationError),
-        ('BoxSessionNotFoundError:', BoxSessionNotFoundError),
-        ('BoxSessionConflictError:', BoxSessionConflictError),
-        ('BoxManagedProcessNotFoundError:', BoxManagedProcessNotFoundError),
-        ('BoxManagedProcessConflictError:', BoxManagedProcessConflictError),
-        ('BoxBackendUnavailableError:', BoxBackendUnavailableError),
+        ("BoxValidationError:", BoxValidationError),
+        ("BoxSessionNotFoundError:", BoxSessionNotFoundError),
+        ("BoxSessionConflictError:", BoxSessionConflictError),
+        ("BoxManagedProcessNotFoundError:", BoxManagedProcessNotFoundError),
+        ("BoxManagedProcessConflictError:", BoxManagedProcessConflictError),
+        ("BoxBackendUnavailableError:", BoxBackendUnavailableError),
     ],
 )
 def test_translate_action_error_maps_known_prefixes(prefix, expected):
-    err = _translate_action_error(Exception(f'{prefix} something went wrong'))
+    err = _translate_action_error(Exception(f"{prefix} something went wrong"))
     assert type(err) is expected
-    assert 'something went wrong' in str(err)
+    assert "something went wrong" in str(err)
 
 
 def test_translate_action_error_falls_back_to_base():
-    err = _translate_action_error(Exception('totally unknown failure'))
+    err = _translate_action_error(Exception("totally unknown failure"))
     assert type(err) is BoxError
-    assert 'totally unknown failure' in str(err)
+    assert "totally unknown failure" in str(err)
 
 
 def test_translate_action_error_matches_prefix_anywhere_in_message():
     # The implementation uses substring containment, not str.startswith.
     err = _translate_action_error(
-        Exception('ActionCallError: BoxSessionNotFoundError: no such session')
+        Exception("ActionCallError: BoxSessionNotFoundError: no such session")
     )
     assert type(err) is BoxSessionNotFoundError
 
@@ -139,17 +139,15 @@ async def test_call_unavailable_propagates_when_no_handler(logger):
 
 @pytest.mark.anyio
 async def test_call_translates_arbitrary_exception(client, handler):
-    handler.call_action.side_effect = RuntimeError(
-        'BoxValidationError: bad spec'
-    )
+    handler.call_action.side_effect = RuntimeError("BoxValidationError: bad spec")
     with pytest.raises(BoxValidationError) as exc_info:
         await client.get_status()
-    assert 'bad spec' in str(exc_info.value)
+    assert "bad spec" in str(exc_info.value)
 
 
 @pytest.mark.anyio
 async def test_call_translates_unknown_to_base_box_error(client, handler):
-    handler.call_action.side_effect = RuntimeError('connection reset')
+    handler.call_action.side_effect = RuntimeError("connection reset")
     with pytest.raises(BoxError) as exc_info:
         await client.get_status()
     assert type(exc_info.value) is BoxError
@@ -157,13 +155,13 @@ async def test_call_translates_unknown_to_base_box_error(client, handler):
 
 @pytest.mark.anyio
 async def test_call_passes_action_data_and_default_timeout(client, handler):
-    handler.call_action.return_value = {'ok': True}
+    handler.call_action.return_value = {"ok": True}
     await client.get_status()
     handler.call_action.assert_awaited_once()
     args, kwargs = handler.call_action.call_args
     assert args[0] is LangBotToBoxAction.STATUS
     assert args[1] == {}
-    assert kwargs['timeout'] == 15.0
+    assert kwargs["timeout"] == 15.0
 
 
 # ── initialize ────────────────────────────────────────────────────────
@@ -179,10 +177,10 @@ async def test_initialize_sends_health(client, handler):
 
 @pytest.mark.anyio
 async def test_initialize_wraps_failure_in_unavailable(client, handler):
-    handler.call_action.side_effect = RuntimeError('boom')
+    handler.call_action.side_effect = RuntimeError("boom")
     with pytest.raises(BoxRuntimeUnavailableError) as exc_info:
         await client.initialize()
-    assert 'box runtime unavailable' in str(exc_info.value)
+    assert "box runtime unavailable" in str(exc_info.value)
 
 
 # ── execute ───────────────────────────────────────────────────────────
@@ -191,60 +189,60 @@ async def test_initialize_wraps_failure_in_unavailable(client, handler):
 @pytest.mark.anyio
 async def test_execute_sends_spec_and_parses_result(client, handler):
     handler.call_action.return_value = {
-        'session_id': 'sess-9',
-        'backend_name': 'nsjail',
-        'status': 'completed',
-        'exit_code': 0,
-        'stdout': 'hi\n',
-        'stderr': '',
-        'duration_ms': 42,
+        "session_id": "sess-9",
+        "backend_name": "nsjail",
+        "status": "completed",
+        "exit_code": 0,
+        "stdout": "hi\n",
+        "stderr": "",
+        "duration_ms": 42,
     }
-    spec = BoxSpec(session_id='sess-9', cmd='echo hi')
+    spec = BoxSpec(session_id="sess-9", cmd="echo hi")
 
     result = await client.execute(spec)
 
     assert isinstance(result, BoxExecutionResult)
-    assert result.session_id == 'sess-9'
-    assert result.backend_name == 'nsjail'
+    assert result.session_id == "sess-9"
+    assert result.backend_name == "nsjail"
     assert result.status is BoxExecutionStatus.COMPLETED
     assert result.exit_code == 0
-    assert result.stdout == 'hi\n'
+    assert result.stdout == "hi\n"
     assert result.duration_ms == 42
     assert result.ok is True
 
     # Verify the EXEC action, json-serialized spec payload, and 300s timeout.
     args, kwargs = handler.call_action.call_args
     assert args[0] is LangBotToBoxAction.EXEC
-    assert args[1] == spec.model_dump(mode='json')
-    assert kwargs['timeout'] == 300.0
+    assert args[1] == spec.model_dump(mode="json")
+    assert kwargs["timeout"] == 300.0
 
 
 @pytest.mark.anyio
 async def test_execute_timed_out_result(client, handler):
     handler.call_action.return_value = {
-        'session_id': 'sess-t',
-        'backend_name': 'e2b',
-        'status': 'timed_out',
-        'exit_code': None,
-        'stderr': 'timed out',
-        'duration_ms': 30000,
+        "session_id": "sess-t",
+        "backend_name": "e2b",
+        "status": "timed_out",
+        "exit_code": None,
+        "stderr": "timed out",
+        "duration_ms": 30000,
     }
-    spec = BoxSpec(session_id='sess-t', cmd='sleep 100')
+    spec = BoxSpec(session_id="sess-t", cmd="sleep 100")
 
     result = await client.execute(spec)
 
     assert result.status is BoxExecutionStatus.TIMED_OUT
     assert result.exit_code is None
-    assert result.stdout == ''  # default applied when key absent
+    assert result.stdout == ""  # default applied when key absent
     assert result.ok is False
 
 
 @pytest.mark.anyio
 async def test_execute_propagates_translated_error(client, handler):
     handler.call_action.side_effect = RuntimeError(
-        'BoxBackendUnavailableError: no backend'
+        "BoxBackendUnavailableError: no backend"
     )
-    spec = BoxSpec(session_id='sess-x', cmd='ls')
+    spec = BoxSpec(session_id="sess-x", cmd="ls")
     with pytest.raises(BoxBackendUnavailableError):
         await client.execute(spec)
 
@@ -264,7 +262,7 @@ async def test_shutdown_sends_action_and_clears_handler(client, handler):
 
 @pytest.mark.anyio
 async def test_shutdown_swallows_errors(client, handler):
-    handler.call_action.side_effect = RuntimeError('already dead')
+    handler.call_action.side_effect = RuntimeError("already dead")
     # Should not raise even though the underlying call fails.
     await client.shutdown()
     with pytest.raises(BoxRuntimeUnavailableError):
@@ -283,21 +281,18 @@ async def test_shutdown_noop_without_handler(logger):
 
 @pytest.mark.anyio
 async def test_get_status_returns_raw_dict(client, handler):
-    handler.call_action.return_value = {'healthy': True, 'sessions': 3}
+    handler.call_action.return_value = {"healthy": True, "sessions": 3}
     result = await client.get_status()
-    assert result == {'healthy': True, 'sessions': 3}
+    assert result == {"healthy": True, "sessions": 3}
     assert handler.call_action.call_args.args[0] is LangBotToBoxAction.STATUS
 
 
 @pytest.mark.anyio
 async def test_get_backend_info_returns_raw_dict(client, handler):
-    handler.call_action.return_value = {'name': 'nsjail', 'available': True}
+    handler.call_action.return_value = {"name": "nsjail", "available": True}
     result = await client.get_backend_info()
-    assert result == {'name': 'nsjail', 'available': True}
-    assert (
-        handler.call_action.call_args.args[0]
-        is LangBotToBoxAction.GET_BACKEND_INFO
-    )
+    assert result == {"name": "nsjail", "available": True}
+    assert handler.call_action.call_args.args[0] is LangBotToBoxAction.GET_BACKEND_INFO
 
 
 # ── sessions ──────────────────────────────────────────────────────────
@@ -305,50 +300,53 @@ async def test_get_backend_info_returns_raw_dict(client, handler):
 
 @pytest.mark.anyio
 async def test_get_sessions_unwraps_list(client, handler):
-    handler.call_action.return_value = {'sessions': [{'session_id': 'a'}, {'session_id': 'b'}]}
+    handler.call_action.return_value = {
+        "sessions": [{"session_id": "a"}, {"session_id": "b"}]
+    }
     sessions = await client.get_sessions()
-    assert sessions == [{'session_id': 'a'}, {'session_id': 'b'}]
+    assert sessions == [{"session_id": "a"}, {"session_id": "b"}]
     assert handler.call_action.call_args.args[0] is LangBotToBoxAction.GET_SESSIONS
 
 
 @pytest.mark.anyio
 async def test_get_session_sends_session_id(client, handler):
-    handler.call_action.return_value = {'session_id': 'sess-5', 'backend_name': 'e2b'}
-    result = await client.get_session('sess-5')
-    assert result == {'session_id': 'sess-5', 'backend_name': 'e2b'}
+    handler.call_action.return_value = {"session_id": "sess-5", "backend_name": "e2b"}
+    result = await client.get_session("sess-5")
+    assert result == {"session_id": "sess-5", "backend_name": "e2b"}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.GET_SESSION
-    assert args[1] == {'session_id': 'sess-5'}
+    assert args[1] == {"session_id": "sess-5"}
 
 
 @pytest.mark.anyio
 async def test_create_session_sends_spec(client, handler):
-    handler.call_action.return_value = {'session_id': 'new-sess', 'backend_name': 'nsjail'}
-    spec = BoxSpec(session_id='new-sess', cmd='', network=BoxNetworkMode.ON)
+    handler.call_action.return_value = {
+        "session_id": "new-sess",
+        "backend_name": "nsjail",
+    }
+    spec = BoxSpec(session_id="new-sess", cmd="", network=BoxNetworkMode.ON)
     result = await client.create_session(spec)
-    assert result == {'session_id': 'new-sess', 'backend_name': 'nsjail'}
+    assert result == {"session_id": "new-sess", "backend_name": "nsjail"}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.CREATE_SESSION
-    assert args[1] == spec.model_dump(mode='json')
+    assert args[1] == spec.model_dump(mode="json")
 
 
 @pytest.mark.anyio
 async def test_delete_session_sends_id_with_timeout(client, handler):
     handler.call_action.return_value = {}
-    await client.delete_session('sess-del')
+    await client.delete_session("sess-del")
     args, kwargs = handler.call_action.call_args
     assert args[0] is LangBotToBoxAction.DELETE_SESSION
-    assert args[1] == {'session_id': 'sess-del'}
-    assert kwargs['timeout'] == 30.0
+    assert args[1] == {"session_id": "sess-del"}
+    assert kwargs["timeout"] == 30.0
 
 
 @pytest.mark.anyio
 async def test_delete_session_translates_not_found(client, handler):
-    handler.call_action.side_effect = RuntimeError(
-        'BoxSessionNotFoundError: missing'
-    )
+    handler.call_action.side_effect = RuntimeError("BoxSessionNotFoundError: missing")
     with pytest.raises(BoxSessionNotFoundError):
-        await client.delete_session('nope')
+        await client.delete_session("nope")
 
 
 # ── managed processes ─────────────────────────────────────────────────
@@ -357,85 +355,87 @@ async def test_delete_session_translates_not_found(client, handler):
 @pytest.mark.anyio
 async def test_start_managed_process_parses_info(client, handler):
     handler.call_action.return_value = _managed_process_payload()
-    spec = BoxManagedProcessSpec(command='python', args=['app.py'])
+    spec = BoxManagedProcessSpec(command="python", args=["app.py"])
 
-    info = await client.start_managed_process('sess-1', spec)
+    info = await client.start_managed_process("sess-1", spec)
 
     assert isinstance(info, BoxManagedProcessInfo)
-    assert info.session_id == 'sess-1'
-    assert info.process_id == 'default'
+    assert info.session_id == "sess-1"
+    assert info.process_id == "default"
     assert info.status is BoxManagedProcessStatus.RUNNING
-    assert info.command == 'python'
-    assert info.args == ['app.py']
+    assert info.command == "python"
+    assert info.args == ["app.py"]
 
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.START_MANAGED_PROCESS
     assert args[1] == {
-        'session_id': 'sess-1',
-        'spec': spec.model_dump(mode='json'),
+        "session_id": "sess-1",
+        "spec": spec.model_dump(mode="json"),
     }
 
 
 @pytest.mark.anyio
 async def test_start_managed_process_conflict_error(client, handler):
     handler.call_action.side_effect = RuntimeError(
-        'BoxManagedProcessConflictError: already running'
+        "BoxManagedProcessConflictError: already running"
     )
-    spec = BoxManagedProcessSpec(command='python')
+    spec = BoxManagedProcessSpec(command="python")
     with pytest.raises(BoxManagedProcessConflictError):
-        await client.start_managed_process('sess-1', spec)
+        await client.start_managed_process("sess-1", spec)
 
 
 @pytest.mark.anyio
 async def test_get_managed_process_default_and_explicit_id(client, handler):
     handler.call_action.return_value = _managed_process_payload(
-        process_id='worker', status='exited', exit_code=0,
-        exited_at='2024-01-01T00:05:00+00:00',
+        process_id="worker",
+        status="exited",
+        exit_code=0,
+        exited_at="2024-01-01T00:05:00+00:00",
     )
 
-    info = await client.get_managed_process('sess-1', 'worker')
+    info = await client.get_managed_process("sess-1", "worker")
 
     assert isinstance(info, BoxManagedProcessInfo)
-    assert info.process_id == 'worker'
+    assert info.process_id == "worker"
     assert info.status is BoxManagedProcessStatus.EXITED
     assert info.exit_code == 0
 
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.GET_MANAGED_PROCESS
-    assert args[1] == {'session_id': 'sess-1', 'process_id': 'worker'}
+    assert args[1] == {"session_id": "sess-1", "process_id": "worker"}
 
 
 @pytest.mark.anyio
 async def test_get_managed_process_uses_default_process_id(client, handler):
     handler.call_action.return_value = _managed_process_payload()
-    await client.get_managed_process('sess-1')
-    assert handler.call_action.call_args.args[1]['process_id'] == 'default'
+    await client.get_managed_process("sess-1")
+    assert handler.call_action.call_args.args[1]["process_id"] == "default"
 
 
 @pytest.mark.anyio
 async def test_get_managed_process_not_found(client, handler):
     handler.call_action.side_effect = RuntimeError(
-        'BoxManagedProcessNotFoundError: gone'
+        "BoxManagedProcessNotFoundError: gone"
     )
     with pytest.raises(BoxManagedProcessNotFoundError):
-        await client.get_managed_process('sess-1', 'ghost')
+        await client.get_managed_process("sess-1", "ghost")
 
 
 @pytest.mark.anyio
 async def test_stop_managed_process_sends_payload_with_timeout(client, handler):
     handler.call_action.return_value = {}
-    await client.stop_managed_process('sess-1', 'worker')
+    await client.stop_managed_process("sess-1", "worker")
     args, kwargs = handler.call_action.call_args
     assert args[0] is LangBotToBoxAction.STOP_MANAGED_PROCESS
-    assert args[1] == {'session_id': 'sess-1', 'process_id': 'worker'}
-    assert kwargs['timeout'] == 30.0
+    assert args[1] == {"session_id": "sess-1", "process_id": "worker"}
+    assert kwargs["timeout"] == 30.0
 
 
 @pytest.mark.anyio
 async def test_stop_managed_process_default_id(client, handler):
     handler.call_action.return_value = {}
-    await client.stop_managed_process('sess-1')
-    assert handler.call_action.call_args.args[1]['process_id'] == 'default'
+    await client.stop_managed_process("sess-1")
+    assert handler.call_action.call_args.args[1]["process_id"] == "default"
 
 
 # ── websocket url builder ─────────────────────────────────────────────
@@ -443,27 +443,25 @@ async def test_stop_managed_process_default_id(client, handler):
 
 def test_ws_url_from_https(client):
     url = client.get_managed_process_websocket_url(
-        'sess-1', 'https://relay.example.com'
+        "sess-1", "https://relay.example.com"
     )
     assert url == (
-        'wss://relay.example.com/v1/sessions/sess-1/managed-process/default/ws'
+        "wss://relay.example.com/v1/sessions/sess-1/managed-process/default/ws"
     )
 
 
 def test_ws_url_from_http(client):
     url = client.get_managed_process_websocket_url(
-        'sess-1', 'http://relay.example.com', process_id='worker'
+        "sess-1", "http://relay.example.com", process_id="worker"
     )
     assert url == (
-        'ws://relay.example.com/v1/sessions/sess-1/managed-process/worker/ws'
+        "ws://relay.example.com/v1/sessions/sess-1/managed-process/worker/ws"
     )
 
 
 def test_ws_url_from_bare_host(client):
-    url = client.get_managed_process_websocket_url('sess-1', 'relay:8080')
-    assert url == (
-        'ws://relay:8080/v1/sessions/sess-1/managed-process/default/ws'
-    )
+    url = client.get_managed_process_websocket_url("sess-1", "relay:8080")
+    assert url == ("ws://relay:8080/v1/sessions/sess-1/managed-process/default/ws")
 
 
 # ── init ──────────────────────────────────────────────────────────────
@@ -472,10 +470,10 @@ def test_ws_url_from_bare_host(client):
 @pytest.mark.anyio
 async def test_init_sends_config(client, handler):
     handler.call_action.return_value = {}
-    await client.init({'backend': 'nsjail', 'foo': 1})
+    await client.init({"backend": "nsjail", "foo": 1})
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.INIT
-    assert args[1] == {'backend': 'nsjail', 'foo': 1}
+    assert args[1] == {"backend": "nsjail", "foo": 1}
 
 
 # ── skills ────────────────────────────────────────────────────────────
@@ -483,115 +481,115 @@ async def test_init_sends_config(client, handler):
 
 @pytest.mark.anyio
 async def test_list_skills_unwraps(client, handler):
-    handler.call_action.return_value = {'skills': [{'name': 's1'}, {'name': 's2'}]}
+    handler.call_action.return_value = {"skills": [{"name": "s1"}, {"name": "s2"}]}
     skills = await client.list_skills()
-    assert skills == [{'name': 's1'}, {'name': 's2'}]
+    assert skills == [{"name": "s1"}, {"name": "s2"}]
     assert handler.call_action.call_args.args[0] is LangBotToBoxAction.LIST_SKILLS
 
 
 @pytest.mark.anyio
 async def test_get_skill_returns_inner(client, handler):
-    handler.call_action.return_value = {'skill': {'name': 'demo'}}
-    result = await client.get_skill('demo')
-    assert result == {'name': 'demo'}
+    handler.call_action.return_value = {"skill": {"name": "demo"}}
+    result = await client.get_skill("demo")
+    assert result == {"name": "demo"}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.GET_SKILL
-    assert args[1] == {'name': 'demo'}
+    assert args[1] == {"name": "demo"}
 
 
 @pytest.mark.anyio
 async def test_get_skill_returns_none_when_absent(client, handler):
     handler.call_action.return_value = {}
-    result = await client.get_skill('missing')
+    result = await client.get_skill("missing")
     assert result is None
 
 
 @pytest.mark.anyio
 async def test_create_skill_sends_and_unwraps(client, handler):
-    handler.call_action.return_value = {'skill': {'name': 'created'}}
-    result = await client.create_skill({'name': 'created'})
-    assert result == {'name': 'created'}
+    handler.call_action.return_value = {"skill": {"name": "created"}}
+    result = await client.create_skill({"name": "created"})
+    assert result == {"name": "created"}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.CREATE_SKILL
-    assert args[1] == {'skill': {'name': 'created'}}
+    assert args[1] == {"skill": {"name": "created"}}
 
 
 @pytest.mark.anyio
 async def test_update_skill_sends_name_and_skill(client, handler):
-    handler.call_action.return_value = {'skill': {'name': 'demo', 'v': 2}}
-    result = await client.update_skill('demo', {'v': 2})
-    assert result == {'name': 'demo', 'v': 2}
+    handler.call_action.return_value = {"skill": {"name": "demo", "v": 2}}
+    result = await client.update_skill("demo", {"v": 2})
+    assert result == {"name": "demo", "v": 2}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.UPDATE_SKILL
-    assert args[1] == {'name': 'demo', 'skill': {'v': 2}}
+    assert args[1] == {"name": "demo", "skill": {"v": 2}}
 
 
 @pytest.mark.anyio
 async def test_delete_skill_sends_name(client, handler):
     handler.call_action.return_value = {}
-    await client.delete_skill('demo')
+    await client.delete_skill("demo")
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.DELETE_SKILL
-    assert args[1] == {'name': 'demo'}
+    assert args[1] == {"name": "demo"}
 
 
 @pytest.mark.anyio
 async def test_scan_skill_directory(client, handler):
-    handler.call_action.return_value = {'found': 2}
-    result = await client.scan_skill_directory('/skills')
-    assert result == {'found': 2}
+    handler.call_action.return_value = {"found": 2}
+    result = await client.scan_skill_directory("/skills")
+    assert result == {"found": 2}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.SCAN_SKILL_DIRECTORY
-    assert args[1] == {'path': '/skills'}
+    assert args[1] == {"path": "/skills"}
 
 
 @pytest.mark.anyio
 async def test_list_skill_files_defaults(client, handler):
-    handler.call_action.return_value = {'entries': []}
-    result = await client.list_skill_files('demo')
-    assert result == {'entries': []}
+    handler.call_action.return_value = {"entries": []}
+    result = await client.list_skill_files("demo")
+    assert result == {"entries": []}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.LIST_SKILL_FILES
     assert args[1] == {
-        'name': 'demo',
-        'path': '.',
-        'include_hidden': False,
-        'max_entries': 200,
+        "name": "demo",
+        "path": ".",
+        "include_hidden": False,
+        "max_entries": 200,
     }
 
 
 @pytest.mark.anyio
 async def test_list_skill_files_custom_args(client, handler):
-    handler.call_action.return_value = {'entries': ['a']}
+    handler.call_action.return_value = {"entries": ["a"]}
     await client.list_skill_files(
-        'demo', path='sub', include_hidden=True, max_entries=10
+        "demo", path="sub", include_hidden=True, max_entries=10
     )
     assert handler.call_action.call_args.args[1] == {
-        'name': 'demo',
-        'path': 'sub',
-        'include_hidden': True,
-        'max_entries': 10,
+        "name": "demo",
+        "path": "sub",
+        "include_hidden": True,
+        "max_entries": 10,
     }
 
 
 @pytest.mark.anyio
 async def test_read_skill_file(client, handler):
-    handler.call_action.return_value = {'content': 'hello'}
-    result = await client.read_skill_file('demo', 'README.md')
-    assert result == {'content': 'hello'}
+    handler.call_action.return_value = {"content": "hello"}
+    result = await client.read_skill_file("demo", "README.md")
+    assert result == {"content": "hello"}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.READ_SKILL_FILE
-    assert args[1] == {'name': 'demo', 'path': 'README.md'}
+    assert args[1] == {"name": "demo", "path": "README.md"}
 
 
 @pytest.mark.anyio
 async def test_write_skill_file(client, handler):
-    handler.call_action.return_value = {'ok': True}
-    result = await client.write_skill_file('demo', 'a.txt', 'body')
-    assert result == {'ok': True}
+    handler.call_action.return_value = {"ok": True}
+    result = await client.write_skill_file("demo", "a.txt", "body")
+    assert result == {"ok": True}
     args = handler.call_action.call_args.args
     assert args[0] is LangBotToBoxAction.WRITE_SKILL_FILE
-    assert args[1] == {'name': 'demo', 'path': 'a.txt', 'content': 'body'}
+    assert args[1] == {"name": "demo", "path": "a.txt", "content": "body"}
 
 
 # ── skill zip upload (send_file + action) ─────────────────────────────
@@ -599,60 +597,60 @@ async def test_write_skill_file(client, handler):
 
 @pytest.mark.anyio
 async def test_preview_skill_zip_sends_file_then_action(client, handler):
-    handler.call_action.return_value = {'skills': [{'name': 'preview'}]}
-    result = await client.preview_skill_zip(b'zipbytes', 'pack.zip')
+    handler.call_action.return_value = {"skills": [{"name": "preview"}]}
+    result = await client.preview_skill_zip(b"zipbytes", "pack.zip")
 
-    assert result == [{'name': 'preview'}]
-    handler.send_file.assert_awaited_once_with(b'zipbytes', 'zip')
+    assert result == [{"name": "preview"}]
+    handler.send_file.assert_awaited_once_with(b"zipbytes", "zip")
 
     args, kwargs = handler.call_action.call_args
     assert args[0] is LangBotToBoxAction.PREVIEW_SKILL_ZIP
     assert args[1] == {
-        'file_key': 'file-key-abc',
-        'filename': 'pack.zip',
-        'source_subdir': '',
-        'target_suffix': 'upload',
+        "file_key": "file-key-abc",
+        "filename": "pack.zip",
+        "source_subdir": "",
+        "target_suffix": "upload",
     }
-    assert kwargs['timeout'] == 60.0
+    assert kwargs["timeout"] == 60.0
 
 
 @pytest.mark.anyio
 async def test_install_skill_zip_default_source_paths(client, handler):
-    handler.call_action.return_value = {'skills': [{'name': 'installed'}]}
-    result = await client.install_skill_zip(b'zipbytes', 'pack.zip')
+    handler.call_action.return_value = {"skills": [{"name": "installed"}]}
+    result = await client.install_skill_zip(b"zipbytes", "pack.zip")
 
-    assert result == [{'name': 'installed'}]
-    handler.send_file.assert_awaited_once_with(b'zipbytes', 'zip')
+    assert result == [{"name": "installed"}]
+    handler.send_file.assert_awaited_once_with(b"zipbytes", "zip")
 
     args, kwargs = handler.call_action.call_args
     assert args[0] is LangBotToBoxAction.INSTALL_SKILL_ZIP
     assert args[1] == {
-        'file_key': 'file-key-abc',
-        'filename': 'pack.zip',
-        'source_paths': [],
-        'source_path': '',
-        'source_subdir': '',
-        'target_suffix': 'upload',
+        "file_key": "file-key-abc",
+        "filename": "pack.zip",
+        "source_paths": [],
+        "source_path": "",
+        "source_subdir": "",
+        "target_suffix": "upload",
     }
-    assert kwargs['timeout'] == 120.0
+    assert kwargs["timeout"] == 120.0
 
 
 @pytest.mark.anyio
 async def test_install_skill_zip_with_source_paths(client, handler):
-    handler.call_action.return_value = {'skills': []}
+    handler.call_action.return_value = {"skills": []}
     await client.install_skill_zip(
-        b'zipbytes',
-        'pack.zip',
-        source_paths=['a', 'b'],
-        source_path='root',
-        source_subdir='sub',
-        target_suffix='custom',
+        b"zipbytes",
+        "pack.zip",
+        source_paths=["a", "b"],
+        source_path="root",
+        source_subdir="sub",
+        target_suffix="custom",
     )
     assert handler.call_action.call_args.args[1] == {
-        'file_key': 'file-key-abc',
-        'filename': 'pack.zip',
-        'source_paths': ['a', 'b'],
-        'source_path': 'root',
-        'source_subdir': 'sub',
-        'target_suffix': 'custom',
+        "file_key": "file-key-abc",
+        "filename": "pack.zip",
+        "source_paths": ["a", "b"],
+        "source_path": "root",
+        "source_subdir": "sub",
+        "target_suffix": "custom",
     }

--- a/tests/box/test_e2b_backend.py
+++ b/tests/box/test_e2b_backend.py
@@ -28,13 +28,13 @@ from langbot_plugin.box.models import (
 
 @pytest.fixture
 def logger():
-    return logging.getLogger('test.e2b')
+    return logging.getLogger("test.e2b")
 
 
 @pytest.fixture
 def backend(logger):
     b = E2BSandboxBackend(logger=logger)
-    b.instance_id = 'test123'
+    b.instance_id = "test123"
     return b
 
 
@@ -42,7 +42,7 @@ def backend(logger):
 def mock_e2b_module():
     """Mock the e2b module for tests."""
     mock_async_sandbox = mock.MagicMock()
-    mock_async_sandbox.sandbox_id = 'sandbox-test-123'
+    mock_async_sandbox.sandbox_id = "sandbox-test-123"
 
     # Mock AsyncSandbox.create
     mock_async_sandbox.create = mock.AsyncMock(return_value=mock_async_sandbox)
@@ -55,8 +55,8 @@ def mock_e2b_module():
 
     # Mock commands.run result
     mock_command_result = mock.MagicMock()
-    mock_command_result.stdout = 'output'
-    mock_command_result.stderr = ''
+    mock_command_result.stdout = "output"
+    mock_command_result.stderr = ""
     mock_command_result.exit_code = 0
 
     mock_commands = mock.MagicMock()
@@ -65,12 +65,13 @@ def mock_e2b_module():
 
     # Mock the module import
     with (
-        mock.patch('langbot_plugin.box.e2b_backend._e2b_available', None),
-        mock.patch('langbot_plugin.box.e2b_backend._AsyncSandbox', None),
-        mock.patch('langbot_plugin.box.e2b_backend._CommandResult', None),
+        mock.patch("langbot_plugin.box.e2b_backend._e2b_available", None),
+        mock.patch("langbot_plugin.box.e2b_backend._AsyncSandbox", None),
+        mock.patch("langbot_plugin.box.e2b_backend._CommandResult", None),
     ):
         # Simulate successful import
         import langbot_plugin.box.e2b_backend as e2b_backend
+
         e2b_backend._e2b_available = True
         e2b_backend._AsyncSandbox = mock_async_sandbox
         yield mock_async_sandbox
@@ -78,25 +79,29 @@ def mock_e2b_module():
 
 # ── Path adaptation ────────────────────────────────────────────────────
 
+
 def test_adapt_path_workspace():
     """_adapt_path_for_e2b maps /workspace to /home/user/workspace."""
-    assert _adapt_path_for_e2b('/workspace') == '/home/user/workspace'
-    assert _adapt_path_for_e2b('/workspace/subdir') == '/home/user/workspace/subdir'
+    assert _adapt_path_for_e2b("/workspace") == "/home/user/workspace"
+    assert _adapt_path_for_e2b("/workspace/subdir") == "/home/user/workspace/subdir"
 
 
 def test_adapt_path_other_paths_unchanged():
     """_adapt_path_for_e2b doesn't modify paths not starting with /workspace."""
-    assert _adapt_path_for_e2b('/home/user') == '/home/user'
-    assert _adapt_path_for_e2b('/tmp') == '/tmp'
-    assert _adapt_path_for_e2b('/code') == '/code'
+    assert _adapt_path_for_e2b("/home/user") == "/home/user"
+    assert _adapt_path_for_e2b("/tmp") == "/tmp"
+    assert _adapt_path_for_e2b("/code") == "/code"
 
 
 # ── is_available ──────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_is_available_no_package(backend):
     """is_available returns False when e2b package is not installed."""
-    with mock.patch('langbot_plugin.box.e2b_backend._check_e2b_available', return_value=False):
+    with mock.patch(
+        "langbot_plugin.box.e2b_backend._check_e2b_available", return_value=False
+    ):
         assert await backend.is_available() is False
 
 
@@ -104,240 +109,260 @@ async def test_is_available_no_package(backend):
 async def test_is_available_no_api_key(backend):
     """is_available returns False when E2B_API_KEY is not set."""
     backend._api_key = None
-    with mock.patch('langbot_plugin.box.e2b_backend._check_e2b_available', return_value=True):
+    with mock.patch(
+        "langbot_plugin.box.e2b_backend._check_e2b_available", return_value=True
+    ):
         assert await backend.is_available() is False
 
 
 @pytest.mark.anyio
 async def test_is_available_with_api_key(backend):
     """is_available returns True when both package and API key are available."""
-    backend._api_key = 'test-api-key'
-    with mock.patch('langbot_plugin.box.e2b_backend._check_e2b_available', return_value=True):
+    backend._api_key = "test-api-key"
+    with mock.patch(
+        "langbot_plugin.box.e2b_backend._check_e2b_available", return_value=True
+    ):
         assert await backend.is_available() is True
 
 
 @pytest.mark.anyio
 async def test_configure_from_langbot(backend, mock_e2b_module):
     """configure() applies settings from LangBot config.yaml."""
-    backend.configure({
-        'api_key': 'config-api-key',
-        'api_url': 'http://127.0.0.1:3000',
-        'template': 'python-3.11',
-    })
+    backend.configure(
+        {
+            "api_key": "config-api-key",
+            "api_url": "http://127.0.0.1:3000",
+            "template": "python-3.11",
+        }
+    )
     await backend.initialize()
 
     # Environment variable takes precedence, so if not set, use config
-    assert backend._api_key == 'config-api-key'
-    assert backend._api_url == 'http://127.0.0.1:3000'
-    assert backend._template == 'python-3.11'
+    assert backend._api_key == "config-api-key"
+    assert backend._api_url == "http://127.0.0.1:3000"
+    assert backend._template == "python-3.11"
 
 
 @pytest.mark.anyio
 async def test_env_vars_override_config(backend, mock_e2b_module):
     """Environment variables take precedence over config.yaml values."""
-    with mock.patch.dict('os.environ', {'E2B_API_KEY': 'env-api-key', 'E2B_API_URL': 'http://env-url'}):
-        backend.configure({
-            'api_key': 'config-api-key',
-            'api_url': 'http://config-url',
-        })
+    with mock.patch.dict(
+        "os.environ", {"E2B_API_KEY": "env-api-key", "E2B_API_URL": "http://env-url"}
+    ):
+        backend.configure(
+            {
+                "api_key": "config-api-key",
+                "api_url": "http://config-url",
+            }
+        )
         await backend.initialize()
 
         # Environment variables should win
-        assert backend._api_key == 'env-api-key'
-        assert backend._api_url == 'http://env-url'
+        assert backend._api_key == "env-api-key"
+        assert backend._api_url == "http://env-url"
 
 
 # ── start_session ─────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_start_session_basic(backend, mock_e2b_module):
     """start_session creates sandbox with default parameters."""
-    backend._api_key = 'test-api-key'
-    spec = BoxSpec(session_id='sess1', cmd='echo hi')
+    backend._api_key = "test-api-key"
+    spec = BoxSpec(session_id="sess1", cmd="echo hi")
 
     info = await backend.start_session(spec)
 
-    assert info.backend_name == 'e2b'
-    assert info.session_id == 'sess1'
-    assert info.backend_session_id == 'sandbox-test-123'
+    assert info.backend_name == "e2b"
+    assert info.session_id == "sess1"
+    assert info.backend_session_id == "sandbox-test-123"
     # Session metadata keeps LangBot's logical mount path so later specs
     # with /workspace can reuse the same session.
-    assert info.mount_path == '/workspace'
+    assert info.mount_path == "/workspace"
 
     # Verify AsyncSandbox.create was called with api_key
     mock_e2b_module.create.assert_called_once()
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    assert call_kwargs.get('api_key') == 'test-api-key'
+    assert call_kwargs.get("api_key") == "test-api-key"
 
 
 @pytest.mark.anyio
 async def test_start_session_with_template(backend, mock_e2b_module):
     """start_session passes template parameter when image is specified."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
     spec = BoxSpec(
-        session_id='sess2',
-        cmd='python script.py',
-        image='python-3.11',
+        session_id="sess2",
+        cmd="python script.py",
+        image="python-3.11",
     )
 
     info = await backend.start_session(spec)
 
-    assert info.image == 'python-3.11'
+    assert info.image == "python-3.11"
 
     # Verify template was passed
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    assert call_kwargs.get('template') == 'python-3.11'
+    assert call_kwargs.get("template") == "python-3.11"
 
 
 @pytest.mark.anyio
 async def test_start_session_with_envs(backend, mock_e2b_module):
     """start_session passes environment variables."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
     spec = BoxSpec(
-        session_id='sess3',
-        cmd='echo $FOO',
-        env={'FOO': 'bar', 'DEBUG': '1'},
+        session_id="sess3",
+        cmd="echo $FOO",
+        env={"FOO": "bar", "DEBUG": "1"},
     )
 
     await backend.start_session(spec)
 
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    assert call_kwargs.get('envs') == {'FOO': 'bar', 'DEBUG': '1'}
+    assert call_kwargs.get("envs") == {"FOO": "bar", "DEBUG": "1"}
 
 
 @pytest.mark.anyio
 async def test_start_session_with_api_url(backend, mock_e2b_module):
     """start_session passes domain for CubeSandbox self-deployment."""
-    backend._api_key = 'dummy'
-    backend._api_url = 'http://127.0.0.1:3000'
-    spec = BoxSpec(session_id='sess4', cmd='ls')
+    backend._api_key = "dummy"
+    backend._api_url = "http://127.0.0.1:3000"
+    spec = BoxSpec(session_id="sess4", cmd="ls")
 
     await backend.start_session(spec)
 
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    assert call_kwargs.get('domain') == 'http://127.0.0.1:3000'
+    assert call_kwargs.get("domain") == "http://127.0.0.1:3000"
 
 
 @pytest.mark.anyio
 async def test_start_session_custom_mount_path(backend, mock_e2b_module):
     """start_session adapts custom mount_path."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
     spec = BoxSpec(
-        session_id='sess5',
-        cmd='ls',
-        mount_path='/workspace/myproject',
+        session_id="sess5",
+        cmd="ls",
+        mount_path="/workspace/myproject",
     )
 
     info = await backend.start_session(spec)
 
     # Session metadata keeps the logical mount path; command execution adapts
     # it to E2B's internal writable path.
-    assert info.mount_path == '/workspace/myproject'
+    assert info.mount_path == "/workspace/myproject"
 
 
 # ── CubeSandbox host-mount metadata ───────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_start_session_host_mount_rw(backend, mock_e2b_module):
     """host_path with rw mode generates correct metadata."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
     spec = BoxSpec(
-        session_id='sess-hp-rw',
-        cmd='ls',
-        host_path='/data/project',
+        session_id="sess-hp-rw",
+        cmd="ls",
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/workspace',
+        mount_path="/workspace",
     )
 
     await backend.start_session(spec)
 
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    metadata = call_kwargs.get('metadata', {})
+    metadata = call_kwargs.get("metadata", {})
 
-    assert 'host-mount' in metadata
-    host_mount = json.loads(metadata['host-mount'])
+    assert "host-mount" in metadata
+    host_mount = json.loads(metadata["host-mount"])
     assert len(host_mount) == 1
-    assert host_mount[0]['hostPath'] == '/data/project'
+    assert host_mount[0]["hostPath"] == "/data/project"
     # mountPath should be adapted
-    assert host_mount[0]['mountPath'] == '/home/user/workspace'
-    assert host_mount[0]['readOnly'] is False
+    assert host_mount[0]["mountPath"] == "/home/user/workspace"
+    assert host_mount[0]["readOnly"] is False
 
 
 @pytest.mark.anyio
 async def test_start_session_host_mount_ro(backend, mock_e2b_module):
     """host_path with ro mode generates readOnly=True in metadata."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
     spec = BoxSpec(
-        session_id='sess-hp-ro',
-        cmd='cat file.txt',
-        host_path='/data/source',
+        session_id="sess-hp-ro",
+        cmd="cat file.txt",
+        host_path="/data/source",
         host_path_mode=BoxHostMountMode.READ_ONLY,
-        mount_path='/src',  # Non-workspace path stays unchanged
+        mount_path="/src",  # Non-workspace path stays unchanged
     )
 
     await backend.start_session(spec)
 
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    metadata = call_kwargs.get('metadata', {})
+    metadata = call_kwargs.get("metadata", {})
 
-    host_mount = json.loads(metadata['host-mount'])
-    assert host_mount[0]['readOnly'] is True
+    host_mount = json.loads(metadata["host-mount"])
+    assert host_mount[0]["readOnly"] is True
     # Non-workspace path stays unchanged
-    assert host_mount[0]['mountPath'] == '/src'
+    assert host_mount[0]["mountPath"] == "/src"
 
 
 @pytest.mark.anyio
 async def test_start_session_no_host_mount_when_none(backend, mock_e2b_module):
     """host_path_mode=none skips host-mount metadata."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
     spec = BoxSpec(
-        session_id='sess-hp-none',
-        cmd='ls',
-        host_path='/data',
+        session_id="sess-hp-none",
+        cmd="ls",
+        host_path="/data",
         host_path_mode=BoxHostMountMode.NONE,
     )
 
     await backend.start_session(spec)
 
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    assert 'host-mount' not in call_kwargs.get('metadata', {})
+    assert "host-mount" not in call_kwargs.get("metadata", {})
 
 
 @pytest.mark.anyio
 async def test_start_session_no_host_mount_when_empty(backend, mock_e2b_module):
     """Empty host_path skips host-mount metadata."""
-    backend._api_key = 'test-api-key'
-    spec = BoxSpec(session_id='sess-no-hp', cmd='ls')
+    backend._api_key = "test-api-key"
+    spec = BoxSpec(session_id="sess-no-hp", cmd="ls")
 
     await backend.start_session(spec)
 
     call_kwargs = mock_e2b_module.create.call_args.kwargs
-    assert 'metadata' not in call_kwargs or 'host-mount' not in call_kwargs.get('metadata', {})
+    assert "metadata" not in call_kwargs or "host-mount" not in call_kwargs.get(
+        "metadata", {}
+    )
 
 
 # ── exec ──────────────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_exec_success(backend, mock_e2b_module):
     """exec runs command and returns result."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
 
     session = BoxSessionInfo(
-        session_id='exec-sess',
-        backend_name='e2b',
-        backend_session_id='sandbox-123',
-        image='base',
+        session_id="exec-sess",
+        backend_name="e2b",
+        backend_session_id="sandbox-123",
+        image="base",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
-    spec = BoxSpec(session_id='exec-sess', cmd='echo hello', workdir='/workspace', env={'FOO': 'bar'})
+    spec = BoxSpec(
+        session_id="exec-sess",
+        cmd="echo hello",
+        workdir="/workspace",
+        env={"FOO": "bar"},
+    )
 
     result = await backend.exec(session, spec)
 
     assert result.status == BoxExecutionStatus.COMPLETED
     assert result.exit_code == 0
-    assert result.stdout == 'output'
+    assert result.stdout == "output"
 
     # Verify connect and run were called
     mock_e2b_module.connect.assert_called_once()
@@ -345,47 +370,47 @@ async def test_exec_success(backend, mock_e2b_module):
 
     # Verify command includes path adaptation
     run_kwargs = mock_e2b_module.commands.run.call_args.kwargs
-    assert '/home/user/workspace' in run_kwargs['cmd']
+    assert "/home/user/workspace" in run_kwargs["cmd"]
 
 
 @pytest.mark.anyio
 async def test_exec_timeout(backend, mock_e2b_module):
     """exec handles timeout correctly."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
 
     # Mock timeout error
     mock_e2b_module.commands.run = mock.AsyncMock(
-        side_effect=Exception('Command timed out after 30 seconds')
+        side_effect=Exception("Command timed out after 30 seconds")
     )
 
     session = BoxSessionInfo(
-        session_id='timeout-sess',
-        backend_name='e2b',
-        backend_session_id='sandbox-456',
-        image='base',
+        session_id="timeout-sess",
+        backend_name="e2b",
+        backend_session_id="sandbox-456",
+        image="base",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
-    spec = BoxSpec(session_id='timeout-sess', cmd='sleep 100', timeout_sec=30)
+    spec = BoxSpec(session_id="timeout-sess", cmd="sleep 100", timeout_sec=30)
 
     result = await backend.exec(session, spec)
 
     assert result.status == BoxExecutionStatus.TIMED_OUT
     assert result.exit_code is None
-    assert 'timed out' in result.stderr.lower()
+    assert "timed out" in result.stderr.lower()
 
 
 @pytest.mark.anyio
 async def test_exec_truncates_large_output(backend, mock_e2b_module):
     """exec truncates output exceeding the limit."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
 
     # Create large output (over 1MB)
-    large_output = 'x' * (2 * 1024 * 1024)  # 2MB
+    large_output = "x" * (2 * 1024 * 1024)  # 2MB
     mock_command_result = mock.MagicMock()
     mock_command_result.stdout = large_output
-    mock_command_result.stderr = ''
+    mock_command_result.stderr = ""
     mock_command_result.exit_code = 0
 
     mock_commands = mock.MagicMock()
@@ -393,36 +418,37 @@ async def test_exec_truncates_large_output(backend, mock_e2b_module):
     mock_e2b_module.commands = mock_commands
 
     session = BoxSessionInfo(
-        session_id='truncate-sess',
-        backend_name='e2b',
-        backend_session_id='sandbox-789',
-        image='base',
+        session_id="truncate-sess",
+        backend_name="e2b",
+        backend_session_id="sandbox-789",
+        image="base",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
-    spec = BoxSpec(session_id='truncate-sess', cmd='cat large_file')
+    spec = BoxSpec(session_id="truncate-sess", cmd="cat large_file")
 
     result = await backend.exec(session, spec)
 
-    assert 'clipped' in result.stdout
+    assert "clipped" in result.stdout
 
 
 # ── stop_session ──────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_stop_session(backend, mock_e2b_module):
     """stop_session kills the sandbox."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
 
     session = BoxSessionInfo(
-        session_id='stop-sess',
-        backend_name='e2b',
-        backend_session_id='sandbox-to-kill',
-        image='base',
+        session_id="stop-sess",
+        backend_name="e2b",
+        backend_session_id="sandbox-to-kill",
+        image="base",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
 
     await backend.stop_session(session)
@@ -434,18 +460,18 @@ async def test_stop_session(backend, mock_e2b_module):
 @pytest.mark.anyio
 async def test_stop_session_handles_error(backend, mock_e2b_module):
     """stop_session logs error but doesn't raise on kill failure."""
-    backend._api_key = 'test-api-key'
+    backend._api_key = "test-api-key"
 
-    mock_e2b_module.kill = mock.AsyncMock(side_effect=Exception('Sandbox not found'))
+    mock_e2b_module.kill = mock.AsyncMock(side_effect=Exception("Sandbox not found"))
 
     session = BoxSessionInfo(
-        session_id='stop-fail',
-        backend_name='e2b',
-        backend_session_id='sandbox-missing',
-        image='base',
+        session_id="stop-fail",
+        backend_name="e2b",
+        backend_session_id="sandbox-missing",
+        image="base",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
 
     # Should not raise
@@ -454,14 +480,16 @@ async def test_stop_session_handles_error(backend, mock_e2b_module):
 
 # ── _check_e2b_available ──────────────────────────────────────────────
 
+
 def test_check_e2b_available_caches_result():
     """_check_e2b_available caches the import check result."""
     # Reset the cache
     import langbot_plugin.box.e2b_backend as e2b_backend
+
     e2b_backend._e2b_available = None
 
     # First call
-    with mock.patch.dict('sys.modules', {'e2b': mock.MagicMock()}):
+    with mock.patch.dict("sys.modules", {"e2b": mock.MagicMock()}):
         result1 = _check_e2b_available()
 
     # Second call should use cached result
@@ -473,10 +501,11 @@ def test_check_e2b_available_caches_result():
 def test_check_e2b_available_returns_false_on_import_error():
     """_check_e2b_available returns False when import fails."""
     import langbot_plugin.box.e2b_backend as e2b_backend
+
     e2b_backend._e2b_available = None
     e2b_backend._AsyncSandbox = None
 
-    with mock.patch('builtins.__import__', side_effect=ImportError('No e2b')):
+    with mock.patch("builtins.__import__", side_effect=ImportError("No e2b")):
         result = _check_e2b_available()
 
     assert result is False

--- a/tests/box/test_nsjail_backend.py
+++ b/tests/box/test_nsjail_backend.py
@@ -28,34 +28,35 @@ from langbot_plugin.box.models import (
 
 @pytest.fixture
 def logger():
-    return logging.getLogger('test.nsjail')
+    return logging.getLogger("test.nsjail")
 
 
 @pytest.fixture
 def tmp_base(tmp_path: pathlib.Path):
-    return tmp_path / 'nsjail-base'
+    return tmp_path / "nsjail-base"
 
 
 @pytest.fixture
 def backend(logger, tmp_base):
     b = NsjailBackend(logger=logger, base_dir=str(tmp_base))
-    b.instance_id = 'test123'
+    b.instance_id = "test123"
     return b
 
 
 # ── is_available ──────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_is_available_no_binary(backend):
-    with mock.patch('shutil.which', return_value=None):
+    with mock.patch("shutil.which", return_value=None):
         assert await backend.is_available() is False
 
 
 @pytest.mark.anyio
 async def test_is_available_binary_exists(backend, tmp_base):
     with (
-        mock.patch('shutil.which', return_value='/usr/bin/nsjail'),
-        mock.patch('asyncio.create_subprocess_exec') as mock_exec,
+        mock.patch("shutil.which", return_value="/usr/bin/nsjail"),
+        mock.patch("asyncio.create_subprocess_exec") as mock_exec,
     ):
         mock_proc = mock.AsyncMock()
         mock_proc.returncode = 0
@@ -69,23 +70,24 @@ async def test_is_available_binary_exists(backend, tmp_base):
 
 # ── start_session ─────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_start_session_creates_directories(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    spec = BoxSpec(session_id='sess1', cmd='echo hi')
+    spec = BoxSpec(session_id="sess1", cmd="echo hi")
 
     info = await backend.start_session(spec)
 
     session_dir = pathlib.Path(info.backend_session_id)
     assert session_dir.exists()
-    assert (session_dir / 'root').is_dir()
-    assert (session_dir / 'workspace').is_dir()
-    assert (session_dir / 'tmp').is_dir()
-    assert (session_dir / 'home').is_dir()
-    assert (session_dir / 'meta.json').exists()
+    assert (session_dir / "root").is_dir()
+    assert (session_dir / "workspace").is_dir()
+    assert (session_dir / "tmp").is_dir()
+    assert (session_dir / "home").is_dir()
+    assert (session_dir / "meta.json").exists()
 
-    assert info.backend_name == 'nsjail'
-    assert info.session_id == 'sess1'
+    assert info.backend_name == "nsjail"
+    assert info.session_id == "sess1"
     assert info.image == spec.image
     assert info.read_only_rootfs is True
 
@@ -93,19 +95,19 @@ async def test_start_session_creates_directories(backend, tmp_base):
 @pytest.mark.anyio
 async def test_start_session_with_host_path(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    host_path = str(tmp_base / 'rw_host')
+    host_path = str(tmp_base / "rw_host")
     spec = BoxSpec(
-        session_id='sess2',
-        cmd='ls',
+        session_id="sess2",
+        cmd="ls",
         host_path=host_path,
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/project',
+        mount_path="/project",
     )
 
     info = await backend.start_session(spec)
     assert info.host_path == host_path
     assert info.host_path_mode == BoxHostMountMode.READ_WRITE
-    assert info.mount_path == '/project'
+    assert info.mount_path == "/project"
 
 
 @pytest.mark.anyio
@@ -114,15 +116,15 @@ async def test_start_session_creates_missing_rw_host_path(backend, tmp_base):
     created by start_session, otherwise nsjail's --bindmount source is missing
     and the command exits 255 with no output (SaaS MCP shared-workspace bug)."""
     tmp_base.mkdir(parents=True, exist_ok=True)
-    host_path = tmp_base / 'never_created' / 'workspace'
+    host_path = tmp_base / "never_created" / "workspace"
     assert not host_path.exists()
 
     spec = BoxSpec(
-        session_id='sess-mkdir',
-        cmd='ls',
+        session_id="sess-mkdir",
+        cmd="ls",
         host_path=str(host_path),
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/workspace',
+        mount_path="/workspace",
     )
 
     await backend.start_session(spec)
@@ -134,15 +136,15 @@ async def test_start_session_does_not_create_ro_host_path(backend, tmp_base):
     """A missing read-only host_path is a caller error and must NOT be silently
     created — it should surface rather than mount an empty dir."""
     tmp_base.mkdir(parents=True, exist_ok=True)
-    host_path = tmp_base / 'ro_missing'
+    host_path = tmp_base / "ro_missing"
     assert not host_path.exists()
 
     spec = BoxSpec(
-        session_id='sess-ro',
-        cmd='ls',
+        session_id="sess-ro",
+        cmd="ls",
         host_path=str(host_path),
         host_path_mode=BoxHostMountMode.READ_ONLY,
-        mount_path='/project',
+        mount_path="/project",
     )
 
     await backend.start_session(spec)
@@ -151,10 +153,11 @@ async def test_start_session_does_not_create_ro_host_path(backend, tmp_base):
 
 # ── stop_session ──────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_stop_session_removes_directory(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    spec = BoxSpec(session_id='sess-rm', cmd='echo')
+    spec = BoxSpec(session_id="sess-rm", cmd="echo")
 
     info = await backend.start_session(spec)
     session_dir = pathlib.Path(info.backend_session_id)
@@ -166,53 +169,54 @@ async def test_stop_session_removes_directory(backend, tmp_base):
 
 # ── nsjail argument construction ──────────────────────────────────────
 
+
 def test_build_nsjail_args_basic(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_dir = tmp_base / 'test_session'
-    for d in ('root', 'workspace', 'tmp', 'home'):
+    session_dir = tmp_base / "test_session"
+    for d in ("root", "workspace", "tmp", "home"):
         (session_dir / d).mkdir(parents=True)
 
-    spec = BoxSpec(session_id='s1', cmd='echo hello', env={'FOO': 'bar'})
+    spec = BoxSpec(session_id="s1", cmd="echo hello", env={"FOO": "bar"})
     session = BoxSessionInfo(
-        session_id='s1',
-        backend_name='nsjail',
+        session_id="s1",
+        backend_name="nsjail",
         backend_session_id=str(session_dir),
         image=spec.image,
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
 
     args = backend._build_nsjail_args(session, spec, session_dir)
 
-    assert args[0] == 'nsjail'
-    assert '--mode' in args
-    assert args[args.index('--mode') + 1] == 'o'
-    assert '--chroot' in args
-    assert args[args.index('--chroot') + 1] == str(session_dir / 'root')
-    assert '--clone_newnet' not in args
-    assert '--clone_newuser' not in args
-    assert '--clone_newns' not in args
-    assert '--disable_clone_newnet' not in args
-    assert '--really_quiet' in args
+    assert args[0] == "nsjail"
+    assert "--mode" in args
+    assert args[args.index("--mode") + 1] == "o"
+    assert "--chroot" in args
+    assert args[args.index("--chroot") + 1] == str(session_dir / "root")
+    assert "--clone_newnet" not in args
+    assert "--clone_newuser" not in args
+    assert "--clone_newns" not in args
+    assert "--disable_clone_newnet" not in args
+    assert "--really_quiet" in args
 
     # Writable mounts should reference session directories.
-    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == '--bindmount']
-    workspace_mount = f'{session_dir}/workspace:/workspace'
+    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == "--bindmount"]
+    workspace_mount = f"{session_dir}/workspace:/workspace"
     assert workspace_mount in rw_binds
 
     # Custom env should be present.
-    env_values = [args[i + 1] for i, a in enumerate(args) if a == '--env']
-    assert 'FOO=bar' in env_values
+    env_values = [args[i + 1] for i, a in enumerate(args) if a == "--env"]
+    assert "FOO=bar" in env_values
 
     # Command is the last part after '--'.
-    separator_idx = args.index('--')
-    assert args[separator_idx + 1] == '/bin/sh'
+    separator_idx = args.index("--")
+    assert args[separator_idx + 1] == "/bin/sh"
 
     # Mount target directories are created under the per-session chroot root.
-    assert (session_dir / 'root' / 'workspace').is_dir()
-    assert (session_dir / 'root' / 'tmp').is_dir()
-    assert (session_dir / 'root' / 'home').is_dir()
+    assert (session_dir / "root" / "workspace").is_dir()
+    assert (session_dir / "root" / "tmp").is_dir()
+    assert (session_dir / "root" / "home").is_dir()
 
 
 def test_build_nsjail_args_binds_essential_dev_nodes(backend, tmp_base):
@@ -223,156 +227,160 @@ def test_build_nsjail_args_binds_essential_dev_nodes(backend, tmp_base):
     handshake, surfacing as a misleading "Connection closed / please check URL".
     """
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_dir = tmp_base / 'test_dev'
-    for d in ('root', 'workspace', 'tmp', 'home'):
+    session_dir = tmp_base / "test_dev"
+    for d in ("root", "workspace", "tmp", "home"):
         (session_dir / d).mkdir(parents=True)
 
-    spec = BoxSpec(session_id='s-dev', cmd='echo hi')
+    spec = BoxSpec(session_id="s-dev", cmd="echo hi")
     session = BoxSessionInfo(
-        session_id='s-dev',
-        backend_name='nsjail',
+        session_id="s-dev",
+        backend_name="nsjail",
         backend_session_id=str(session_dir),
         image=spec.image,
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
 
     # Pretend every candidate device node exists on the host.
-    with mock.patch('os.path.exists', return_value=True):
+    with mock.patch("os.path.exists", return_value=True):
         args = backend._build_nsjail_args(session, spec, session_dir)
 
     # /dev itself is a tmpfs mount.
-    mount_specs = [args[i + 1] for i, a in enumerate(args) if a == '--mount']
-    assert 'none:/dev:tmpfs:rw' in mount_specs
+    mount_specs = [args[i + 1] for i, a in enumerate(args) if a == "--mount"]
+    assert "none:/dev:tmpfs:rw" in mount_specs
 
     # /dev/null (the critical one for uv) must be bind-mounted read-write,
     # ordered AFTER the /dev tmpfs mount so it lands on the fresh tmpfs.
-    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == '--bindmount']
-    assert '/dev/null:/dev/null' in rw_binds
-    assert '/dev/urandom:/dev/urandom' in rw_binds
+    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == "--bindmount"]
+    assert "/dev/null:/dev/null" in rw_binds
+    assert "/dev/urandom:/dev/urandom" in rw_binds
 
     dev_tmpfs_idx = next(
-        i for i, a in enumerate(args)
-        if a == '--mount' and args[i + 1] == 'none:/dev:tmpfs:rw'
+        i
+        for i, a in enumerate(args)
+        if a == "--mount" and args[i + 1] == "none:/dev:tmpfs:rw"
     )
     dev_null_idx = next(
-        i for i, a in enumerate(args)
-        if a == '--bindmount' and args[i + 1] == '/dev/null:/dev/null'
+        i
+        for i, a in enumerate(args)
+        if a == "--bindmount" and args[i + 1] == "/dev/null:/dev/null"
     )
     assert dev_tmpfs_idx < dev_null_idx
 
 
 def test_build_nsjail_args_network_on(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_dir = tmp_base / 'test_session_net'
-    for d in ('root', 'workspace', 'tmp', 'home'):
+    session_dir = tmp_base / "test_session_net"
+    for d in ("root", "workspace", "tmp", "home"):
         (session_dir / d).mkdir(parents=True)
 
     session = BoxSessionInfo(
-        session_id='s2',
-        backend_name='nsjail',
+        session_id="s2",
+        backend_name="nsjail",
         backend_session_id=str(session_dir),
-        image='host',
+        image="host",
         network=BoxNetworkMode.ON,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
-    spec = BoxSpec(session_id='s2', cmd='curl http://example.com', network=BoxNetworkMode.ON)
+    spec = BoxSpec(
+        session_id="s2", cmd="curl http://example.com", network=BoxNetworkMode.ON
+    )
 
     args = backend._build_nsjail_args(session, spec, session_dir)
 
-    assert '--disable_clone_newnet' in args
-    assert '--clone_newnet' not in args
+    assert "--disable_clone_newnet" in args
+    assert "--clone_newnet" not in args
 
 
 def test_build_nsjail_args_host_path_ro(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_dir = tmp_base / 'test_hp'
-    for d in ('root', 'workspace', 'tmp', 'home'):
+    session_dir = tmp_base / "test_hp"
+    for d in ("root", "workspace", "tmp", "home"):
         (session_dir / d).mkdir(parents=True)
 
     session = BoxSessionInfo(
-        session_id='s3',
-        backend_name='nsjail',
+        session_id="s3",
+        backend_name="nsjail",
         backend_session_id=str(session_dir),
-        image='host',
+        image="host",
         network=BoxNetworkMode.OFF,
-        host_path='/data/project',
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_ONLY,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
     spec = BoxSpec(
-        session_id='s3',
-        cmd='ls',
-        host_path='/data/project',
+        session_id="s3",
+        cmd="ls",
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_ONLY,
     )
 
     args = backend._build_nsjail_args(session, spec, session_dir)
 
-    ro_binds = [args[i + 1] for i, a in enumerate(args) if a == '--bindmount_ro']
-    assert '/data/project:/workspace' in ro_binds
+    ro_binds = [args[i + 1] for i, a in enumerate(args) if a == "--bindmount_ro"]
+    assert "/data/project:/workspace" in ro_binds
 
 
 def test_build_nsjail_args_uses_custom_mount_path(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_dir = tmp_base / 'test_custom_mount'
-    for d in ('root', 'workspace', 'tmp', 'home'):
+    session_dir = tmp_base / "test_custom_mount"
+    for d in ("root", "workspace", "tmp", "home"):
         (session_dir / d).mkdir(parents=True)
 
     session = BoxSessionInfo(
-        session_id='s4',
-        backend_name='nsjail',
+        session_id="s4",
+        backend_name="nsjail",
         backend_session_id=str(session_dir),
-        image='host',
+        image="host",
         network=BoxNetworkMode.OFF,
-        host_path='/data/project',
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/project',
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        mount_path="/project",
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
     spec = BoxSpec(
-        session_id='s4',
-        cmd='pwd',
-        workdir='/project/src',
-        host_path='/data/project',
+        session_id="s4",
+        cmd="pwd",
+        workdir="/project/src",
+        host_path="/data/project",
         host_path_mode=BoxHostMountMode.READ_WRITE,
-        mount_path='/project',
+        mount_path="/project",
     )
 
     args = backend._build_nsjail_args(session, spec, session_dir)
 
-    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == '--bindmount']
-    assert '/data/project:/project' in rw_binds
-    assert args[args.index('--cwd') + 1] == '/project/src'
-    assert (session_dir / 'root' / 'project').is_dir()
+    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == "--bindmount"]
+    assert "/data/project:/project" in rw_binds
+    assert args[args.index("--cwd") + 1] == "/project/src"
+    assert (session_dir / "root" / "project").is_dir()
 
 
 def test_build_nsjail_args_extra_mounts_prepare_targets(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    session_dir = tmp_base / 'test_extra_mount'
-    for d in ('root', 'workspace', 'tmp', 'home'):
+    session_dir = tmp_base / "test_extra_mount"
+    for d in ("root", "workspace", "tmp", "home"):
         (session_dir / d).mkdir(parents=True)
 
     session = BoxSessionInfo(
-        session_id='s5',
-        backend_name='nsjail',
+        session_id="s5",
+        backend_name="nsjail",
         backend_session_id=str(session_dir),
-        image='host',
+        image="host",
         network=BoxNetworkMode.OFF,
-        created_at='2024-01-01T00:00:00+00:00',
-        last_used_at='2024-01-01T00:00:00+00:00',
+        created_at="2024-01-01T00:00:00+00:00",
+        last_used_at="2024-01-01T00:00:00+00:00",
     )
     spec = BoxSpec(
-        session_id='s5',
-        cmd='ls /workspace/.skills/demo',
+        session_id="s5",
+        cmd="ls /workspace/.skills/demo",
         extra_mounts=[
             BoxMountSpec(
-                host_path='/data/skills/demo',
-                mount_path='/workspace/.skills/demo',
+                host_path="/data/skills/demo",
+                mount_path="/workspace/.skills/demo",
                 mode=BoxHostMountMode.READ_WRITE,
             )
         ],
@@ -380,34 +388,34 @@ def test_build_nsjail_args_extra_mounts_prepare_targets(backend, tmp_base):
 
     args = backend._build_nsjail_args(session, spec, session_dir)
 
-    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == '--bindmount']
-    assert '/data/skills/demo:/workspace/.skills/demo' in rw_binds
-    assert (session_dir / 'root' / 'workspace' / '.skills' / 'demo').is_dir()
+    rw_binds = [args[i + 1] for i, a in enumerate(args) if a == "--bindmount"]
+    assert "/data/skills/demo:/workspace/.skills/demo" in rw_binds
+    assert (session_dir / "root" / "workspace" / ".skills" / "demo").is_dir()
 
 
 def test_build_resource_limits_cgroup(backend):
     backend._cgroup_v2_available = True
-    spec = BoxSpec(session_id='s', cmd='x', cpus=2.0, memory_mb=1024, pids_limit=256)
+    spec = BoxSpec(session_id="s", cmd="x", cpus=2.0, memory_mb=1024, pids_limit=256)
 
     args = backend._build_resource_limits(spec)
 
     # Bug regression: cgroup v2 mode MUST opt in explicitly, otherwise nsjail
     # falls back to the v1 layout and aborts on a v2-only host.
-    assert '--use_cgroupv2' in args
-    assert '--cgroup_mem_max' in args
-    mem_idx = args.index('--cgroup_mem_max')
+    assert "--use_cgroupv2" in args
+    assert "--cgroup_mem_max" in args
+    mem_idx = args.index("--cgroup_mem_max")
     assert args[mem_idx + 1] == str(1024 * 1024 * 1024)
 
-    pids_idx = args.index('--cgroup_pids_max')
-    assert args[pids_idx + 1] == '256'
+    pids_idx = args.index("--cgroup_pids_max")
+    assert args[pids_idx + 1] == "256"
 
-    cpu_idx = args.index('--cgroup_cpu_ms_per_sec')
-    assert args[cpu_idx + 1] == '2000'
+    cpu_idx = args.index("--cgroup_cpu_ms_per_sec")
+    assert args[cpu_idx + 1] == "2000"
 
 
 def test_build_resource_limits_rlimit_fallback(backend):
     backend._cgroup_v2_available = False
-    spec = BoxSpec(session_id='s', cmd='x', memory_mb=512, pids_limit=128)
+    spec = BoxSpec(session_id="s", cmd="x", memory_mb=512, pids_limit=128)
 
     args = backend._build_resource_limits(spec)
 
@@ -417,52 +425,55 @@ def test_build_resource_limits_rlimit_fallback(backend):
     # exit 255) and silently broke every uvx stdio MCP server. There is no
     # RSS-based rlimit on modern Linux, so memory capping requires cgroups;
     # the fallback runs without a hard memory cap by design.
-    assert '--rlimit_as' not in args
+    assert "--rlimit_as" not in args
 
-    nproc_idx = args.index('--rlimit_nproc')
-    assert args[nproc_idx + 1] == '128'
+    nproc_idx = args.index("--rlimit_nproc")
+    assert args[nproc_idx + 1] == "128"
 
     # Safe rlimits still apply.
-    assert '--rlimit_fsize' in args
-    assert '--rlimit_nofile' in args
+    assert "--rlimit_fsize" in args
+    assert "--rlimit_nofile" in args
 
     # cgroup flags should NOT be present.
-    assert '--use_cgroupv2' not in args
-    assert '--cgroup_mem_max' not in args
+    assert "--use_cgroupv2" not in args
+    assert "--cgroup_mem_max" not in args
 
 
 # ── exec ──────────────────────────────────────────────────────────────
 
+
 @pytest.mark.anyio
 async def test_exec_success(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    spec = BoxSpec(session_id='exec1', cmd='echo hello')
+    spec = BoxSpec(session_id="exec1", cmd="echo hello")
     info = await backend.start_session(spec)
 
-    with mock.patch.object(backend, '_run_nsjail') as mock_run:
+    with mock.patch.object(backend, "_run_nsjail") as mock_run:
         from langbot_plugin.box.backend import _CommandResult
+
         mock_run.return_value = _CommandResult(
-            return_code=0, stdout='hello\n', stderr='', timed_out=False
+            return_code=0, stdout="hello\n", stderr="", timed_out=False
         )
 
         result = await backend.exec(info, spec)
 
     assert result.status == BoxExecutionStatus.COMPLETED
     assert result.exit_code == 0
-    assert result.stdout == 'hello\n'
-    assert result.backend_name == 'nsjail'
+    assert result.stdout == "hello\n"
+    assert result.backend_name == "nsjail"
 
 
 @pytest.mark.anyio
 async def test_exec_timeout(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
-    spec = BoxSpec(session_id='exec2', cmd='sleep 100', timeout_sec=1)
+    spec = BoxSpec(session_id="exec2", cmd="sleep 100", timeout_sec=1)
     info = await backend.start_session(spec)
 
-    with mock.patch.object(backend, '_run_nsjail') as mock_run:
+    with mock.patch.object(backend, "_run_nsjail") as mock_run:
         from langbot_plugin.box.backend import _CommandResult
+
         mock_run.return_value = _CommandResult(
-            return_code=-1, stdout='', stderr='', timed_out=True
+            return_code=-1, stdout="", stderr="", timed_out=True
         )
 
         result = await backend.exec(info, spec)
@@ -473,8 +484,9 @@ async def test_exec_timeout(backend, tmp_base):
 
 # ── cgroup detection ──────────────────────────────────────────────────
 
+
 def test_detect_cgroup_v2_no_mount():
-    with mock.patch.object(pathlib.Path, 'exists', return_value=False):
+    with mock.patch.object(pathlib.Path, "exists", return_value=False):
         assert NsjailBackend._detect_cgroup_v2() is False
 
 
@@ -487,20 +499,21 @@ def test_detect_cgroup_v2_subtree_writable():
     succeeds even in a private cgroup namespace where the subtree_control write
     then fails with EBUSY.
     """
+
     def fake_exists(self):
         path = str(self)
         return path in (
-            '/sys/fs/cgroup',
-            '/sys/fs/cgroup/cgroup.controllers',
-            '/sys/fs/cgroup/cgroup.subtree_control',
+            "/sys/fs/cgroup",
+            "/sys/fs/cgroup/cgroup.controllers",
+            "/sys/fs/cgroup/cgroup.subtree_control",
         )
 
     def fake_read_text(self, *a, **k):
         path = str(self)
-        if path.endswith('cgroup.controllers'):
-            return 'cpuset cpu io memory hugetlb pids'
-        if path.endswith('cgroup.subtree_control'):
-            return ''  # nothing delegated yet -> probe will enable then disable
+        if path.endswith("cgroup.controllers"):
+            return "cpuset cpu io memory hugetlb pids"
+        if path.endswith("cgroup.subtree_control"):
+            return ""  # nothing delegated yet -> probe will enable then disable
         raise FileNotFoundError(path)
 
     writes: list[str] = []
@@ -510,13 +523,13 @@ def test_detect_cgroup_v2_subtree_writable():
         return len(data)
 
     with (
-        mock.patch.object(pathlib.Path, 'exists', fake_exists),
-        mock.patch.object(pathlib.Path, 'read_text', fake_read_text),
-        mock.patch.object(pathlib.Path, 'write_text', fake_write_text),
+        mock.patch.object(pathlib.Path, "exists", fake_exists),
+        mock.patch.object(pathlib.Path, "read_text", fake_read_text),
+        mock.patch.object(pathlib.Path, "write_text", fake_write_text),
     ):
         assert NsjailBackend._detect_cgroup_v2() is True
     # Probe must enable then disable to leave host config untouched.
-    assert writes == ['+memory', '-memory']
+    assert writes == ["+memory", "-memory"]
 
 
 def test_detect_cgroup_v2_private_cgroupns_ebusy_returns_false():
@@ -525,64 +538,69 @@ def test_detect_cgroup_v2_private_cgroupns_ebusy_returns_false():
     The probe MUST catch this and report False so the backend uses the rlimit
     fallback instead of selecting a cgroup path that aborts nsjail (exit 255).
     """
+
     def fake_exists(self):
         path = str(self)
         return path in (
-            '/sys/fs/cgroup',
-            '/sys/fs/cgroup/cgroup.controllers',
-            '/sys/fs/cgroup/cgroup.subtree_control',
+            "/sys/fs/cgroup",
+            "/sys/fs/cgroup/cgroup.controllers",
+            "/sys/fs/cgroup/cgroup.subtree_control",
         )
 
     def fake_read_text(self, *a, **k):
         path = str(self)
-        if path.endswith('cgroup.controllers'):
-            return 'cpu memory pids'
-        if path.endswith('cgroup.subtree_control'):
-            return ''
+        if path.endswith("cgroup.controllers"):
+            return "cpu memory pids"
+        if path.endswith("cgroup.subtree_control"):
+            return ""
         raise FileNotFoundError(path)
 
     def fake_write_text(self, data, *a, **k):
-        raise OSError(16, 'Device or resource busy')
+        raise OSError(16, "Device or resource busy")
 
     with (
-        mock.patch.object(pathlib.Path, 'exists', fake_exists),
-        mock.patch.object(pathlib.Path, 'read_text', fake_read_text),
-        mock.patch.object(pathlib.Path, 'write_text', fake_write_text),
+        mock.patch.object(pathlib.Path, "exists", fake_exists),
+        mock.patch.object(pathlib.Path, "read_text", fake_read_text),
+        mock.patch.object(pathlib.Path, "write_text", fake_write_text),
     ):
         assert NsjailBackend._detect_cgroup_v2() is False
 
 
 def test_detect_cgroup_v2_no_subtree_control_returns_false():
     """A read-only /sys/fs/cgroup with no subtree_control file reports False."""
+
     def fake_exists(self):
         path = str(self)
         return path in (
-            '/sys/fs/cgroup',
-            '/sys/fs/cgroup/cgroup.controllers',
+            "/sys/fs/cgroup",
+            "/sys/fs/cgroup/cgroup.controllers",
         )
 
-    with mock.patch.object(pathlib.Path, 'exists', fake_exists):
+    with mock.patch.object(pathlib.Path, "exists", fake_exists):
         assert NsjailBackend._detect_cgroup_v2() is False
 
 
 # ── cleanup_orphaned_containers ───────────────────────────────────────
+
 
 @pytest.mark.anyio
 async def test_cleanup_orphaned_removes_old_sessions(backend, tmp_base):
     tmp_base.mkdir(parents=True, exist_ok=True)
 
     # Create a dir from a different instance.
-    old_dir = tmp_base / 'oldinst_sess1_abc'
+    old_dir = tmp_base / "oldinst_sess1_abc"
     old_dir.mkdir()
-    (old_dir / 'workspace').mkdir()
+    (old_dir / "workspace").mkdir()
 
     # Create a dir from current instance.
-    current_dir = tmp_base / 'test123_sess2_def'
+    current_dir = tmp_base / "test123_sess2_def"
     current_dir.mkdir()
-    (current_dir / 'workspace').mkdir()
+    (current_dir / "workspace").mkdir()
 
-    with mock.patch.object(backend, '_kill_session_processes', new_callable=mock.AsyncMock):
-        await backend.cleanup_orphaned_containers('test123')
+    with mock.patch.object(
+        backend, "_kill_session_processes", new_callable=mock.AsyncMock
+    ):
+        await backend.cleanup_orphaned_containers("test123")
 
     assert not old_dir.exists()
     assert current_dir.exists()
@@ -590,14 +608,15 @@ async def test_cleanup_orphaned_removes_old_sessions(backend, tmp_base):
 
 # ── output clipping ──────────────────────────────────────────────────
 
+
 def test_clip_captured_bytes_within_limit():
-    data = b'hello world'
+    data = b"hello world"
     result = NsjailBackend._clip_captured_bytes(data, len(data))
-    assert result == 'hello world'
+    assert result == "hello world"
 
 
 def test_clip_captured_bytes_exceeds_limit():
-    data = b'hello'
+    data = b"hello"
     result = NsjailBackend._clip_captured_bytes(data, 2_000_000, limit=1_000_000)
-    assert 'clipped' in result
-    assert '1000000' in result
+    assert "clipped" in result
+    assert "1000000" in result

--- a/tests/box/test_runtime.py
+++ b/tests/box/test_runtime.py
@@ -39,7 +39,7 @@ _UTC = dt.timezone.utc
 
 @pytest.fixture
 def logger():
-    return logging.getLogger('test.box.runtime')
+    return logging.getLogger("test.box.runtime")
 
 
 class FakeBackend(BaseSandboxBackend):
@@ -52,7 +52,7 @@ class FakeBackend(BaseSandboxBackend):
     def __init__(
         self,
         logger: logging.Logger,
-        name: str = 'fake',
+        name: str = "fake",
         available: bool = True,
     ):
         super().__init__(logger)
@@ -94,7 +94,7 @@ class FakeBackend(BaseSandboxBackend):
         return BoxSessionInfo(
             session_id=spec.session_id,
             backend_name=self.name,
-            backend_session_id=f'{self.name}-{self.started_sessions}',
+            backend_session_id=f"{self.name}-{self.started_sessions}",
             image=spec.image,
             network=spec.network,
             host_path=spec.host_path,
@@ -117,8 +117,8 @@ class FakeBackend(BaseSandboxBackend):
             backend_name=self.name,
             status=self.exec_status,
             exit_code=self.exec_exit_code,
-            stdout='hello',
-            stderr='',
+            stdout="hello",
+            stderr="",
             duration_ms=12,
         )
 
@@ -169,8 +169,8 @@ class FakeProcess:
         return self.returncode if self.returncode is not None else 0
 
 
-def _make_spec(session_id: str = 's1', **kwargs) -> BoxSpec:
-    base = {'session_id': session_id, 'cmd': 'echo hi', 'read_only_rootfs': False}
+def _make_spec(session_id: str = "s1", **kwargs) -> BoxSpec:
+    base = {"session_id": session_id, "cmd": "echo hi", "read_only_rootfs": False}
     base.update(kwargs)
     return BoxSpec(**base)
 
@@ -180,7 +180,7 @@ def _make_spec(session_id: str = 's1', **kwargs) -> BoxSpec:
 
 def test_init_without_env_config_has_empty_box_config(logger):
     """No LANGBOT_BOX_CONFIG → empty parsed config."""
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[FakeBackend(logger)])
     assert runtime._box_config == {}
     assert runtime.session_ttl_sec == 300
@@ -189,31 +189,31 @@ def test_init_without_env_config_has_empty_box_config(logger):
 
 def test_init_reads_langbot_box_config_env(logger):
     """LANGBOT_BOX_CONFIG env JSON is parsed into _box_config."""
-    payload = {'backend': 'fake', 'fake': {'foo': 'bar'}}
-    with mock.patch('os.getenv', return_value=json.dumps(payload)):
+    payload = {"backend": "fake", "fake": {"foo": "bar"}}
+    with mock.patch("os.getenv", return_value=json.dumps(payload)):
         runtime = BoxRuntime(logger, backends=[FakeBackend(logger)])
     assert runtime._box_config == payload
 
 
 def test_init_invalid_env_config_is_ignored(logger):
     """Malformed LANGBOT_BOX_CONFIG JSON is swallowed (warning) → empty config."""
-    with mock.patch('os.getenv', return_value='{not valid json'):
+    with mock.patch("os.getenv", return_value="{not valid json"):
         runtime = BoxRuntime(logger, backends=[FakeBackend(logger)])
     assert runtime._box_config == {}
 
 
 def test_init_method_applies_config_and_resets_backend(logger):
     """init() merges config, applies to backends, resets backend when idle."""
-    backend = FakeBackend(logger, name='fake')
+    backend = FakeBackend(logger, name="fake")
     backend.configure = mock.Mock()
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
     runtime._backend = backend  # pretend already selected
 
-    runtime.init({'backend': 'fake', 'fake': {'cpus': 2}})
+    runtime.init({"backend": "fake", "fake": {"cpus": 2}})
 
-    assert runtime._box_config['backend'] == 'fake'
-    backend.configure.assert_called_once_with({'cpus': 2})
+    assert runtime._box_config["backend"] == "fake"
+    backend.configure.assert_called_once_with({"cpus": 2})
     # No active sessions → backend reset so it re-selects with new config.
     assert runtime._backend is None
 
@@ -222,26 +222,26 @@ def test_init_method_applies_config_and_resets_backend(logger):
 async def test_init_method_keeps_backend_when_sessions_exist(logger):
     """init() must NOT reset backend while sessions are live."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('keep'))
-    runtime.init({'backend': 'fake'})
+        await runtime.create_session(_make_spec("keep"))
+    runtime.init({"backend": "fake"})
     assert runtime._backend is backend
 
 
 @pytest.mark.anyio
 async def test_initialize_applies_config_selects_and_cleans_orphans(logger):
     """initialize() applies env config, selects backend, sets instance_id, cleans orphans."""
-    backend = FakeBackend(logger, name='fake')
+    backend = FakeBackend(logger, name="fake")
     backend.configure = mock.Mock()
     backend.cleanup_orphaned_containers = mock.AsyncMock()
-    cfg = json.dumps({'backend': 'fake', 'fake': {'cpus': 1}})
-    with mock.patch('os.getenv', return_value=cfg):
+    cfg = json.dumps({"backend": "fake", "fake": {"cpus": 1}})
+    with mock.patch("os.getenv", return_value=cfg):
         runtime = BoxRuntime(logger, backends=[backend])
         await runtime.initialize()
 
     assert runtime._backend is backend
-    backend.configure.assert_called_once_with({'cpus': 1})
+    backend.configure.assert_called_once_with({"cpus": 1})
     assert backend.instance_id == runtime.instance_id
     backend.cleanup_orphaned_containers.assert_awaited_once_with(runtime.instance_id)
 
@@ -250,8 +250,10 @@ async def test_initialize_applies_config_selects_and_cleans_orphans(logger):
 async def test_initialize_orphan_cleanup_failure_is_swallowed(logger):
     """A failing orphan cleanup must not raise out of initialize()."""
     backend = FakeBackend(logger)
-    backend.cleanup_orphaned_containers = mock.AsyncMock(side_effect=RuntimeError('boom'))
-    with mock.patch('os.getenv', return_value=''):
+    backend.cleanup_orphaned_containers = mock.AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         await runtime.initialize()  # should not raise
     assert runtime._backend is backend
@@ -263,13 +265,13 @@ async def test_initialize_orphan_cleanup_failure_is_swallowed(logger):
 @pytest.mark.anyio
 async def test_create_session_creates_new(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        info = await runtime.create_session(_make_spec('alpha'))
+        info = await runtime.create_session(_make_spec("alpha"))
 
     assert backend.started_sessions == 1
-    assert info['session_id'] == 'alpha'
-    assert info['backend_session_id'] == 'fake-1'
+    assert info["session_id"] == "alpha"
+    assert info["backend_session_id"] == "fake-1"
     assert len(runtime._sessions) == 1
 
 
@@ -277,13 +279,13 @@ async def test_create_session_creates_new(logger):
 async def test_create_session_reuses_existing(logger):
     """Same session_id + compatible spec reuses the live session."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        first = await runtime.create_session(_make_spec('beta'))
-        second = await runtime.create_session(_make_spec('beta'))
+        first = await runtime.create_session(_make_spec("beta"))
+        second = await runtime.create_session(_make_spec("beta"))
 
     assert backend.started_sessions == 1  # not started again
-    assert first['backend_session_id'] == second['backend_session_id'] == 'fake-1'
+    assert first["backend_session_id"] == second["backend_session_id"] == "fake-1"
     backend.is_session_alive.assert_awaited()  # liveness checked on reuse
 
 
@@ -291,14 +293,14 @@ async def test_create_session_reuses_existing(logger):
 async def test_reuse_recreates_when_backend_session_dead(logger):
     """If backend reports the session is dead, it is dropped and recreated."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        first = await runtime.create_session(_make_spec('gamma'))
+        first = await runtime.create_session(_make_spec("gamma"))
         backend._alive = False
-        second = await runtime.create_session(_make_spec('gamma'))
+        second = await runtime.create_session(_make_spec("gamma"))
 
-    assert first['backend_session_id'] == 'fake-1'
-    assert second['backend_session_id'] == 'fake-2'
+    assert first["backend_session_id"] == "fake-1"
+    assert second["backend_session_id"] == "fake-2"
     assert backend.started_sessions == 2
     assert backend.stopped_sessions == 1
 
@@ -308,24 +310,24 @@ async def test_reuse_recreates_when_backend_session_dead(logger):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    'field,changed',
+    "field,changed",
     [
-        ('image', 'other/image:latest'),
-        ('memory_mb', 1024),
-        ('cpus', 2.0),
-        ('pids_limit', 64),
-        ('workspace_quota_mb', 50),
-        ('persistent', True),
+        ("image", "other/image:latest"),
+        ("memory_mb", 1024),
+        ("cpus", 2.0),
+        ("pids_limit", 64),
+        ("workspace_quota_mb", 50),
+        ("persistent", True),
     ],
 )
 async def test_incompatible_reuse_raises_conflict(logger, field, changed):
     """Reusing a session_id with a differing _COMPAT_FIELD raises conflict."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('delta'))
+        await runtime.create_session(_make_spec("delta"))
         with pytest.raises(BoxSessionConflictError) as exc_info:
-            await runtime.create_session(_make_spec('delta', **{field: changed}))
+            await runtime.create_session(_make_spec("delta", **{field: changed}))
 
     assert field in str(exc_info.value)
     # Conflict means we did not start a second backend session.
@@ -336,11 +338,13 @@ async def test_incompatible_reuse_raises_conflict(logger, field, changed):
 async def test_compatible_reuse_does_not_raise(logger):
     """Differing-but-non-compat field (e.g. cmd/timeout) still reuses."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('eps', cmd='echo a', timeout_sec=10))
-        info = await runtime.create_session(_make_spec('eps', cmd='echo b', timeout_sec=99))
-    assert info['backend_session_id'] == 'fake-1'
+        await runtime.create_session(_make_spec("eps", cmd="echo a", timeout_sec=10))
+        info = await runtime.create_session(
+            _make_spec("eps", cmd="echo b", timeout_sec=99)
+        )
+    assert info["backend_session_id"] == "fake-1"
     assert backend.started_sessions == 1
 
 
@@ -350,37 +354,37 @@ async def test_compatible_reuse_does_not_raise(logger):
 @pytest.mark.anyio
 async def test_execute_empty_cmd_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxValidationError):
-            await runtime.execute(_make_spec('z', cmd=''))
+            await runtime.execute(_make_spec("z", cmd=""))
 
 
 @pytest.mark.anyio
 async def test_execute_creates_session_and_runs(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        result = await runtime.execute(_make_spec('run1', cmd='echo hi'))
+        result = await runtime.execute(_make_spec("run1", cmd="echo hi"))
 
     assert isinstance(result, BoxExecutionResult)
     assert result.status == BoxExecutionStatus.COMPLETED
     assert result.exit_code == 0
-    assert result.stdout == 'hello'
+    assert result.stdout == "hello"
     assert backend.started_sessions == 1
-    assert backend.exec_calls == [('fake-1', 'echo hi')]
+    assert backend.exec_calls == [("fake-1", "echo hi")]
     assert len(runtime._sessions) == 1
 
 
 @pytest.mark.anyio
 async def test_execute_updates_last_used_at(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('run2'))
-        before = runtime._sessions['run2'].info.last_used_at
-        await runtime.execute(_make_spec('run2', cmd='echo hi'))
-        after = runtime._sessions['run2'].info.last_used_at
+        await runtime.create_session(_make_spec("run2"))
+        before = runtime._sessions["run2"].info.last_used_at
+        await runtime.execute(_make_spec("run2", cmd="echo hi"))
+        after = runtime._sessions["run2"].info.last_used_at
     assert after >= before
 
 
@@ -390,12 +394,12 @@ async def test_execute_timeout_drops_session(logger):
     backend = FakeBackend(logger)
     backend.exec_status = BoxExecutionStatus.TIMED_OUT
     backend.exec_exit_code = None
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        result = await runtime.execute(_make_spec('to', cmd='sleep 999'))
+        result = await runtime.execute(_make_spec("to", cmd="sleep 999"))
 
     assert result.status == BoxExecutionStatus.TIMED_OUT
-    assert 'to' not in runtime._sessions
+    assert "to" not in runtime._sessions
     backend.stop_session.assert_awaited_once()
 
 
@@ -406,18 +410,18 @@ async def test_execute_timeout_drops_session(logger):
 async def test_reap_expired_sessions(logger):
     """Sessions idle past TTL are reaped on the next create/exec under lock."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend], session_ttl_sec=60)
-        await runtime.create_session(_make_spec('old'))
+        await runtime.create_session(_make_spec("old"))
         # Force the session to look stale.
         stale = dt.datetime.now(_UTC) - dt.timedelta(seconds=120)
-        runtime._sessions['old'].info.last_used_at = stale
+        runtime._sessions["old"].info.last_used_at = stale
 
         # Touching another session triggers reaping of expired ones.
-        await runtime.create_session(_make_spec('fresh'))
+        await runtime.create_session(_make_spec("fresh"))
 
-    assert 'old' not in runtime._sessions
-    assert 'fresh' in runtime._sessions
+    assert "old" not in runtime._sessions
+    assert "fresh" in runtime._sessions
     backend.stop_session.assert_awaited_once()
 
 
@@ -425,16 +429,16 @@ async def test_reap_expired_sessions(logger):
 async def test_reap_skips_persistent_sessions(logger):
     """Persistent sessions are never reaped even when idle."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend], session_ttl_sec=60)
-        await runtime.create_session(_make_spec('keep', persistent=True))
-        runtime._sessions['keep'].info.last_used_at = (
-            dt.datetime.now(_UTC) - dt.timedelta(seconds=999)
-        )
+        await runtime.create_session(_make_spec("keep", persistent=True))
+        runtime._sessions["keep"].info.last_used_at = dt.datetime.now(
+            _UTC
+        ) - dt.timedelta(seconds=999)
         async with runtime._lock:
             await runtime._reap_expired_sessions_locked()
 
-    assert 'keep' in runtime._sessions
+    assert "keep" in runtime._sessions
     backend.stop_session.assert_not_awaited()
 
 
@@ -442,16 +446,16 @@ async def test_reap_skips_persistent_sessions(logger):
 async def test_reap_disabled_when_ttl_non_positive(logger):
     """ttl <= 0 disables reaping entirely."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend], session_ttl_sec=0)
-        await runtime.create_session(_make_spec('immortal'))
-        runtime._sessions['immortal'].info.last_used_at = (
-            dt.datetime.now(_UTC) - dt.timedelta(days=7)
-        )
+        await runtime.create_session(_make_spec("immortal"))
+        runtime._sessions["immortal"].info.last_used_at = dt.datetime.now(
+            _UTC
+        ) - dt.timedelta(days=7)
         async with runtime._lock:
             await runtime._reap_expired_sessions_locked()
 
-    assert 'immortal' in runtime._sessions
+    assert "immortal" in runtime._sessions
     backend.stop_session.assert_not_awaited()
 
 
@@ -461,35 +465,35 @@ async def test_reap_disabled_when_ttl_non_positive(logger):
 @pytest.mark.anyio
 async def test_delete_unknown_session_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxSessionNotFoundError):
-            await runtime.delete_session('nope')
+            await runtime.delete_session("nope")
 
 
 @pytest.mark.anyio
 async def test_delete_session_stops_backend(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('del'))
-        await runtime.delete_session('del')
+        await runtime.create_session(_make_spec("del"))
+        await runtime.delete_session("del")
 
-    assert 'del' not in runtime._sessions
+    assert "del" not in runtime._sessions
     backend.stop_session.assert_awaited_once()
 
 
 @pytest.mark.anyio
 async def test_shutdown_drops_non_persistent_keeps_persistent(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('ephemeral'))
-        await runtime.create_session(_make_spec('persist', persistent=True))
+        await runtime.create_session(_make_spec("ephemeral"))
+        await runtime.create_session(_make_spec("persist", persistent=True))
         await runtime.shutdown()
 
-    assert 'ephemeral' not in runtime._sessions
-    assert 'persist' in runtime._sessions
+    assert "ephemeral" not in runtime._sessions
+    assert "persist" in runtime._sessions
     assert backend.stopped_sessions == 1
 
 
@@ -499,60 +503,60 @@ async def test_shutdown_drops_non_persistent_keeps_persistent(logger):
 @pytest.mark.anyio
 async def test_get_status_reports_sessions_and_ttl(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend], session_ttl_sec=42)
-        await runtime.create_session(_make_spec('a'))
-        await runtime.create_session(_make_spec('b'))
+        await runtime.create_session(_make_spec("a"))
+        await runtime.create_session(_make_spec("b"))
         status = await runtime.get_status()
 
-    assert status['active_sessions'] == 2
-    assert status['session_ttl_sec'] == 42
-    assert status['managed_processes'] == 0
-    assert status['backend'] == {'name': 'fake', 'available': True}
+    assert status["active_sessions"] == 2
+    assert status["session_ttl_sec"] == 42
+    assert status["managed_processes"] == 0
+    assert status["backend"] == {"name": "fake", "available": True}
 
 
 @pytest.mark.anyio
 async def test_get_backend_info_unavailable(logger):
     """is_available raising → reported as unavailable."""
     backend = FakeBackend(logger)
-    backend.is_available = mock.AsyncMock(side_effect=RuntimeError('probe failed'))
-    with mock.patch('os.getenv', return_value=''):
+    backend.is_available = mock.AsyncMock(side_effect=RuntimeError("probe failed"))
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         runtime._backend = backend
         info = await runtime.get_backend_info()
-    assert info == {'name': 'fake', 'available': False}
+    assert info == {"name": "fake", "available": False}
 
 
 @pytest.mark.anyio
 async def test_get_backend_info_none_when_no_backend(logger):
     """All backends unavailable → backend info reports name None / not available."""
     backend = FakeBackend(logger, available=False)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         info = await runtime.get_backend_info()
-    assert info == {'name': None, 'available': False}
+    assert info == {"name": None, "available": False}
 
 
 @pytest.mark.anyio
 async def test_get_sessions_and_get_session(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('one'))
+        await runtime.create_session(_make_spec("one"))
         sessions = runtime.get_sessions()
-        single = runtime.get_session('one')
+        single = runtime.get_session("one")
 
     assert len(sessions) == 1
-    assert single['session_id'] == 'one'
-    assert 'managed_processes' not in single  # none started
+    assert single["session_id"] == "one"
+    assert "managed_processes" not in single  # none started
 
 
 def test_get_session_unknown_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxSessionNotFoundError):
-            runtime.get_session('ghost')
+            runtime.get_session("ghost")
 
 
 # ── _get_backend / backend selection ────────────────────────────────────
@@ -560,9 +564,9 @@ def test_get_session_unknown_raises(logger):
 
 @pytest.mark.anyio
 async def test_get_backend_selects_first_available(logger):
-    unavailable = FakeBackend(logger, name='fake', available=False)
-    available = FakeBackend(logger, name='other', available=True)
-    with mock.patch('os.getenv', return_value=''):
+    unavailable = FakeBackend(logger, name="fake", available=False)
+    available = FakeBackend(logger, name="other", available=True)
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[unavailable, available])
         selected = await runtime._get_backend()
     assert selected is available
@@ -571,7 +575,7 @@ async def test_get_backend_selects_first_available(logger):
 @pytest.mark.anyio
 async def test_get_backend_raises_when_none_available(logger):
     backend = FakeBackend(logger, available=False)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxBackendUnavailableError):
             await runtime._get_backend()
@@ -580,7 +584,7 @@ async def test_get_backend_raises_when_none_available(logger):
 @pytest.mark.anyio
 async def test_get_backend_caches_selection(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         first = await runtime._get_backend()
         second = await runtime._get_backend()
@@ -592,21 +596,21 @@ async def test_get_backend_caches_selection(logger):
 @pytest.mark.anyio
 async def test_select_backend_forced_local_picks_local_name(logger):
     """box.backend=local fans out to local container backends."""
-    nsjail = FakeBackend(logger, name='nsjail', available=True)
-    e2b = FakeBackend(logger, name='e2b', available=True)
-    with mock.patch('os.getenv', return_value=''):
+    nsjail = FakeBackend(logger, name="nsjail", available=True)
+    e2b = FakeBackend(logger, name="e2b", available=True)
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[e2b, nsjail])
-        runtime.init({'backend': 'local'})
+        runtime.init({"backend": "local"})
         selected = await runtime._select_backend()
     assert selected is nsjail
 
 
 @pytest.mark.anyio
 async def test_select_backend_forced_local_no_local_returns_none(logger):
-    e2b = FakeBackend(logger, name='e2b', available=True)
-    with mock.patch('os.getenv', return_value=''):
+    e2b = FakeBackend(logger, name="e2b", available=True)
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[e2b])
-        runtime.init({'backend': 'local'})
+        runtime.init({"backend": "local"})
         selected = await runtime._select_backend()
     assert selected is None
 
@@ -614,10 +618,10 @@ async def test_select_backend_forced_local_no_local_returns_none(logger):
 @pytest.mark.anyio
 async def test_select_backend_probe_exception_skips_backend(logger):
     """A backend whose probe raises is skipped in favour of the next one."""
-    bad = FakeBackend(logger, name='bad', available=True)
-    bad.is_available = mock.AsyncMock(side_effect=RuntimeError('probe blew up'))
-    good = FakeBackend(logger, name='good', available=True)
-    with mock.patch('os.getenv', return_value=''):
+    bad = FakeBackend(logger, name="bad", available=True)
+    bad.is_available = mock.AsyncMock(side_effect=RuntimeError("probe blew up"))
+    good = FakeBackend(logger, name="good", available=True)
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[bad, good])
         selected = await runtime._select_backend()
     assert selected is good
@@ -635,47 +639,47 @@ async def _settle():
 @pytest.mark.anyio
 async def test_start_managed_process_creates_and_reports_running(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('mp'))
+        await runtime.create_session(_make_spec("mp"))
         info = await runtime.start_managed_process(
-            'mp', BoxManagedProcessSpec(command='sleep', args=['1'])
+            "mp", BoxManagedProcessSpec(command="sleep", args=["1"])
         )
         await _settle()
 
-        assert info['session_id'] == 'mp'
-        assert info['process_id'] == 'default'
-        assert info['status'] == BoxManagedProcessStatus.RUNNING.value
+        assert info["session_id"] == "mp"
+        assert info["process_id"] == "default"
+        assert info["status"] == BoxManagedProcessStatus.RUNNING.value
 
         # get_managed_process returns the same view.
-        got = runtime.get_managed_process('mp', 'default')
-        assert got['command'] == 'sleep'
-        assert got['args'] == ['1']
+        got = runtime.get_managed_process("mp", "default")
+        assert got["command"] == "sleep"
+        assert got["args"] == ["1"]
 
         # get_session surfaces the managed process.
-        session = runtime.get_session('mp')
-        assert 'managed_processes' in session
-        assert 'managed_process' in session  # 'default' alias
-        assert session['managed_process']['status'] == (
+        session = runtime.get_session("mp")
+        assert "managed_processes" in session
+        assert "managed_process" in session  # 'default' alias
+        assert session["managed_process"]["status"] == (
             BoxManagedProcessStatus.RUNNING.value
         )
 
         # get_status counts the running managed process.
         status = await runtime.get_status()
-        assert status['managed_processes'] == 1
+        assert status["managed_processes"] == 1
 
         # Clean up: stop the process and its background tasks.
-        await runtime.stop_managed_process('mp', 'default')
+        await runtime.stop_managed_process("mp", "default")
 
 
 @pytest.mark.anyio
 async def test_start_managed_process_unknown_session_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxSessionNotFoundError):
             await runtime.start_managed_process(
-                'ghost', BoxManagedProcessSpec(command='sleep')
+                "ghost", BoxManagedProcessSpec(command="sleep")
             )
 
 
@@ -683,94 +687,94 @@ async def test_start_managed_process_unknown_session_raises(logger):
 async def test_start_managed_process_replaces_running_one(logger):
     """Starting a process when one is already running terminates the old one."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('mp2'))
+        await runtime.create_session(_make_spec("mp2"))
         await runtime.start_managed_process(
-            'mp2', BoxManagedProcessSpec(command='first')
+            "mp2", BoxManagedProcessSpec(command="first")
         )
         await _settle()
         first_proc = backend.last_process
 
         await runtime.start_managed_process(
-            'mp2', BoxManagedProcessSpec(command='second')
+            "mp2", BoxManagedProcessSpec(command="second")
         )
         await _settle()
 
         # The stale process was terminated before the new one started.
         assert first_proc.returncode is not None
-        got = runtime.get_managed_process('mp2', 'default')
-        assert got['command'] == 'second'
+        got = runtime.get_managed_process("mp2", "default")
+        assert got["command"] == "second"
 
-        await runtime.stop_managed_process('mp2', 'default')
+        await runtime.stop_managed_process("mp2", "default")
 
 
 @pytest.mark.anyio
 async def test_get_managed_process_not_found_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('mp3'))
+        await runtime.create_session(_make_spec("mp3"))
         with pytest.raises(BoxManagedProcessNotFoundError):
-            runtime.get_managed_process('mp3', 'default')
+            runtime.get_managed_process("mp3", "default")
 
 
 def test_get_managed_process_unknown_session_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxSessionNotFoundError):
-            runtime.get_managed_process('ghost', 'default')
+            runtime.get_managed_process("ghost", "default")
 
 
 @pytest.mark.anyio
 async def test_stop_managed_process_terminates_and_marks_exited(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('mp4'))
+        await runtime.create_session(_make_spec("mp4"))
         await runtime.start_managed_process(
-            'mp4', BoxManagedProcessSpec(command='daemon')
+            "mp4", BoxManagedProcessSpec(command="daemon")
         )
         await _settle()
         proc = backend.last_process
 
-        await runtime.stop_managed_process('mp4', 'default')
+        await runtime.stop_managed_process("mp4", "default")
 
         assert proc.returncode is not None
         # The process entry was removed from the session.
         with pytest.raises(BoxManagedProcessNotFoundError):
-            runtime.get_managed_process('mp4', 'default')
+            runtime.get_managed_process("mp4", "default")
 
 
 @pytest.mark.anyio
 async def test_stop_managed_process_unknown_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('mp5'))
+        await runtime.create_session(_make_spec("mp5"))
         with pytest.raises(BoxManagedProcessNotFoundError):
-            await runtime.stop_managed_process('mp5', 'default')
+            await runtime.stop_managed_process("mp5", "default")
 
 
 @pytest.mark.anyio
 async def test_stop_managed_process_unknown_session_raises(logger):
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
         with pytest.raises(BoxSessionNotFoundError):
-            await runtime.stop_managed_process('ghost', 'default')
+            await runtime.stop_managed_process("ghost", "default")
 
 
 @pytest.mark.anyio
 async def test_watch_managed_process_marks_exit_on_natural_finish(logger):
     """When the underlying process exits, the watcher records the exit code."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        await runtime.create_session(_make_spec('mp6'))
+        await runtime.create_session(_make_spec("mp6"))
         await runtime.start_managed_process(
-            'mp6', BoxManagedProcessSpec(command='quickexit')
+            "mp6", BoxManagedProcessSpec(command="quickexit")
         )
         await _settle()
 
@@ -778,28 +782,28 @@ async def test_watch_managed_process_marks_exit_on_natural_finish(logger):
         proc.finish(code=3)
         await _settle()
 
-        got = runtime.get_managed_process('mp6', 'default')
-        assert got['status'] == BoxManagedProcessStatus.EXITED.value
-        assert got['exit_code'] == 3
+        got = runtime.get_managed_process("mp6", "default")
+        assert got["status"] == BoxManagedProcessStatus.EXITED.value
+        assert got["exit_code"] == 3
 
 
 @pytest.mark.anyio
 async def test_reap_skips_session_with_running_managed_process(logger):
     """An idle session is NOT reaped while it has a running managed process."""
     backend = FakeBackend(logger)
-    with mock.patch('os.getenv', return_value=''):
+    with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend], session_ttl_sec=60)
-        await runtime.create_session(_make_spec('mp7'))
+        await runtime.create_session(_make_spec("mp7"))
         await runtime.start_managed_process(
-            'mp7', BoxManagedProcessSpec(command='daemon')
+            "mp7", BoxManagedProcessSpec(command="daemon")
         )
         await _settle()
-        runtime._sessions['mp7'].info.last_used_at = (
-            dt.datetime.now(_UTC) - dt.timedelta(seconds=999)
-        )
+        runtime._sessions["mp7"].info.last_used_at = dt.datetime.now(
+            _UTC
+        ) - dt.timedelta(seconds=999)
 
         async with runtime._lock:
             await runtime._reap_expired_sessions_locked()
 
-        assert 'mp7' in runtime._sessions  # protected by running process
-        await runtime.stop_managed_process('mp7', 'default')
+        assert "mp7" in runtime._sessions  # protected by running process
+        await runtime.stop_managed_process("mp7", "default")

--- a/tests/box/test_server.py
+++ b/tests/box/test_server.py
@@ -316,9 +316,7 @@ async def test_create_session_success(handler, mock_runtime):
 
 
 async def test_create_session_invalid_spec(handler, mock_runtime):
-    resp = await _invoke(
-        handler, LangBotToBoxAction.CREATE_SESSION, {"cmd": "echo hi"}
-    )
+    resp = await _invoke(handler, LangBotToBoxAction.CREATE_SESSION, {"cmd": "echo hi"})
     assert resp.code == 1
     assert "BoxValidationError" in resp.message
     mock_runtime.create_session.assert_not_awaited()
@@ -329,9 +327,7 @@ async def test_create_session_invalid_spec(handler, mock_runtime):
 
 async def test_get_session(handler, mock_runtime):
     mock_runtime.get_session.return_value = {"session_id": "abc"}
-    resp = await _invoke(
-        handler, LangBotToBoxAction.GET_SESSION, {"session_id": "abc"}
-    )
+    resp = await _invoke(handler, LangBotToBoxAction.GET_SESSION, {"session_id": "abc"})
     assert resp.code == 0
     assert resp.data == {"session_id": "abc"}
     mock_runtime.get_session.assert_called_once_with("abc")
@@ -480,9 +476,7 @@ async def test_update_skill_error(handler, mock_runtime):
 
 
 async def test_delete_skill_success(handler, mock_runtime):
-    resp = await _invoke(
-        handler, LangBotToBoxAction.DELETE_SKILL, {"name": "demo"}
-    )
+    resp = await _invoke(handler, LangBotToBoxAction.DELETE_SKILL, {"name": "demo"})
     assert resp.code == 0
     assert resp.data == {"deleted": True}
     mock_runtime.skill_store.delete_skill.assert_called_once_with("demo")
@@ -490,9 +484,7 @@ async def test_delete_skill_success(handler, mock_runtime):
 
 async def test_delete_skill_error(handler, mock_runtime):
     mock_runtime.skill_store.delete_skill.side_effect = RuntimeError("locked")
-    resp = await _invoke(
-        handler, LangBotToBoxAction.DELETE_SKILL, {"name": "demo"}
-    )
+    resp = await _invoke(handler, LangBotToBoxAction.DELETE_SKILL, {"name": "demo"})
     assert resp.code == 1
     assert "BoxValidationError" in resp.message
 
@@ -516,9 +508,7 @@ async def test_scan_skill_directory_error(handler, mock_runtime):
 
 
 async def test_list_skill_files_uses_defaults(handler, mock_runtime):
-    resp = await _invoke(
-        handler, LangBotToBoxAction.LIST_SKILL_FILES, {"name": "demo"}
-    )
+    resp = await _invoke(handler, LangBotToBoxAction.LIST_SKILL_FILES, {"name": "demo"})
     assert resp.code == 0
     mock_runtime.skill_store.list_skill_files.assert_called_once_with(
         "demo", ".", include_hidden=False, max_entries=200
@@ -543,9 +533,7 @@ async def test_list_skill_files_passes_overrides(handler, mock_runtime):
 
 async def test_list_skill_files_error(handler, mock_runtime):
     mock_runtime.skill_store.list_skill_files.side_effect = ValueError("nope")
-    resp = await _invoke(
-        handler, LangBotToBoxAction.LIST_SKILL_FILES, {"name": "demo"}
-    )
+    resp = await _invoke(handler, LangBotToBoxAction.LIST_SKILL_FILES, {"name": "demo"})
     assert resp.code == 1
     assert "BoxValidationError" in resp.message
 
@@ -730,10 +718,7 @@ def test_create_app_registers_routes_and_runtime(mock_runtime):
     assert isinstance(app, web.Application)
     assert app["runtime"] is mock_runtime
 
-    routes = {
-        (route.method, route.resource.canonical)
-        for route in app.router.routes()
-    }
+    routes = {(route.method, route.resource.canonical) for route in app.router.routes()}
     assert ("GET", "/rpc/ws") in routes
     assert (
         "GET",

--- a/tests/box/test_skill_store.py
+++ b/tests/box/test_skill_store.py
@@ -13,60 +13,64 @@ from langbot_plugin.box.skill_store import (
 )
 
 
-def _skill_zip(name: str = 'demo') -> bytes:
+def _skill_zip(name: str = "demo") -> bytes:
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, 'w') as zf:
+    with zipfile.ZipFile(buffer, "w") as zf:
         zf.writestr(
-            f'{name}/SKILL.md',
-            '---\n'
-            f'name: {name}\n'
-            f'display_name: {name.title()}\n'
-            'description: Demo skill\n'
-            '---\n\n'
-            'Use this skill for tests.\n',
+            f"{name}/SKILL.md",
+            "---\n"
+            f"name: {name}\n"
+            f"display_name: {name.title()}\n"
+            "description: Demo skill\n"
+            "---\n\n"
+            "Use this skill for tests.\n",
         )
-        zf.writestr(f'{name}/notes.txt', 'hello')
+        zf.writestr(f"{name}/notes.txt", "hello")
     return buffer.getvalue()
 
 
 def _nested_skill_zip() -> bytes:
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, 'w') as zf:
+    with zipfile.ZipFile(buffer, "w") as zf:
         zf.writestr(
-            'repo/packages/alpha/SKILL.md',
-            '---\nname: alpha\ndisplay_name: Alpha\n---\n\nAlpha instructions.\n',
+            "repo/packages/alpha/SKILL.md",
+            "---\nname: alpha\ndisplay_name: Alpha\n---\n\nAlpha instructions.\n",
         )
         zf.writestr(
-            'repo/packages/beta/SKILL.md',
-            '---\nname: beta\ndisplay_name: Beta\n---\n\nBeta instructions.\n',
+            "repo/packages/beta/SKILL.md",
+            "---\nname: beta\ndisplay_name: Beta\n---\n\nBeta instructions.\n",
         )
     return buffer.getvalue()
 
 
-def _make_store(tmp_path, skills_root: str = 'skills') -> BoxSkillStore:
-    return BoxSkillStore({
-        'local': {
-            'host_root': str(tmp_path),
-            'skills_root': skills_root,
+def _make_store(tmp_path, skills_root: str = "skills") -> BoxSkillStore:
+    return BoxSkillStore(
+        {
+            "local": {
+                "host_root": str(tmp_path),
+                "skills_root": skills_root,
+            }
         }
-    })
+    )
 
 
-def _write_skill_dir(base, name: str, *, frontmatter: bool = True, instructions: str = 'Body.') -> str:
+def _write_skill_dir(
+    base, name: str, *, frontmatter: bool = True, instructions: str = "Body."
+) -> str:
     """Create a SKILL.md package directory on disk, return its path."""
     skill_dir = base / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     if frontmatter:
         content = (
-            '---\n'
-            f'name: {name}\n'
-            f'display_name: {name.title()}\n'
-            'description: A test skill\n'
-            f'---\n\n{instructions}\n'
+            "---\n"
+            f"name: {name}\n"
+            f"display_name: {name.title()}\n"
+            "description: A test skill\n"
+            f"---\n\n{instructions}\n"
         )
     else:
-        content = instructions + '\n'
-    (skill_dir / 'SKILL.md').write_text(content, encoding='utf-8')
+        content = instructions + "\n"
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return str(skill_dir)
 
 
@@ -74,69 +78,75 @@ def _write_skill_dir(base, name: str, *, frontmatter: bool = True, instructions:
 
 
 def test_skill_store_installs_zip_under_configured_relative_skills_root(tmp_path):
-    store = BoxSkillStore({
-        'local': {
-            'host_root': str(tmp_path),
-            'skills_root': 'custom-skills',
+    store = BoxSkillStore(
+        {
+            "local": {
+                "host_root": str(tmp_path),
+                "skills_root": "custom-skills",
+            }
         }
-    })
+    )
 
-    preview = store.preview_zip_upload(file_bytes=_skill_zip(), filename='demo.zip')
-    assert preview[0]['package_root'] == str(tmp_path / 'custom-skills' / 'demo-upload')
+    preview = store.preview_zip_upload(file_bytes=_skill_zip(), filename="demo.zip")
+    assert preview[0]["package_root"] == str(tmp_path / "custom-skills" / "demo-upload")
 
-    installed = store.install_zip_upload(file_bytes=_skill_zip(), filename='demo.zip')
-    assert installed[0]['name'] == 'demo'
-    assert installed[0]['package_root'] == str(tmp_path / 'custom-skills' / 'demo-upload')
+    installed = store.install_zip_upload(file_bytes=_skill_zip(), filename="demo.zip")
+    assert installed[0]["name"] == "demo"
+    assert installed[0]["package_root"] == str(
+        tmp_path / "custom-skills" / "demo-upload"
+    )
 
-    files = store.list_skill_files('demo')
-    assert {entry['name'] for entry in files['entries']} == {'SKILL.md', 'notes.txt'}
+    files = store.list_skill_files("demo")
+    assert {entry["name"] for entry in files["entries"]} == {"SKILL.md", "notes.txt"}
 
-    content = store.read_skill_file('demo', 'notes.txt')
-    assert content['content'] == 'hello'
+    content = store.read_skill_file("demo", "notes.txt")
+    assert content["content"] == "hello"
 
-    store.write_skill_file('demo', 'notes.txt', 'updated')
-    assert store.read_skill_file('demo', 'notes.txt')['content'] == 'updated'
+    store.write_skill_file("demo", "notes.txt", "updated")
+    assert store.read_skill_file("demo", "notes.txt")["content"] == "updated"
 
 
 def test_skill_store_supports_source_subdir_before_selecting_candidates(tmp_path):
-    store = BoxSkillStore({
-        'local': {
-            'host_root': str(tmp_path),
-            'skills_root': 'skills',
+    store = BoxSkillStore(
+        {
+            "local": {
+                "host_root": str(tmp_path),
+                "skills_root": "skills",
+            }
         }
-    })
+    )
 
     preview = store.preview_zip_upload(
         file_bytes=_nested_skill_zip(),
-        filename='repo.zip',
-        source_subdir='packages',
+        filename="repo.zip",
+        source_subdir="packages",
     )
 
-    assert [skill['source_path'] for skill in preview] == ['alpha', 'beta']
+    assert [skill["source_path"] for skill in preview] == ["alpha", "beta"]
 
     installed = store.install_zip_upload(
         file_bytes=_nested_skill_zip(),
-        filename='repo.zip',
-        source_subdir='packages',
-        source_paths=['beta'],
+        filename="repo.zip",
+        source_subdir="packages",
+        source_paths=["beta"],
     )
 
-    assert [skill['name'] for skill in installed] == ['beta']
-    assert installed[0]['package_root'] == str(tmp_path / 'skills' / 'repo-beta-upload')
+    assert [skill["name"] for skill in installed] == ["beta"]
+    assert installed[0]["package_root"] == str(tmp_path / "skills" / "repo-beta-upload")
 
 
 # ── parse_frontmatter ───────────────────────────────────────────────────
 
 
 def test_parse_frontmatter_extracts_metadata_and_instructions():
-    content = '---\nname: foo\ndescription: bar\n---\n\nDo the thing.\n'
+    content = "---\nname: foo\ndescription: bar\n---\n\nDo the thing.\n"
     metadata, instructions = parse_frontmatter(content)
-    assert metadata == {'name': 'foo', 'description': 'bar'}
-    assert instructions == 'Do the thing.\n'
+    assert metadata == {"name": "foo", "description": "bar"}
+    assert instructions == "Do the thing.\n"
 
 
 def test_parse_frontmatter_without_leading_marker_returns_whole_body():
-    content = 'no frontmatter here\nsecond line\n'
+    content = "no frontmatter here\nsecond line\n"
     metadata, instructions = parse_frontmatter(content)
     assert metadata == {}
     assert instructions == content
@@ -144,94 +154,96 @@ def test_parse_frontmatter_without_leading_marker_returns_whole_body():
 
 def test_parse_frontmatter_first_line_not_marker():
     # Starts with '---' but first stripped line is not exactly '---'.
-    content = '--- header\nname: foo\n---\nbody'
+    content = "--- header\nname: foo\n---\nbody"
     metadata, instructions = parse_frontmatter(content)
     assert metadata == {}
     assert instructions == content
 
 
 def test_parse_frontmatter_unterminated_block_returns_whole_body():
-    content = '---\nname: foo\nno closing marker\n'
+    content = "---\nname: foo\nno closing marker\n"
     metadata, instructions = parse_frontmatter(content)
     assert metadata == {}
     assert instructions == content
 
 
 def test_parse_frontmatter_non_dict_yaml_is_discarded():
-    content = '---\n- just\n- a\n- list\n---\nbody text'
+    content = "---\n- just\n- a\n- list\n---\nbody text"
     metadata, instructions = parse_frontmatter(content)
     assert metadata == {}
-    assert instructions == 'body text'
+    assert instructions == "body text"
 
 
 def test_parse_frontmatter_empty_metadata_block():
-    content = '---\n---\nbody only'
+    content = "---\n---\nbody only"
     metadata, instructions = parse_frontmatter(content)
     assert metadata == {}
-    assert instructions == 'body only'
+    assert instructions == "body only"
 
 
 # ── build_skill_md ──────────────────────────────────────────────────────
 
 
 def test_build_skill_md_roundtrips_with_parse_frontmatter():
-    metadata = {'name': 'foo', 'display_name': 'Foo', 'description': 'desc'}
-    md = build_skill_md(metadata, 'Hello instructions.')
-    assert md.startswith('---\n')
+    metadata = {"name": "foo", "display_name": "Foo", "description": "desc"}
+    md = build_skill_md(metadata, "Hello instructions.")
+    assert md.startswith("---\n")
     parsed_meta, parsed_instructions = parse_frontmatter(md)
     assert parsed_meta == metadata
-    assert parsed_instructions == 'Hello instructions.'
+    assert parsed_instructions == "Hello instructions."
 
 
 def test_build_skill_md_without_metadata_returns_instructions_only():
-    md = build_skill_md({}, 'just instructions')
-    assert md == 'just instructions'
+    md = build_skill_md({}, "just instructions")
+    assert md == "just instructions"
 
 
 def test_build_skill_md_drops_blank_and_none_fields():
-    metadata = {'name': 'foo', 'display_name': '   ', 'description': None}
-    md = build_skill_md(metadata, 'body')
+    metadata = {"name": "foo", "display_name": "   ", "description": None}
+    md = build_skill_md(metadata, "body")
     parsed_meta, _ = parse_frontmatter(md)
-    assert parsed_meta == {'name': 'foo'}
+    assert parsed_meta == {"name": "foo"}
 
 
 def test_build_skill_md_ignores_unknown_fields():
-    metadata = {'name': 'foo', 'package_root': '/should/not/appear'}
-    md = build_skill_md(metadata, 'body')
+    metadata = {"name": "foo", "package_root": "/should/not/appear"}
+    md = build_skill_md(metadata, "body")
     parsed_meta, _ = parse_frontmatter(md)
-    assert parsed_meta == {'name': 'foo'}
+    assert parsed_meta == {"name": "foo"}
 
 
 # ── root resolution ─────────────────────────────────────────────────────
 
 
 def test_root_uses_configured_absolute_host_root(tmp_path):
-    store = _make_store(tmp_path, skills_root='my-skills')
-    assert store.root == str((tmp_path / 'my-skills').resolve())
+    store = _make_store(tmp_path, skills_root="my-skills")
+    assert store.root == str((tmp_path / "my-skills").resolve())
 
 
 def test_root_defaults_when_config_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     store = BoxSkillStore()
-    expected = str((tmp_path / 'data' / 'box' / 'skills').resolve())
+    expected = str((tmp_path / "data" / "box" / "skills").resolve())
     assert store.root == expected
 
 
 def test_root_absolute_skills_root_overrides_host_root(tmp_path):
-    abs_skills = tmp_path / 'elsewhere' / 'skills'
-    store = BoxSkillStore({
-        'local': {
-            'host_root': str(tmp_path / 'host'),
-            'skills_root': str(abs_skills),
+    abs_skills = tmp_path / "elsewhere" / "skills"
+    store = BoxSkillStore(
+        {
+            "local": {
+                "host_root": str(tmp_path / "host"),
+                "skills_root": str(abs_skills),
+            }
         }
-    })
+    )
     assert store.root == str(abs_skills.resolve())
 
 
 def test_update_config_changes_root(tmp_path):
     store = BoxSkillStore()
-    store.update_config({'local': {'host_root': str(tmp_path), 'skills_root': 'sk'}})
-    assert store.root == str((tmp_path / 'sk').resolve())
+    store.update_config({"local": {"host_root": str(tmp_path), "skills_root": "sk"}})
+    assert store.root == str((tmp_path / "sk").resolve())
 
 
 # ── list_skills / get_skill ─────────────────────────────────────────────
@@ -245,71 +257,79 @@ def test_list_skills_on_empty_root_creates_dir_and_returns_empty(tmp_path):
 
 def test_list_skills_returns_managed_skills_sorted_by_updated_at(tmp_path):
     store = _make_store(tmp_path)
-    root = tmp_path / 'skills'
-    older = _write_skill_dir(root, 'older')
-    _write_skill_dir(root, 'newer')
+    root = tmp_path / "skills"
+    older = _write_skill_dir(root, "older")
+    _write_skill_dir(root, "newer")
     # Force ordering by mtime: older skill in the past.
-    os.utime(os.path.join(older, 'SKILL.md'), (1000, 1000))
+    os.utime(os.path.join(older, "SKILL.md"), (1000, 1000))
 
     skills = store.list_skills()
-    names = [s['name'] for s in skills]
-    assert names == ['newer', 'older']
+    names = [s["name"] for s in skills]
+    assert names == ["newer", "older"]
     # Serialized form exposes only public fields.
     assert set(skills[0].keys()) <= {
-        'name', 'display_name', 'description', 'instructions',
-        'package_root', 'entry_file', 'created_at', 'updated_at',
+        "name",
+        "display_name",
+        "description",
+        "instructions",
+        "package_root",
+        "entry_file",
+        "created_at",
+        "updated_at",
     }
-    assert all('source_path' not in s for s in skills)
+    assert all("source_path" not in s for s in skills)
 
 
 def test_list_skills_skips_corrupt_entries(tmp_path):
     store = _make_store(tmp_path)
-    root = tmp_path / 'skills'
-    _write_skill_dir(root, 'good')
+    root = tmp_path / "skills"
+    _write_skill_dir(root, "good")
     # A directory whose SKILL.md cannot be decoded as UTF-8 should be skipped,
     # not crash list_skills.
-    bad_dir = root / 'bad'
+    bad_dir = root / "bad"
     bad_dir.mkdir(parents=True)
-    (bad_dir / 'SKILL.md').write_bytes(b'\xff\xfe\x00bad')
+    (bad_dir / "SKILL.md").write_bytes(b"\xff\xfe\x00bad")
 
-    names = [s['name'] for s in store.list_skills()]
-    assert 'good' in names
-    assert 'bad' not in names
+    names = [s["name"] for s in store.list_skills()]
+    assert "good" in names
+    assert "bad" not in names
 
 
 def test_get_skill_returns_match_and_none_for_missing(tmp_path):
     store = _make_store(tmp_path)
-    _write_skill_dir(tmp_path / 'skills', 'alpha')
-    found = store.get_skill('alpha')
+    _write_skill_dir(tmp_path / "skills", "alpha")
+    found = store.get_skill("alpha")
     assert found is not None
-    assert found['name'] == 'alpha'
-    assert store.get_skill('does-not-exist') is None
+    assert found["name"] == "alpha"
+    assert store.get_skill("does-not-exist") is None
 
 
 def test_load_skill_package_falls_back_to_dir_name_without_frontmatter(tmp_path):
     store = _make_store(tmp_path)
-    _write_skill_dir(tmp_path / 'skills', 'plainskill', frontmatter=False, instructions='Just a body')
-    skill = store.get_skill('plainskill')
+    _write_skill_dir(
+        tmp_path / "skills", "plainskill", frontmatter=False, instructions="Just a body"
+    )
+    skill = store.get_skill("plainskill")
     assert skill is not None
-    assert skill['name'] == 'plainskill'
-    assert skill['display_name'] == 'plainskill'
-    assert skill['description'] == ''
-    assert 'Just a body' in skill['instructions']
+    assert skill["name"] == "plainskill"
+    assert skill["display_name"] == "plainskill"
+    assert skill["description"] == ""
+    assert "Just a body" in skill["instructions"]
 
 
 def test_load_skill_package_supports_lowercase_entry_file(tmp_path):
     store = _make_store(tmp_path)
-    skill_dir = tmp_path / 'skills' / 'lower'
+    skill_dir = tmp_path / "skills" / "lower"
     skill_dir.mkdir(parents=True)
-    (skill_dir / 'skill.md').write_text(
-        '---\nname: lower\n---\n\nbody\n', encoding='utf-8'
+    (skill_dir / "skill.md").write_text(
+        "---\nname: lower\n---\n\nbody\n", encoding="utf-8"
     )
-    skill = store.get_skill('lower')
+    skill = store.get_skill("lower")
     assert skill is not None
     # Entry file is one of the accepted SKILL.md spellings (case-insensitive
     # filesystems may report either casing).
-    assert skill['entry_file'].lower() == 'skill.md'
-    assert 'body' in skill['instructions']
+    assert skill["entry_file"].lower() == "skill.md"
+    assert "body" in skill["instructions"]
 
 
 # ── create_skill ────────────────────────────────────────────────────────
@@ -317,56 +337,58 @@ def test_load_skill_package_supports_lowercase_entry_file(tmp_path):
 
 def test_create_skill_minimal_managed(tmp_path):
     store = _make_store(tmp_path)
-    created = store.create_skill({
-        'name': 'fresh',
-        'display_name': 'Fresh Skill',
-        'description': 'desc',
-        'instructions': 'do stuff',
-    })
-    assert created['name'] == 'fresh'
-    assert created['display_name'] == 'Fresh Skill'
-    assert created['description'] == 'desc'
-    assert created['instructions'].strip() == 'do stuff'
-    assert os.path.isfile(os.path.join(store.root, 'fresh', 'SKILL.md'))
+    created = store.create_skill(
+        {
+            "name": "fresh",
+            "display_name": "Fresh Skill",
+            "description": "desc",
+            "instructions": "do stuff",
+        }
+    )
+    assert created["name"] == "fresh"
+    assert created["display_name"] == "Fresh Skill"
+    assert created["description"] == "desc"
+    assert created["instructions"].strip() == "do stuff"
+    assert os.path.isfile(os.path.join(store.root, "fresh", "SKILL.md"))
 
 
 def test_create_skill_rejects_duplicate(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'dup', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='already exists'):
-        store.create_skill({'name': 'dup', 'instructions': 'y'})
+    store.create_skill({"name": "dup", "instructions": "x"})
+    with pytest.raises(ValueError, match="already exists"):
+        store.create_skill({"name": "dup", "instructions": "y"})
 
 
 @pytest.mark.parametrize(
-    'bad_name, message',
+    "bad_name, message",
     [
-        ('', 'required'),
-        ('   ', 'required'),
-        ('bad name!', 'letters, numbers'),
-        ('a' * 65, 'exceed 64'),
+        ("", "required"),
+        ("   ", "required"),
+        ("bad name!", "letters, numbers"),
+        ("a" * 65, "exceed 64"),
     ],
 )
 def test_create_skill_rejects_invalid_names(tmp_path, bad_name, message):
     store = _make_store(tmp_path)
     with pytest.raises(ValueError, match=message):
-        store.create_skill({'name': bad_name})
+        store.create_skill({"name": bad_name})
 
 
 def test_create_skill_imports_external_package_by_copy(tmp_path):
     store = _make_store(tmp_path)
-    external = tmp_path / 'external'
-    src = _write_skill_dir(external, 'imported', instructions='Imported body')
-    (external / 'imported' / 'extra.txt').write_text('payload', encoding='utf-8')
+    external = tmp_path / "external"
+    src = _write_skill_dir(external, "imported", instructions="Imported body")
+    (external / "imported" / "extra.txt").write_text("payload", encoding="utf-8")
 
-    created = store.create_skill({'name': 'copied', 'package_root': src})
-    assert created['name'] == 'copied'
+    created = store.create_skill({"name": "copied", "package_root": src})
+    assert created["name"] == "copied"
     # Imported metadata flows through when not overridden.
-    assert created['display_name'] == 'Imported'
-    assert created['description'] == 'A test skill'
+    assert created["display_name"] == "Imported"
+    assert created["description"] == "A test skill"
     # Copied into the managed root, extra file came along.
-    managed = os.path.join(store.root, 'copied')
-    assert os.path.isfile(os.path.join(managed, 'extra.txt'))
-    assert created['package_root'] == os.path.realpath(managed)
+    managed = os.path.join(store.root, "copied")
+    assert os.path.isfile(os.path.join(managed, "extra.txt"))
+    assert created["package_root"] == os.path.realpath(managed)
 
 
 def test_create_skill_imports_in_place_when_package_under_root(tmp_path):
@@ -374,43 +396,47 @@ def test_create_skill_imports_in_place_when_package_under_root(tmp_path):
     # A package that already lives under the managed skills root, in a directory
     # whose name (and frontmatter) does not yet match the requested skill name,
     # so get_skill('native') is None before creation.
-    in_root = tmp_path / 'skills' / 'pkgdir'
+    in_root = tmp_path / "skills" / "pkgdir"
     in_root.mkdir(parents=True)
-    (in_root / 'SKILL.md').write_text(
-        '---\nname: placeholder\ndescription: imported desc\n---\n\nImported body\n',
-        encoding='utf-8',
+    (in_root / "SKILL.md").write_text(
+        "---\nname: placeholder\ndescription: imported desc\n---\n\nImported body\n",
+        encoding="utf-8",
     )
-    (in_root / 'asset.txt').write_text('payload', encoding='utf-8')
+    (in_root / "asset.txt").write_text("payload", encoding="utf-8")
 
-    created = store.create_skill({
-        'name': 'native',
-        'package_root': str(in_root),
-        'display_name': 'Overridden',
-    })
-    assert created['name'] == 'native'
-    assert created['display_name'] == 'Overridden'
+    created = store.create_skill(
+        {
+            "name": "native",
+            "package_root": str(in_root),
+            "display_name": "Overridden",
+        }
+    )
+    assert created["name"] == "native"
+    assert created["display_name"] == "Overridden"
     # Imported in place: the SKILL.md is rewritten inside the original directory,
     # and the sibling asset is preserved.
-    assert created['package_root'] == os.path.realpath(str(in_root))
-    assert (in_root / 'asset.txt').read_text() == 'payload'
+    assert created["package_root"] == os.path.realpath(str(in_root))
+    assert (in_root / "asset.txt").read_text() == "payload"
 
 
 def test_create_skill_missing_external_dir_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='Directory does not exist'):
-        store.create_skill({
-            'name': 'ghost',
-            'package_root': str(tmp_path / 'nope'),
-        })
+    with pytest.raises(ValueError, match="Directory does not exist"):
+        store.create_skill(
+            {
+                "name": "ghost",
+                "package_root": str(tmp_path / "nope"),
+            }
+        )
 
 
 def test_create_skill_external_target_collision_raises(tmp_path):
     store = _make_store(tmp_path)
     # Managed dir already exists.
-    _write_skill_dir(tmp_path / 'skills', 'clash')
-    external = _write_skill_dir(tmp_path / 'ext', 'clash')
-    with pytest.raises(ValueError, match='already exists'):
-        store.create_skill({'name': 'clash', 'package_root': external})
+    _write_skill_dir(tmp_path / "skills", "clash")
+    external = _write_skill_dir(tmp_path / "ext", "clash")
+    with pytest.raises(ValueError, match="already exists"):
+        store.create_skill({"name": "clash", "package_root": external})
 
 
 # ── update_skill ────────────────────────────────────────────────────────
@@ -418,45 +444,51 @@ def test_create_skill_external_target_collision_raises(tmp_path):
 
 def test_update_skill_changes_metadata_and_instructions(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'edit', 'instructions': 'old'})
-    updated = store.update_skill('edit', {
-        'display_name': 'Edited',
-        'description': 'new desc',
-        'instructions': 'new body',
-    })
-    assert updated['display_name'] == 'Edited'
-    assert updated['description'] == 'new desc'
-    assert updated['instructions'].strip() == 'new body'
+    store.create_skill({"name": "edit", "instructions": "old"})
+    updated = store.update_skill(
+        "edit",
+        {
+            "display_name": "Edited",
+            "description": "new desc",
+            "instructions": "new body",
+        },
+    )
+    assert updated["display_name"] == "Edited"
+    assert updated["description"] == "new desc"
+    assert updated["instructions"].strip() == "new body"
 
 
 def test_update_skill_missing_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='not found'):
-        store.update_skill('ghost', {'instructions': 'x'})
+    with pytest.raises(ValueError, match="not found"):
+        store.update_skill("ghost", {"instructions": "x"})
 
 
 def test_update_skill_rename_rejected(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'keep', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='Renaming'):
-        store.update_skill('keep', {'name': 'renamed'})
+    store.create_skill({"name": "keep", "instructions": "x"})
+    with pytest.raises(ValueError, match="Renaming"):
+        store.update_skill("keep", {"name": "renamed"})
 
 
 def test_update_skill_changing_package_root_rejected(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'fixed', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='Updating package_root is not supported'):
-        store.update_skill('fixed', {'package_root': str(tmp_path / 'somewhere-else')})
+    store.create_skill({"name": "fixed", "instructions": "x"})
+    with pytest.raises(ValueError, match="Updating package_root is not supported"):
+        store.update_skill("fixed", {"package_root": str(tmp_path / "somewhere-else")})
 
 
 def test_update_skill_same_package_root_allowed(tmp_path):
     store = _make_store(tmp_path)
-    created = store.create_skill({'name': 'samep', 'instructions': 'x'})
-    updated = store.update_skill('samep', {
-        'package_root': created['package_root'],
-        'instructions': 'changed',
-    })
-    assert updated['instructions'].strip() == 'changed'
+    created = store.create_skill({"name": "samep", "instructions": "x"})
+    updated = store.update_skill(
+        "samep",
+        {
+            "package_root": created["package_root"],
+            "instructions": "changed",
+        },
+    )
+    assert updated["instructions"].strip() == "changed"
 
 
 # ── delete_skill ────────────────────────────────────────────────────────
@@ -464,18 +496,18 @@ def test_update_skill_same_package_root_allowed(tmp_path):
 
 def test_delete_skill_removes_managed_directory(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'gone', 'instructions': 'x'})
-    assert os.path.isdir(os.path.join(store.root, 'gone'))
-    result = store.delete_skill('gone')
-    assert result == {'deleted': 'gone'}
-    assert not os.path.exists(os.path.join(store.root, 'gone'))
-    assert store.get_skill('gone') is None
+    store.create_skill({"name": "gone", "instructions": "x"})
+    assert os.path.isdir(os.path.join(store.root, "gone"))
+    result = store.delete_skill("gone")
+    assert result == {"deleted": "gone"}
+    assert not os.path.exists(os.path.join(store.root, "gone"))
+    assert store.get_skill("gone") is None
 
 
 def test_delete_skill_missing_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='not found'):
-        store.delete_skill('ghost')
+    with pytest.raises(ValueError, match="not found"):
+        store.delete_skill("ghost")
 
 
 def test_delete_skill_rejects_skill_at_root_level(tmp_path):
@@ -484,25 +516,27 @@ def test_delete_skill_rejects_skill_at_root_level(tmp_path):
     store = _make_store(tmp_path)
     root = store.root
     os.makedirs(root, exist_ok=True)
-    with open(os.path.join(root, 'SKILL.md'), 'w', encoding='utf-8') as f:
-        f.write('---\nname: rootskill\n---\n\nbody\n')
+    with open(os.path.join(root, "SKILL.md"), "w", encoding="utf-8") as f:
+        f.write("---\nname: rootskill\n---\n\nbody\n")
 
-    skill = store.get_skill('rootskill')
+    skill = store.get_skill("rootskill")
     assert skill is not None
-    assert os.path.realpath(skill['package_root']) == os.path.realpath(root)
-    with pytest.raises(ValueError, match='Only managed skills'):
-        store.delete_skill('rootskill')
+    assert os.path.realpath(skill["package_root"]) == os.path.realpath(root)
+    with pytest.raises(ValueError, match="Only managed skills"):
+        store.delete_skill("rootskill")
 
 
 def test_delete_skill_imported_external_is_managed(tmp_path):
     # An externally imported skill is copied under the managed root, becoming
     # deletable.
     store = _make_store(tmp_path)
-    outside = _write_skill_dir(tmp_path / 'outside', 'external')
-    created = store.create_skill({'name': 'external', 'package_root': outside})
-    assert os.path.realpath(created['package_root']).startswith(os.path.realpath(store.root) + os.sep)
-    assert store.delete_skill('external') == {'deleted': 'external'}
-    assert store.get_skill('external') is None
+    outside = _write_skill_dir(tmp_path / "outside", "external")
+    created = store.create_skill({"name": "external", "package_root": outside})
+    assert os.path.realpath(created["package_root"]).startswith(
+        os.path.realpath(store.root) + os.sep
+    )
+    assert store.delete_skill("external") == {"deleted": "external"}
+    assert store.get_skill("external") is None
 
 
 # ── scan_directory ──────────────────────────────────────────────────────
@@ -510,39 +544,39 @@ def test_delete_skill_imported_external_is_managed(tmp_path):
 
 def test_scan_directory_finds_single_skill(tmp_path):
     store = _make_store(tmp_path)
-    skill_dir = _write_skill_dir(tmp_path / 'scan', 'one')
+    skill_dir = _write_skill_dir(tmp_path / "scan", "one")
     scanned = store.scan_directory(skill_dir)
-    assert scanned['name'] == 'one'
+    assert scanned["name"] == "one"
 
 
 def test_scan_directory_finds_skill_in_subdir(tmp_path):
     store = _make_store(tmp_path)
-    base = tmp_path / 'scan'
-    _write_skill_dir(base, 'nested')
+    base = tmp_path / "scan"
+    _write_skill_dir(base, "nested")
     scanned = store.scan_directory(str(base))
-    assert scanned['name'] == 'nested'
+    assert scanned["name"] == "nested"
 
 
 def test_scan_directory_missing_path_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='Directory does not exist'):
-        store.scan_directory(str(tmp_path / 'nope'))
+    with pytest.raises(ValueError, match="Directory does not exist"):
+        store.scan_directory(str(tmp_path / "nope"))
 
 
 def test_scan_directory_no_skill_raises(tmp_path):
     store = _make_store(tmp_path)
-    empty = tmp_path / 'empty'
+    empty = tmp_path / "empty"
     empty.mkdir()
-    with pytest.raises(ValueError, match='No SKILL.md found'):
+    with pytest.raises(ValueError, match="No SKILL.md found"):
         store.scan_directory(str(empty))
 
 
 def test_scan_directory_multiple_skills_raises(tmp_path):
     store = _make_store(tmp_path)
-    base = tmp_path / 'multi'
-    _write_skill_dir(base, 'a')
-    _write_skill_dir(base, 'b')
-    with pytest.raises(ValueError, match='Multiple skill directories'):
+    base = tmp_path / "multi"
+    _write_skill_dir(base, "a")
+    _write_skill_dir(base, "b")
+    with pytest.raises(ValueError, match="Multiple skill directories"):
         store.scan_directory(str(base))
 
 
@@ -551,180 +585,182 @@ def test_scan_directory_multiple_skills_raises(tmp_path):
 
 def test_list_skill_files_root_and_subdir(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'files', 'instructions': 'x'})
-    store.write_skill_file('files', 'sub/inner.txt', 'hi')
+    store.create_skill({"name": "files", "instructions": "x"})
+    store.write_skill_file("files", "sub/inner.txt", "hi")
 
-    top = store.list_skill_files('files')
-    assert top['skill'] == {'name': 'files'}
-    assert top['base_path'] == '.'
-    names = {e['name'] for e in top['entries']}
-    assert {'SKILL.md', 'sub'} <= names
-    sub_entry = next(e for e in top['entries'] if e['name'] == 'sub')
-    assert sub_entry['is_dir'] is True
-    assert sub_entry['size'] is None
+    top = store.list_skill_files("files")
+    assert top["skill"] == {"name": "files"}
+    assert top["base_path"] == "."
+    names = {e["name"] for e in top["entries"]}
+    assert {"SKILL.md", "sub"} <= names
+    sub_entry = next(e for e in top["entries"] if e["name"] == "sub")
+    assert sub_entry["is_dir"] is True
+    assert sub_entry["size"] is None
 
-    inner = store.list_skill_files('files', 'sub')
-    assert inner['base_path'] == 'sub'
-    assert [e['name'] for e in inner['entries']] == ['inner.txt']
-    assert inner['entries'][0]['path'] == 'sub/inner.txt'
-    assert inner['entries'][0]['size'] == len('hi')
+    inner = store.list_skill_files("files", "sub")
+    assert inner["base_path"] == "sub"
+    assert [e["name"] for e in inner["entries"]] == ["inner.txt"]
+    assert inner["entries"][0]["path"] == "sub/inner.txt"
+    assert inner["entries"][0]["size"] == len("hi")
 
 
 def test_list_skill_files_hidden_filter(tmp_path):
     store = _make_store(tmp_path)
-    created = store.create_skill({'name': 'hid', 'instructions': 'x'})
-    hidden = os.path.join(created['package_root'], '.secret')
-    with open(hidden, 'w', encoding='utf-8') as f:
-        f.write('shh')
+    created = store.create_skill({"name": "hid", "instructions": "x"})
+    hidden = os.path.join(created["package_root"], ".secret")
+    with open(hidden, "w", encoding="utf-8") as f:
+        f.write("shh")
 
-    without = {e['name'] for e in store.list_skill_files('hid')['entries']}
-    assert '.secret' not in without
+    without = {e["name"] for e in store.list_skill_files("hid")["entries"]}
+    assert ".secret" not in without
 
-    with_hidden = {e['name'] for e in store.list_skill_files('hid', include_hidden=True)['entries']}
-    assert '.secret' in with_hidden
+    with_hidden = {
+        e["name"] for e in store.list_skill_files("hid", include_hidden=True)["entries"]
+    }
+    assert ".secret" in with_hidden
 
 
 def test_list_skill_files_truncation(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'many', 'instructions': 'x'})
+    store.create_skill({"name": "many", "instructions": "x"})
     for i in range(5):
-        store.write_skill_file('many', f'file{i}.txt', 'data')
+        store.write_skill_file("many", f"file{i}.txt", "data")
 
-    result = store.list_skill_files('many', max_entries=3)
-    assert len(result['entries']) == 3
-    assert result['truncated'] is True
+    result = store.list_skill_files("many", max_entries=3)
+    assert len(result["entries"]) == 3
+    assert result["truncated"] is True
 
 
 def test_list_skill_files_missing_skill_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='not found'):
-        store.list_skill_files('ghost')
+    with pytest.raises(ValueError, match="not found"):
+        store.list_skill_files("ghost")
 
 
 def test_list_skill_files_directory_not_found_raises(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 's', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='Skill directory not found'):
-        store.list_skill_files('s', 'no-such-dir')
+    store.create_skill({"name": "s", "instructions": "x"})
+    with pytest.raises(ValueError, match="Skill directory not found"):
+        store.list_skill_files("s", "no-such-dir")
 
 
 def test_read_write_edit_delete_round_trip(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'crud', 'instructions': 'x'})
+    store.create_skill({"name": "crud", "instructions": "x"})
 
-    write_result = store.write_skill_file('crud', 'data/info.txt', 'hello world')
-    assert write_result['path'] == 'data/info.txt'
-    assert write_result['bytes_written'] == len('hello world'.encode('utf-8'))
+    write_result = store.write_skill_file("crud", "data/info.txt", "hello world")
+    assert write_result["path"] == "data/info.txt"
+    assert write_result["bytes_written"] == len("hello world".encode("utf-8"))
 
-    read_result = store.read_skill_file('crud', 'data/info.txt')
-    assert read_result['content'] == 'hello world'
-    assert read_result['path'] == 'data/info.txt'
-    assert read_result['skill'] == {'name': 'crud'}
+    read_result = store.read_skill_file("crud", "data/info.txt")
+    assert read_result["content"] == "hello world"
+    assert read_result["path"] == "data/info.txt"
+    assert read_result["skill"] == {"name": "crud"}
 
     # "Edit" == overwrite via write_skill_file.
-    store.write_skill_file('crud', 'data/info.txt', 'edited')
-    assert store.read_skill_file('crud', 'data/info.txt')['content'] == 'edited'
+    store.write_skill_file("crud", "data/info.txt", "edited")
+    assert store.read_skill_file("crud", "data/info.txt")["content"] == "edited"
 
     # Delete by removing the file on disk, then confirm read fails.
-    target = os.path.join(store.get_skill('crud')['package_root'], 'data', 'info.txt')
+    target = os.path.join(store.get_skill("crud")["package_root"], "data", "info.txt")
     os.remove(target)
-    with pytest.raises(ValueError, match='Skill file not found'):
-        store.read_skill_file('crud', 'data/info.txt')
+    with pytest.raises(ValueError, match="Skill file not found"):
+        store.read_skill_file("crud", "data/info.txt")
 
 
 def test_write_skill_file_handles_unicode(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'uni', 'instructions': 'x'})
-    text = '你好, мир 🌍'
-    result = store.write_skill_file('uni', 'i18n.txt', text)
-    assert result['bytes_written'] == len(text.encode('utf-8'))
-    assert store.read_skill_file('uni', 'i18n.txt')['content'] == text
+    store.create_skill({"name": "uni", "instructions": "x"})
+    text = "你好, мир 🌍"
+    result = store.write_skill_file("uni", "i18n.txt", text)
+    assert result["bytes_written"] == len(text.encode("utf-8"))
+    assert store.read_skill_file("uni", "i18n.txt")["content"] == text
 
 
 def test_read_skill_file_non_utf8_raises(tmp_path):
     store = _make_store(tmp_path)
-    created = store.create_skill({'name': 'binskill', 'instructions': 'x'})
-    binpath = os.path.join(created['package_root'], 'blob.bin')
-    with open(binpath, 'wb') as f:
-        f.write(b'\xff\xfe\x00\x01')
-    with pytest.raises(ValueError, match='not valid UTF-8'):
-        store.read_skill_file('binskill', 'blob.bin')
+    created = store.create_skill({"name": "binskill", "instructions": "x"})
+    binpath = os.path.join(created["package_root"], "blob.bin")
+    with open(binpath, "wb") as f:
+        f.write(b"\xff\xfe\x00\x01")
+    with pytest.raises(ValueError, match="not valid UTF-8"):
+        store.read_skill_file("binskill", "blob.bin")
 
 
 def test_read_skill_file_missing_raises(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 's', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='Skill file not found'):
-        store.read_skill_file('s', 'missing.txt')
+    store.create_skill({"name": "s", "instructions": "x"})
+    with pytest.raises(ValueError, match="Skill file not found"):
+        store.read_skill_file("s", "missing.txt")
 
 
 # ── path traversal rejection in _resolve_skill_path ─────────────────────
 
 
-@pytest.mark.parametrize('bad_path', ['../escape.txt', '../../etc/passwd', '..'])
+@pytest.mark.parametrize("bad_path", ["../escape.txt", "../../etc/passwd", ".."])
 def test_skill_file_relative_traversal_rejected(tmp_path, bad_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'safe', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='stay within the skill package root'):
-        store.read_skill_file('safe', bad_path)
+    store.create_skill({"name": "safe", "instructions": "x"})
+    with pytest.raises(ValueError, match="stay within the skill package root"):
+        store.read_skill_file("safe", bad_path)
 
 
 def test_skill_file_absolute_path_rejected(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'safe', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='must be relative'):
-        store.read_skill_file('safe', str(tmp_path / 'outside.txt'))
+    store.create_skill({"name": "safe", "instructions": "x"})
+    with pytest.raises(ValueError, match="must be relative"):
+        store.read_skill_file("safe", str(tmp_path / "outside.txt"))
 
 
 def test_list_skill_files_absolute_path_rejected(tmp_path):
     store = _make_store(tmp_path)
-    store.create_skill({'name': 'safe', 'instructions': 'x'})
-    with pytest.raises(ValueError, match='must be relative'):
-        store.list_skill_files('safe', str(tmp_path))
+    store.create_skill({"name": "safe", "instructions": "x"})
+    with pytest.raises(ValueError, match="must be relative"):
+        store.list_skill_files("safe", str(tmp_path))
 
 
 # ── _safe_extract_zip / zip-slip rejection ──────────────────────────────
 
 
-def _zip_with_member(arcname: str, data: bytes = b'x') -> bytes:
+def _zip_with_member(arcname: str, data: bytes = b"x") -> bytes:
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, 'w') as zf:
+    with zipfile.ZipFile(buffer, "w") as zf:
         # SKILL.md so the extraction has something legitimate too.
-        zf.writestr('pkg/SKILL.md', '---\nname: pkg\n---\nbody\n')
+        zf.writestr("pkg/SKILL.md", "---\nname: pkg\n---\nbody\n")
         zf.writestr(arcname, data)
     return buffer.getvalue()
 
 
 def test_safe_extract_zip_extracts_clean_archive(tmp_path):
-    target = tmp_path / 'out'
+    target = tmp_path / "out"
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, 'w') as zf:
-        zf.writestr('a/b.txt', 'data')
-        zf.writestr('a/c/', '')  # directory entry, should be skipped without error
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("a/b.txt", "data")
+        zf.writestr("a/c/", "")  # directory entry, should be skipped without error
     with zipfile.ZipFile(io.BytesIO(buffer.getvalue())) as zf:
         BoxSkillStore._safe_extract_zip(zf, str(target))
-    assert (target / 'a' / 'b.txt').read_text() == 'data'
+    assert (target / "a" / "b.txt").read_text() == "data"
 
 
 def test_safe_extract_zip_rejects_parent_traversal(tmp_path):
-    payload = _zip_with_member('../evil.txt')
+    payload = _zip_with_member("../evil.txt")
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='unsafe path'):
-        store.preview_zip_upload(file_bytes=payload, filename='evil.zip')
+    with pytest.raises(ValueError, match="unsafe path"):
+        store.preview_zip_upload(file_bytes=payload, filename="evil.zip")
 
 
 def test_safe_extract_zip_rejects_absolute_member(tmp_path):
-    payload = _zip_with_member('/tmp/abs-evil.txt')
+    payload = _zip_with_member("/tmp/abs-evil.txt")
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='unsafe path'):
-        store.preview_zip_upload(file_bytes=payload, filename='evil.zip')
+    with pytest.raises(ValueError, match="unsafe path"):
+        store.preview_zip_upload(file_bytes=payload, filename="evil.zip")
 
 
 def test_safe_extract_zip_rejects_nested_parent_escape(tmp_path):
-    payload = _zip_with_member('sub/../../escape.txt')
+    payload = _zip_with_member("sub/../../escape.txt")
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='unsafe path'):
-        store.preview_zip_upload(file_bytes=payload, filename='evil.zip')
+    with pytest.raises(ValueError, match="unsafe path"):
+        store.preview_zip_upload(file_bytes=payload, filename="evil.zip")
 
 
 # ── zip upload error handling ───────────────────────────────────────────
@@ -732,72 +768,72 @@ def test_safe_extract_zip_rejects_nested_parent_escape(tmp_path):
 
 def test_preview_zip_upload_empty_bytes_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='empty'):
-        store.preview_zip_upload(file_bytes=b'', filename='x.zip')
+    with pytest.raises(ValueError, match="empty"):
+        store.preview_zip_upload(file_bytes=b"", filename="x.zip")
 
 
 def test_install_zip_upload_empty_bytes_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='empty'):
-        store.install_zip_upload(file_bytes=b'', filename='x.zip')
+    with pytest.raises(ValueError, match="empty"):
+        store.install_zip_upload(file_bytes=b"", filename="x.zip")
 
 
 def test_preview_zip_upload_corrupt_archive_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='valid .zip archive'):
-        store.preview_zip_upload(file_bytes=b'not a zip at all', filename='x.zip')
+    with pytest.raises(ValueError, match="valid .zip archive"):
+        store.preview_zip_upload(file_bytes=b"not a zip at all", filename="x.zip")
 
 
 def test_preview_zip_upload_no_skill_in_archive_raises(tmp_path):
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, 'w') as zf:
-        zf.writestr('pkg/readme.txt', 'no skill here')
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("pkg/readme.txt", "no skill here")
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='No SKILL.md found'):
-        store.preview_zip_upload(file_bytes=buffer.getvalue(), filename='pkg.zip')
+    with pytest.raises(ValueError, match="No SKILL.md found"):
+        store.preview_zip_upload(file_bytes=buffer.getvalue(), filename="pkg.zip")
 
 
 def test_install_zip_upload_multiple_without_selection_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='Please choose one or more source_paths'):
+    with pytest.raises(ValueError, match="Please choose one or more source_paths"):
         store.install_zip_upload(
             file_bytes=_nested_skill_zip(),
-            filename='repo.zip',
-            source_subdir='packages',
+            filename="repo.zip",
+            source_subdir="packages",
         )
 
 
 def test_install_zip_upload_invalid_source_path_raises(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='Invalid source_path'):
+    with pytest.raises(ValueError, match="Invalid source_path"):
         store.install_zip_upload(
             file_bytes=_nested_skill_zip(),
-            filename='repo.zip',
-            source_subdir='packages',
-            source_paths=['gamma'],
+            filename="repo.zip",
+            source_subdir="packages",
+            source_paths=["gamma"],
         )
 
 
 def test_install_zip_upload_existing_target_raises(tmp_path):
     store = _make_store(tmp_path)
     # First install succeeds.
-    store.install_zip_upload(file_bytes=_skill_zip(), filename='demo.zip')
+    store.install_zip_upload(file_bytes=_skill_zip(), filename="demo.zip")
     # Re-installing into the same computed target dir should fail.
-    with pytest.raises(ValueError, match='already exists'):
-        store.install_zip_upload(file_bytes=_skill_zip(), filename='demo.zip')
+    with pytest.raises(ValueError, match="already exists"):
+        store.install_zip_upload(file_bytes=_skill_zip(), filename="demo.zip")
 
 
 def test_install_zip_upload_installs_multiple_selected(tmp_path):
     store = _make_store(tmp_path)
     installed = store.install_zip_upload(
         file_bytes=_nested_skill_zip(),
-        filename='repo.zip',
-        source_subdir='packages',
-        source_paths=['alpha', 'beta'],
+        filename="repo.zip",
+        source_subdir="packages",
+        source_paths=["alpha", "beta"],
     )
-    assert sorted(s['name'] for s in installed) == ['alpha', 'beta']
-    assert store.get_skill('alpha') is not None
-    assert store.get_skill('beta') is not None
+    assert sorted(s["name"] for s in installed) == ["alpha", "beta"]
+    assert store.get_skill("alpha") is not None
+    assert store.get_skill("beta") is not None
 
 
 def test_install_zip_upload_legacy_source_path_arg(tmp_path):
@@ -805,33 +841,33 @@ def test_install_zip_upload_legacy_source_path_arg(tmp_path):
     store = _make_store(tmp_path)
     installed = store.install_zip_upload(
         file_bytes=_nested_skill_zip(),
-        filename='repo.zip',
-        source_subdir='packages',
-        source_path='alpha',
+        filename="repo.zip",
+        source_subdir="packages",
+        source_path="alpha",
     )
-    assert [s['name'] for s in installed] == ['alpha']
+    assert [s["name"] for s in installed] == ["alpha"]
 
 
 def test_install_zip_upload_multi_top_level_uses_extract_root(tmp_path):
     # An archive with multiple top-level entries is rooted at the extract dir,
     # and skills are discovered within it.
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, 'w') as zf:
-        zf.writestr('alpha/SKILL.md', '---\nname: alpha\n---\n\nA\n')
-        zf.writestr('beta/SKILL.md', '---\nname: beta\n---\n\nB\n')
-        zf.writestr('toplevel.txt', 'loose file at root')
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("alpha/SKILL.md", "---\nname: alpha\n---\n\nA\n")
+        zf.writestr("beta/SKILL.md", "---\nname: beta\n---\n\nB\n")
+        zf.writestr("toplevel.txt", "loose file at root")
     payload = buffer.getvalue()
 
     store = _make_store(tmp_path)
-    candidates = store.preview_zip_upload(file_bytes=payload, filename='multi.zip')
-    assert sorted(c['source_path'] for c in candidates) == ['alpha', 'beta']
+    candidates = store.preview_zip_upload(file_bytes=payload, filename="multi.zip")
+    assert sorted(c["source_path"] for c in candidates) == ["alpha", "beta"]
 
     installed = store.install_zip_upload(
         file_bytes=payload,
-        filename='multi.zip',
-        source_paths=['alpha'],
+        filename="multi.zip",
+        source_paths=["alpha"],
     )
-    assert [s['name'] for s in installed] == ['alpha']
+    assert [s["name"] for s in installed] == ["alpha"]
 
 
 # ── source_subdir validation ────────────────────────────────────────────
@@ -839,11 +875,11 @@ def test_install_zip_upload_multi_top_level_uses_extract_root(tmp_path):
 
 def test_source_subdir_traversal_rejected(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='stay within the uploaded archive'):
+    with pytest.raises(ValueError, match="stay within the uploaded archive"):
         store.preview_zip_upload(
             file_bytes=_nested_skill_zip(),
-            filename='repo.zip',
-            source_subdir='../escape',
+            filename="repo.zip",
+            source_subdir="../escape",
         )
 
 
@@ -851,21 +887,21 @@ def test_source_subdir_leading_slash_is_stripped_then_checked(tmp_path):
     # Leading slashes are stripped, so an "/etc" subdir is treated as relative
     # "etc" and rejected for not existing inside the archive (not as absolute).
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='does not exist in the uploaded archive'):
+    with pytest.raises(ValueError, match="does not exist in the uploaded archive"):
         store.preview_zip_upload(
             file_bytes=_nested_skill_zip(),
-            filename='repo.zip',
-            source_subdir='/etc',
+            filename="repo.zip",
+            source_subdir="/etc",
         )
 
 
 def test_source_subdir_nonexistent_rejected(tmp_path):
     store = _make_store(tmp_path)
-    with pytest.raises(ValueError, match='does not exist in the uploaded archive'):
+    with pytest.raises(ValueError, match="does not exist in the uploaded archive"):
         store.preview_zip_upload(
             file_bytes=_nested_skill_zip(),
-            filename='repo.zip',
-            source_subdir='packages/missing',
+            filename="repo.zip",
+            source_subdir="packages/missing",
         )
 
 
@@ -873,12 +909,12 @@ def test_source_subdir_nonexistent_rejected(tmp_path):
 
 
 @pytest.mark.parametrize(
-    'filename, expected_prefix',
+    "filename, expected_prefix",
     [
-        ('My Skill!.zip', 'My-Skill'),
-        ('', 'uploaded-skill'),
-        ('???.zip', 'uploaded-skill'),
-        ('clean_name.zip', 'clean_name'),
+        ("My Skill!.zip", "My-Skill"),
+        ("", "uploaded-skill"),
+        ("???.zip", "uploaded-skill"),
+        ("clean_name.zip", "clean_name"),
     ],
 )
 def test_uploaded_skill_target_stem_sanitization(filename, expected_prefix):
@@ -889,12 +925,12 @@ def test_preview_target_dir_appends_leaf_and_suffix(tmp_path):
     store = _make_store(tmp_path)
     preview = store.preview_zip_upload(
         file_bytes=_nested_skill_zip(),
-        filename='repo.zip',
-        source_subdir='packages',
-        target_suffix='v2',
+        filename="repo.zip",
+        source_subdir="packages",
+        target_suffix="v2",
     )
-    package_roots = {os.path.basename(p['package_root']) for p in preview}
-    assert package_roots == {'repo-alpha-v2', 'repo-beta-v2'}
+    package_roots = {os.path.basename(p["package_root"]) for p in preview}
+    assert package_roots == {"repo-alpha-v2", "repo-beta-v2"}
 
 
 # ── managed install root resolution ─────────────────────────────────────
@@ -904,11 +940,13 @@ def test_managed_install_root_for_package(tmp_path):
     store = _make_store(tmp_path)
     root = store.root
     # A package nested two levels under root maps to its top-level dir.
-    nested = os.path.join(root, 'topdir', 'inner')
-    assert store._managed_install_root_for_package(nested) == os.path.join(root, 'topdir')
+    nested = os.path.join(root, "topdir", "inner")
+    assert store._managed_install_root_for_package(nested) == os.path.join(
+        root, "topdir"
+    )
     # The root itself is not a managed install.
-    assert store._managed_install_root_for_package(root) == ''
+    assert store._managed_install_root_for_package(root) == ""
     # An empty package root yields ''.
-    assert store._managed_install_root_for_package('') == ''
+    assert store._managed_install_root_for_package("") == ""
     # A path outside the root yields ''.
-    assert store._managed_install_root_for_package(str(tmp_path / 'elsewhere')) == ''
+    assert store._managed_install_root_for_package(str(tmp_path / "elsewhere")) == ""

--- a/tests/cli/run/test_controller.py
+++ b/tests/cli/run/test_controller.py
@@ -82,7 +82,9 @@ def test_controller_builds_unmounted_placeholder_container():
     assert controller.ws_debug_url == "ws://runtime/plugin/ws"
     assert controller.plugin_container.status is RuntimeContainerStatus.UNMOUNTED
     assert isinstance(controller.plugin_container.plugin_instance, NonePlugin)
-    assert [component.manifest.kind for component in controller.plugin_container.components] == [
+    assert [
+        component.manifest.kind for component in controller.plugin_container.components
+    ] == [
         "Tool",
         "EventListener",
         "UnknownKind",
@@ -159,9 +161,7 @@ async def test_cleanup_instances_resets_runtime_objects(monkeypatch):
         fake_component_class,
     )
 
-    await controller.initialize(
-        {"enabled": True, "priority": 0, "plugin_config": {}}
-    )
+    await controller.initialize({"enabled": True, "priority": 0, "plugin_config": {}})
     await controller.cleanup_instances()
 
     assert isinstance(controller.plugin_container.plugin_instance, NonePlugin)

--- a/tests/cli/run/test_runtime_handler.py
+++ b/tests/cli/run/test_runtime_handler.py
@@ -74,7 +74,9 @@ def _handler():
     return handler, initialized
 
 
-def test_resolve_asset_path_accepts_assets_and_component_page_files(tmp_path, monkeypatch):
+def test_resolve_asset_path_accepts_assets_and_component_page_files(
+    tmp_path, monkeypatch
+):
     assets_file = tmp_path / "assets" / "icon.svg"
     page_file = tmp_path / "components" / "pages" / "settings.html"
     outside_file = tmp_path / "components" / "tools" / "secret.txt"

--- a/tests/cli/test_buildplugin.py
+++ b/tests/cli/test_buildplugin.py
@@ -63,9 +63,7 @@ def test_build_plugin_process_packages_manifest_and_filters_ignored_files(
 
     package_path = buildplugin.build_plugin_process(str(output_dir))
 
-    assert package_path == os.path.join(
-        str(output_dir), "tester-demo-0.1.0.lbpkg"
-    )
+    assert package_path == os.path.join(str(output_dir), "tester-demo-0.1.0.lbpkg")
     with zipfile.ZipFile(package_path) as package:
         names = set(package.namelist())
         assert {"manifest.yaml", "main.py", ".gitignore"} <= names

--- a/tests/cli/test_initplugin.py
+++ b/tests/cli/test_initplugin.py
@@ -47,7 +47,11 @@ def test_init_git_repo_invokes_git_init(monkeypatch):
 def test_init_git_repo_reports_git_warning(monkeypatch):
     error = subprocess.CalledProcessError(1, ["git"], stderr=b"boom")
     prints = []
-    monkeypatch.setattr(initplugin.subprocess, "run", lambda *args, **kwargs: (_ for _ in ()).throw(error))
+    monkeypatch.setattr(
+        initplugin.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(error),
+    )
     monkeypatch.setattr(initplugin, "cli_print", lambda *args: prints.append(args))
 
     initplugin.init_git_repo("plugin")
@@ -93,7 +97,9 @@ def test_init_plugin_process_rejects_invalid_name(tmp_path, monkeypatch, capsys)
     assert not (tmp_path / "bad name").exists()
 
 
-def test_init_plugin_process_rejects_non_empty_existing_directory(tmp_path, monkeypatch, capsys):
+def test_init_plugin_process_rejects_non_empty_existing_directory(
+    tmp_path, monkeypatch, capsys
+):
     plugin_dir = tmp_path / "demo"
     plugin_dir.mkdir()
     (plugin_dir / "main.py").write_text("existing", encoding="utf-8")

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -208,9 +208,7 @@ def test_generate_device_code_posts_to_token_generate(monkeypatch):
         "code": 0,
         "data": {"device_code": "d"},
     }
-    assert FakeClient.calls == [
-        ("https://cloud/api/v1/accounts/token/generate", {})
-    ]
+    assert FakeClient.calls == [("https://cloud/api/v1/accounts/token/generate", {})]
 
 
 def test_generate_device_code_reports_network_failure(monkeypatch):

--- a/tests/cli/test_logout_publish.py
+++ b/tests/cli/test_logout_publish.py
@@ -34,7 +34,9 @@ def test_logout_process_removes_old_flat_token_config(tmp_path, monkeypatch):
     assert prints[0] == ("logout_successful",)
 
 
-def test_logout_process_removes_current_server_from_nested_config(tmp_path, monkeypatch):
+def test_logout_process_removes_current_server_from_nested_config(
+    tmp_path, monkeypatch
+):
     config_dir = tmp_path / ".langbot" / "cli"
     config_dir.mkdir(parents=True)
     config_file = config_dir / "config.json"
@@ -171,9 +173,21 @@ def test_publish_process_builds_publishes_and_cleans_tmp_dir(monkeypatch):
     calls = []
     monkeypatch.setattr(publish, "check_login_status", lambda: True)
     monkeypatch.setattr(publish, "get_access_token", lambda: "token")
-    monkeypatch.setattr(publish, "build_plugin_process", lambda output_dir: calls.append(("build", output_dir)) or "pkg")
-    monkeypatch.setattr(publish, "publish_plugin", lambda path, changelog, token: calls.append(("publish", path, changelog, token)))
-    monkeypatch.setattr(publish.shutil, "rmtree", lambda path: calls.append(("rmtree", path)))
+    monkeypatch.setattr(
+        publish,
+        "build_plugin_process",
+        lambda output_dir: calls.append(("build", output_dir)) or "pkg",
+    )
+    monkeypatch.setattr(
+        publish,
+        "publish_plugin",
+        lambda path, changelog, token: calls.append(
+            ("publish", path, changelog, token)
+        ),
+    )
+    monkeypatch.setattr(
+        publish.shutil, "rmtree", lambda path: calls.append(("rmtree", path))
+    )
 
     publish.publish_process()
 

--- a/tests/cli/test_renderer.py
+++ b/tests/cli/test_renderer.py
@@ -12,19 +12,30 @@ def test_component_input_post_processors_create_python_class_names():
         "tool_description": "Search the web",
         "tool_attr": "WebSearch",
     }
-    assert renderer.command_component_input_post_process(
-        {"cmd_name": "hello_world", "cmd_description": "Say hello"}
-    )["cmd_attr"] == "HelloWorld"
-    assert renderer.knowledge_engine_component_input_post_process(
-        {
-            "knowledge_engine_name": "local_docs",
-            "knowledge_engine_description": "Docs",
-        }
-    )["knowledge_engine_attr"] == "LocalDocs"
-    assert renderer.parser_component_input_post_process(
-        {"parser_name": "pdf_reader", "parser_description": "PDF"}
-    )["parser_label"] == "PdfReader"
-    assert renderer.page_component_input_post_process({"page_name": "settings_page"}) == {
+    assert (
+        renderer.command_component_input_post_process(
+            {"cmd_name": "hello_world", "cmd_description": "Say hello"}
+        )["cmd_attr"]
+        == "HelloWorld"
+    )
+    assert (
+        renderer.knowledge_engine_component_input_post_process(
+            {
+                "knowledge_engine_name": "local_docs",
+                "knowledge_engine_description": "Docs",
+            }
+        )["knowledge_engine_attr"]
+        == "LocalDocs"
+    )
+    assert (
+        renderer.parser_component_input_post_process(
+            {"parser_name": "pdf_reader", "parser_description": "PDF"}
+        )["parser_label"]
+        == "PdfReader"
+    )
+    assert renderer.page_component_input_post_process(
+        {"page_name": "settings_page"}
+    ) == {
         "page_name": "settings_page",
         "page_label": "SettingsPage",
     }

--- a/tests/cli/test_runplugin.py
+++ b/tests/cli/test_runplugin.py
@@ -110,8 +110,9 @@ async def test_arun_plugin_process_builds_controller_and_sets_runtime_env(
             (),
             {
                 "load_component_manifest": (
-                    lambda self, **kwargs: calls.append(("load_manifest", kwargs))
-                    or manifest
+                    lambda self, **kwargs: (
+                        calls.append(("load_manifest", kwargs)) or manifest
+                    )
                 )
             },
         )(),
@@ -119,10 +120,9 @@ async def test_arun_plugin_process_builds_controller_and_sets_runtime_env(
     monkeypatch.setattr(
         runplugin,
         "discover_plugin_components",
-        lambda plugin_manifest, engine: calls.append(
-            ("discover_components", plugin_manifest, engine)
-        )
-        or components,
+        lambda plugin_manifest, engine: (
+            calls.append(("discover_components", plugin_manifest, engine)) or components
+        ),
     )
     monkeypatch.setattr(
         runplugin,

--- a/tests/entities/io/test_protocol.py
+++ b/tests/entities/io/test_protocol.py
@@ -66,7 +66,9 @@ def test_action_response_success_error_and_chunk_serialization():
 
 
 def test_action_response_normalizes_missing_chunk_status_to_continue():
-    response = ActionResponse(seq_id=1, code=0, message="ok", data={}, chunk_status=None)
+    response = ActionResponse(
+        seq_id=1, code=0, message="ok", data={}, chunk_status=None
+    )
     assert response.chunk_status is ChunkStatus.CONTINUE
 
 

--- a/tests/runtime/helper/test_marketplace.py
+++ b/tests/runtime/helper/test_marketplace.py
@@ -78,7 +78,9 @@ class FakeAsyncClient:
 def fake_client(monkeypatch):
     FakeAsyncClient.requests = []
     monkeypatch.setattr(marketplace.httpx, "AsyncClient", FakeAsyncClient)
-    monkeypatch.setattr(marketplace.runtime_settings, "cloud_service_url", "https://cloud")
+    monkeypatch.setattr(
+        marketplace.runtime_settings, "cloud_service_url", "https://cloud"
+    )
     return FakeAsyncClient
 
 

--- a/tests/runtime/helper/test_pkgmgr.py
+++ b/tests/runtime/helper/test_pkgmgr.py
@@ -45,10 +45,14 @@ def test_parse_downloaded_bytes_supports_common_pip_units():
         ]
     )
 
-    assert pkgmgr._parse_downloaded_bytes(output) == int(1.5 * 1024) + 2 * 1024 * 1024 + 3
+    assert (
+        pkgmgr._parse_downloaded_bytes(output) == int(1.5 * 1024) + 2 * 1024 * 1024 + 3
+    )
 
 
-def test_install_single_builds_pip_command_and_returns_parsed_download_size(monkeypatch):
+def test_install_single_builds_pip_command_and_returns_parsed_download_size(
+    monkeypatch,
+):
     class Result:
         returncode = 0
         stdout = "Downloading pkg.whl (1 kB)"
@@ -56,7 +60,11 @@ def test_install_single_builds_pip_command_and_returns_parsed_download_size(monk
 
     calls = []
     monkeypatch.setattr(pkgmgr, "get_pip_index_args", lambda: ["-i", "https://mirror"])
-    monkeypatch.setattr(pkgmgr.subprocess, "run", lambda cmd, **kwargs: calls.append((cmd, kwargs)) or Result())
+    monkeypatch.setattr(
+        pkgmgr.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append((cmd, kwargs)) or Result(),
+    )
 
     returncode, downloaded, output = pkgmgr.install_single("demo", ["--no-deps"])
 

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -26,7 +26,12 @@ class FakePlugin:
         )
 
     def model_dump(self, **kwargs):
-        return {"manifest": {"author": self.manifest.metadata.author, "name": self.manifest.metadata.name}}
+        return {
+            "manifest": {
+                "author": self.manifest.metadata.author,
+                "name": self.manifest.metadata.name,
+            }
+        }
 
 
 class FakePluginManager:
@@ -119,7 +124,9 @@ class FakePluginManager:
         self.calls.append(("list_parsers",))
         return [{"name": "parser"}]
 
-    async def parse_document(self, plugin_author, plugin_name, context_data, file_bytes):
+    async def parse_document(
+        self, plugin_author, plugin_name, context_data, file_bytes
+    ):
         self.calls.append(
             ("parse_document", plugin_author, plugin_name, context_data, file_bytes)
         )
@@ -219,9 +226,7 @@ async def test_control_handler_get_plugin_assets_file_sends_file_key(monkeypatch
             },
         )
 
-    assert manager.calls == [
-        ("get_plugin_assets_file", "tester", "demo", "icon.svg")
-    ]
+    assert manager.calls == [("get_plugin_assets_file", "tester", "demo", "icon.svg")]
     assert response["data"] == {
         "file_file_key": "asset-key",
         "mime_type": "text/plain",

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -18,7 +18,9 @@ class FakeManifest:
         self.metadata = SimpleNamespace(author=author, name=name)
 
     def model_dump(self, **kwargs):
-        return {"metadata": {"author": self.metadata.author, "name": self.metadata.name}}
+        return {
+            "metadata": {"author": self.metadata.author, "name": self.metadata.name}
+        }
 
 
 class FakePluginContainer:
@@ -58,9 +60,7 @@ class FakePluginManager:
         return self.tools
 
     async def call_tool(self, tool_name, tool_parameters, session, query_id):
-        self.calls.append(
-            ("call_tool", tool_name, tool_parameters, session, query_id)
-        )
+        self.calls.append(("call_tool", tool_name, tool_parameters, session, query_id))
         return {"text": "tool response"}
 
     async def list_commands(self):
@@ -98,7 +98,9 @@ def _handler(debug_plugin=False):
 
 async def test_plugin_handler_registers_plugin_when_debug_key_matches(monkeypatch):
     handler, manager, _control = _handler(debug_plugin=True)
-    monkeypatch.setattr(plugin_handler_module.runtime_settings, "plugin_debug_key", "key")
+    monkeypatch.setattr(
+        plugin_handler_module.runtime_settings, "plugin_debug_key", "key"
+    )
 
     async with ProtocolSession(handler) as session:
         response = await session.request(
@@ -107,14 +109,14 @@ async def test_plugin_handler_registers_plugin_when_debug_key_matches(monkeypatc
         )
 
     assert response["code"] == 0
-    assert manager.calls == [
-        ("register_plugin", handler, {"id": "plugin"}, True)
-    ]
+    assert manager.calls == [("register_plugin", handler, {"id": "plugin"}, True)]
 
 
 async def test_plugin_handler_rejects_plugin_with_invalid_debug_key(monkeypatch):
     handler, manager, _control = _handler(debug_plugin=True)
-    monkeypatch.setattr(plugin_handler_module.runtime_settings, "plugin_debug_key", "key")
+    monkeypatch.setattr(
+        plugin_handler_module.runtime_settings, "plugin_debug_key", "key"
+    )
 
     async with ProtocolSession(handler) as session:
         response = await session.request(
@@ -139,9 +141,7 @@ async def test_plugin_handler_prod_registration_disables_debug_mode(monkeypatch)
 
     assert response["code"] == 0
     assert handler.debug_plugin is False
-    assert manager.calls == [
-        ("register_plugin", handler, {"id": "plugin"}, False)
-    ]
+    assert manager.calls == [("register_plugin", handler, {"id": "plugin"}, False)]
 
 
 async def test_plugin_handler_forwards_invoke_llm_with_validated_timeout():
@@ -206,7 +206,9 @@ async def test_plugin_handler_workspace_storage_uses_default_workspace_owner():
 
 async def test_plugin_handler_forwards_config_file_requests_to_langbot():
     handler, _manager, control = _handler()
-    control.results[RuntimeToLangBotAction.GET_CONFIG_FILE] = {"file_base64": "Y29uZmln"}
+    control.results[RuntimeToLangBotAction.GET_CONFIG_FILE] = {
+        "file_base64": "Y29uZmln"
+    }
 
     async with ProtocolSession(handler) as session:
         response = await session.request(

--- a/tests/runtime/io/test_handler.py
+++ b/tests/runtime/io/test_handler.py
@@ -67,7 +67,9 @@ async def test_call_action_sends_request_and_returns_response_data():
     assert request["data"] == {"message": "hello"}
 
     handler.resp_waiters[request["seq_id"]].set_result(
-        ActionResponse(seq_id=request["seq_id"], code=0, message="ok", data={"ok": True})
+        ActionResponse(
+            seq_id=request["seq_id"], code=0, message="ok", data={"ok": True}
+        )
     )
 
     assert await task == {"ok": True}
@@ -404,9 +406,7 @@ async def test_call_action_generator_raises_on_error_chunk():
     [request] = await conn.sent_messages(1)
     queue = handler.resp_queues[request["seq_id"]]
     await queue.put(
-        ActionResponse(
-            seq_id=request["seq_id"], code=1, message="stream boom", data={}
-        )
+        ActionResponse(seq_id=request["seq_id"], code=1, message="stream boom", data={})
     )
 
     await task

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -274,7 +274,9 @@ async def test_install_plugin_from_file_extracts_manifest_and_replaces_old_versi
 
 
 @pytest.mark.asyncio
-async def test_install_plugin_from_file_rejects_same_version_duplicate(tmp_path, monkeypatch):
+async def test_install_plugin_from_file_rejects_same_version_duplicate(
+    tmp_path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     manager = _manager()
     manager.plugins = [_plugin(name="demo")]
@@ -284,7 +286,9 @@ async def test_install_plugin_from_file_rejects_same_version_duplicate(tmp_path,
 
 
 @pytest.mark.asyncio
-async def test_install_plugin_raises_when_dependency_install_fails(tmp_path, monkeypatch):
+async def test_install_plugin_raises_when_dependency_install_fails(
+    tmp_path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     plugin_path = tmp_path / "data/plugins/tester__demo"
     plugin_path.mkdir(parents=True)
@@ -337,7 +341,9 @@ async def test_install_plugin_raises_when_dependency_install_fails(tmp_path, mon
 
 
 @pytest.mark.asyncio
-async def test_install_plugin_raises_verification_error_when_pip_lies(tmp_path, monkeypatch):
+async def test_install_plugin_raises_verification_error_when_pip_lies(
+    tmp_path, monkeypatch
+):
     """pip reports success but the dependency is still unsatisfiable."""
     monkeypatch.chdir(tmp_path)
     plugin_path = tmp_path / "data/plugins/tester__demo"
@@ -392,9 +398,9 @@ async def test_register_plugin_initializes_settings_and_refreshes_container():
     assert registered.install_source == PluginInstallSource.MARKETPLACE.value
     assert registered.install_info == {"plugin_version": "1.0.0"}
     assert registered.status is RuntimeContainerStatus.INITIALIZED
-    assert [component.manifest.metadata.name for component in registered.components] == [
-        "lookup"
-    ]
+    assert [
+        component.manifest.metadata.name for component in registered.components
+    ] == ["lookup"]
     assert handler.initialized_with["plugin_config"] == {"api_key": "secret"}
 
 

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -241,9 +241,7 @@ async def test_runtime_application_run_can_skip_deps_and_plugin_launch(monkeypat
         "PluginConnectionHandler",
         FakePluginHandler,
     )
-    app = runtime_app.RuntimeApplication(
-        _args(skip_deps_check=True, debug_only=True)
-    )
+    app = runtime_app.RuntimeApplication(_args(skip_deps_check=True, debug_only=True))
 
     await app.run()
 

--- a/tests/test_plugin_logbuffer.py
+++ b/tests/test_plugin_logbuffer.py
@@ -7,9 +7,7 @@ from langbot_plugin.runtime.plugin.logbuffer import PluginLogBuffer
 
 def test_parses_standard_log_line_level():
     buf = PluginLogBuffer()
-    buf.add_line(
-        "[06-13 10:30:00.123] main.py (45) - [INFO] : hello world"
-    )
+    buf.add_line("[06-13 10:30:00.123] main.py (45) - [INFO] : hello world")
     logs = buf.get_logs()
     assert len(logs) == 1
     assert logs[0]["level"] == "INFO"
@@ -18,9 +16,7 @@ def test_parses_standard_log_line_level():
 
 def test_continuation_line_inherits_level():
     buf = PluginLogBuffer()
-    buf.add_line(
-        "[06-13 10:30:00.123] main.py (45) - [ERROR] : boom"
-    )
+    buf.add_line("[06-13 10:30:00.123] main.py (45) - [ERROR] : boom")
     buf.add_line("Traceback (most recent call last):")
     buf.add_line('  File "x.py", line 1, in <module>')
     logs = buf.get_logs()
@@ -65,9 +61,7 @@ def test_empty_lines_skipped():
 def test_attach_stream_reads_to_eof():
     async def run():
         reader = asyncio.StreamReader()
-        reader.feed_data(
-            b"[06-13 10:30:00.1] a.py (1) - [INFO] : streamed\n"
-        )
+        reader.feed_data(b"[06-13 10:30:00.1] a.py (1) - [INFO] : streamed\n")
         reader.feed_eof()
         buf = PluginLogBuffer()
         await buf.attach_stream(reader)

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -58,12 +58,13 @@ def test_load_component_manifests_in_dir_respects_depth_and_file_extension(tmp_p
     components = engine.load_component_manifests_in_dir(str(tmp_path), max_depth=2)
 
     assert {component.metadata.name for component in components} == {"root", "nested"}
-    assert [component.metadata.name for component in engine.get_components_by_kind("Command")] == [
-        "root"
-    ]
-    assert [component.metadata.name for component in engine.get_components_by_kind("Tool")] == [
-        "nested"
-    ]
+    assert [
+        component.metadata.name
+        for component in engine.get_components_by_kind("Command")
+    ] == ["root"]
+    assert [
+        component.metadata.name for component in engine.get_components_by_kind("Tool")
+    ] == ["nested"]
 
 
 def test_discover_blueprint_loads_templates_before_other_component_groups(tmp_path):

--- a/tests/utils/test_importutil.py
+++ b/tests/utils/test_importutil.py
@@ -7,7 +7,9 @@ import textwrap
 from langbot_plugin.utils import importutil
 
 
-def test_import_dot_style_dir_imports_python_modules_from_package(tmp_path, monkeypatch):
+def test_import_dot_style_dir_imports_python_modules_from_package(
+    tmp_path, monkeypatch
+):
     package = tmp_path / "samplepkg"
     package.mkdir()
     (package / "__init__.py").write_text("", encoding="utf-8")


### PR DESCRIPTION
## Summary

Split the CI and formatting changes out of the AgentRunner pluginization PR.

This PR makes the lint job cover `src tests`, adds `ruff format --check src tests`, and applies the mechanical formatting needed for the new check to pass. It also includes the small lint cleanup required by widening `ruff check` from tests-only to `src tests`.

## Validation

- `uv run ruff format --check src tests` (`198 files already formatted`)
- `uv run ruff check src tests`