### PR TITLE
test: raise runtime coverage gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
             --ignore=tests/packaging \
             --cov=langbot_plugin \
             --cov-report=term-missing \
-            --cov-fail-under=82
+            --cov-fail-under=83
 
   test-lint:
     name: Lint and Format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
             --ignore=tests/packaging \
             --cov=langbot_plugin \
             --cov-report=term-missing \
-            --cov-fail-under=83
+            --cov-fail-under=84
 
   test-lint:
     name: Lint and Format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
             --ignore=tests/packaging \
             --cov=langbot_plugin \
             --cov-report=term-missing \
-            --cov-fail-under=79
+            --cov-fail-under=82
 
   test-lint:
     name: Lint and Format

--- a/tests/cli/run/test_runtime_handler.py
+++ b/tests/cli/run/test_runtime_handler.py
@@ -4,8 +4,22 @@ import asyncio
 from types import SimpleNamespace
 
 from langbot_plugin.api.definition.components.base import NoneComponent
+from langbot_plugin.api.definition.components.knowledge_engine.engine import (
+    KnowledgeEngine,
+)
 from langbot_plugin.api.definition.components.page import Page, PageRequest
+from langbot_plugin.api.definition.components.parser.parser import Parser
 from langbot_plugin.api.definition.components.tool.tool import Tool
+from langbot_plugin.api.entities.builtin.rag.context import (
+    RetrievalResponse,
+    RetrievalResultEntry,
+)
+from langbot_plugin.api.entities.builtin.rag.enums import DocumentStatus
+from langbot_plugin.api.entities.builtin.rag.models import (
+    IngestionResult,
+    ParseResult,
+)
+from langbot_plugin.api.entities.builtin.provider.message import ContentElement
 from langbot_plugin.cli.run.handler import PluginRuntimeHandler, _resolve_asset_path
 from langbot_plugin.entities.io.actions.enums import RuntimeToPluginAction
 
@@ -13,16 +27,27 @@ from tests.helpers.protocol import ProtocolConnection, ProtocolSession
 
 
 class FakeManifest:
-    def __init__(self, kind: str = "Plugin", name: str = "demo"):
+    def __init__(
+        self,
+        kind: str = "Plugin",
+        name: str = "demo",
+        component_class=None,
+    ):
         self.kind = kind
         self.metadata = SimpleNamespace(name=name)
         self.icon_rel_path = None
+        self._component_class = component_class
 
     def model_dump(self, **kwargs):
         return {
             "kind": self.kind,
             "metadata": {"name": self.metadata.name},
         }
+
+    def get_python_component_class(self):
+        if self._component_class is None:
+            raise AssertionError("component class not configured")
+        return self._component_class
 
 
 class FakePluginContainer:
@@ -40,8 +65,18 @@ class FakePluginContainer:
 
 
 class FakeComponentContainer:
-    def __init__(self, kind: str, name: str, component_instance):
-        self.manifest = FakeManifest(kind=kind, name=name)
+    def __init__(
+        self,
+        kind: str,
+        name: str,
+        component_instance,
+        component_class=None,
+    ):
+        self.manifest = FakeManifest(
+            kind=kind,
+            name=name,
+            component_class=component_class,
+        )
         self.component_instance = component_instance
 
 
@@ -61,6 +96,61 @@ class FakeTool(Tool):
     async def call(self, params, session, query_id):
         self.calls.append((params, session, query_id))
         return {"ok": True, "sender_id": session.sender_id, "query_id": query_id}
+
+
+class SimpleTool(Tool):
+    async def call(self, params):
+        return {"ok": True, "params": params}
+
+
+class FakeKnowledgeEngine(KnowledgeEngine):
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+
+    @classmethod
+    def get_capabilities(cls):
+        return ["doc_ingestion", "doc_parsing"]
+
+    async def ingest(self, context):
+        return IngestionResult(
+            document_id=context.file_object.metadata.document_id,
+            status=DocumentStatus.COMPLETED,
+            chunks_created=2,
+            metadata={"collection_id": context.get_collection_id()},
+        )
+
+    async def delete_document(self, kb_id: str, document_id: str) -> bool:
+        self.deleted.append((kb_id, document_id))
+        return True
+
+    async def retrieve(self, context):
+        return RetrievalResponse(
+            results=[
+                RetrievalResultEntry(
+                    id="chunk-1",
+                    content=[ContentElement.from_text(f"answer:{context.query}")],
+                    metadata={"kb": context.get_collection_id()},
+                    distance=0.1,
+                    score=0.9,
+                )
+            ],
+            total_found=1,
+        )
+
+    async def on_knowledge_base_create(self, kb_id: str, config: dict) -> None:
+        self.created.append((kb_id, config))
+
+    async def on_knowledge_base_delete(self, kb_id: str) -> None:
+        self.deleted.append((kb_id, None))
+
+
+class FakeParser(Parser):
+    async def parse(self, context):
+        return ParseResult(
+            text=context.file_content.decode() or context.filename,
+            metadata={"mime_type": context.mime_type},
+        )
 
 
 def _handler():
@@ -322,6 +412,219 @@ async def test_plugin_runtime_handler_call_tool_reports_missing_or_uninitialized
     assert uninitialized["message"] == "Tool is not initialized"
     assert missing["code"] == 1
     assert missing["message"] == "Tool missing not found"
+
+
+async def test_plugin_runtime_handler_call_tool_supports_simple_call_signature():
+    handler, _initialized = _handler()
+    handler.plugin_container.components = [
+        FakeComponentContainer(Tool.__kind__, "simple", SimpleTool())
+    ]
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            RuntimeToPluginAction.CALL_TOOL.value,
+            {
+                "tool_name": "simple",
+                "tool_parameters": {"x": 1},
+                "session": {},
+                "query_id": 1,
+            },
+        )
+
+    assert response["data"] == {"tool_response": {"ok": True, "params": {"x": 1}}}
+
+
+async def test_plugin_runtime_handler_knowledge_engine_actions_succeed():
+    handler, _initialized = _handler()
+    engine = FakeKnowledgeEngine()
+    handler.plugin_container.components = [
+        FakeComponentContainer(
+            KnowledgeEngine.__kind__,
+            "kb",
+            engine,
+            component_class=FakeKnowledgeEngine,
+        )
+    ]
+
+    async with ProtocolSession(handler) as session:
+        retrieve = await session.request(
+            RuntimeToPluginAction.RETRIEVE_KNOWLEDGE.value,
+            {
+                "retriever_name": "kb",
+                "retrieval_context": {
+                    "query": "hello",
+                    "knowledge_base_id": "kb-1",
+                },
+            },
+            seq_id=1,
+        )
+        ingest = await session.request(
+            RuntimeToPluginAction.INGEST_DOCUMENT.value,
+            {
+                "context": {
+                    "knowledge_base_id": "kb-1",
+                    "file_object": {
+                        "metadata": {
+                            "filename": "a.md",
+                            "file_size": 4,
+                            "mime_type": "text/markdown",
+                            "document_id": "doc-1",
+                            "knowledge_base_id": "kb-1",
+                        },
+                        "storage_path": "files/doc-1",
+                    },
+                }
+            },
+            seq_id=2,
+        )
+        delete_doc = await session.request(
+            RuntimeToPluginAction.DELETE_DOCUMENT.value,
+            {"kb_id": "kb-1", "document_id": "doc-1"},
+            seq_id=3,
+        )
+        create_kb = await session.request(
+            RuntimeToPluginAction.ON_KB_CREATE.value,
+            {"kb_id": "kb-2", "config": {"top_k": 3}},
+            seq_id=4,
+        )
+        delete_kb = await session.request(
+            RuntimeToPluginAction.ON_KB_DELETE.value,
+            {"kb_id": "kb-2"},
+            seq_id=5,
+        )
+        capabilities = await session.request(
+            RuntimeToPluginAction.GET_RAG_CAPABILITIES.value,
+            seq_id=6,
+        )
+
+    assert retrieve["data"]["total_found"] == 1
+    assert retrieve["data"]["results"][0]["content"][0]["text"] == "answer:hello"
+    assert ingest["data"]["document_id"] == "doc-1"
+    assert ingest["data"]["chunks_created"] == 2
+    assert delete_doc["data"] == {"success": True}
+    assert create_kb["data"] == {"success": True}
+    assert delete_kb["data"] == {"success": True}
+    assert capabilities["data"] == {"capabilities": ["doc_ingestion", "doc_parsing"]}
+    assert engine.created == [("kb-2", {"top_k": 3})]
+    assert engine.deleted == [("kb-1", "doc-1"), ("kb-2", None)]
+
+
+async def test_plugin_runtime_handler_knowledge_engine_reports_missing_states():
+    handler, _initialized = _handler()
+
+    async with ProtocolSession(handler) as session:
+        missing = await session.request(
+            RuntimeToPluginAction.RETRIEVE_KNOWLEDGE.value,
+            {"retriever_name": "kb", "retrieval_context": {"query": "hello"}},
+            seq_id=1,
+        )
+        missing_capabilities = await session.request(
+            RuntimeToPluginAction.GET_RAG_CAPABILITIES.value,
+            seq_id=2,
+        )
+
+    assert missing["code"] == 1
+    assert missing["message"] == "KnowledgeEngine kb not found"
+    assert missing_capabilities["code"] == 1
+    assert (
+        missing_capabilities["message"]
+        == "KnowledgeEngine component not found in this plugin"
+    )
+
+    handler, _initialized = _handler()
+    handler.plugin_container.components = [
+        FakeComponentContainer(KnowledgeEngine.__kind__, "kb", NoneComponent())
+    ]
+    async with ProtocolSession(handler) as session:
+        uninitialized = await session.request(
+            RuntimeToPluginAction.INGEST_DOCUMENT.value,
+            {
+                "context": {
+                    "knowledge_base_id": "kb-1",
+                    "file_object": {
+                        "metadata": {
+                            "filename": "a.md",
+                            "file_size": 4,
+                            "mime_type": "text/markdown",
+                            "document_id": "doc-1",
+                            "knowledge_base_id": "kb-1",
+                        },
+                        "storage_path": "files/doc-1",
+                    },
+                }
+            },
+        )
+
+    assert uninitialized["code"] == 1
+    assert uninitialized["message"] == "KnowledgeEngine component is not initialized"
+
+
+async def test_plugin_runtime_handler_parser_actions_succeed(tmp_path, monkeypatch):
+    handler, _initialized = _handler()
+    handler.plugin_container.components = [
+        FakeComponentContainer(Parser.__kind__, "pdf", FakeParser())
+    ]
+    read_keys = []
+    deleted_keys = []
+
+    async def fake_read_local_file(file_key):
+        read_keys.append(file_key)
+        return b"parsed bytes"
+
+    async def fake_delete_local_file(file_key):
+        deleted_keys.append(file_key)
+
+    monkeypatch.setattr(handler, "read_local_file", fake_read_local_file)
+    monkeypatch.setattr(handler, "delete_local_file", fake_delete_local_file)
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            RuntimeToPluginAction.PARSE_DOCUMENT.value,
+            {
+                "context": {
+                    "file_key": "file-key",
+                    "mime_type": "application/pdf",
+                    "filename": "a.pdf",
+                    "metadata": {"page": 1},
+                }
+            },
+        )
+
+    assert response["data"] == {
+        "text": "parsed bytes",
+        "sections": [],
+        "metadata": {"mime_type": "application/pdf"},
+    }
+    assert read_keys == ["file-key"]
+    assert deleted_keys == ["file-key"]
+
+
+async def test_plugin_runtime_handler_parser_reports_missing_states():
+    handler, _initialized = _handler()
+
+    async with ProtocolSession(handler) as session:
+        missing = await session.request(
+            RuntimeToPluginAction.PARSE_DOCUMENT.value,
+            {"context": {"filename": "a.pdf"}},
+            seq_id=1,
+        )
+
+    assert missing["code"] == 1
+    assert missing["message"] == "Parser component not found in this plugin"
+
+    handler, _initialized = _handler()
+    handler.plugin_container.components = [
+        FakeComponentContainer(Parser.__kind__, "pdf", NoneComponent())
+    ]
+    async with ProtocolSession(handler) as session:
+        uninitialized = await session.request(
+            RuntimeToPluginAction.PARSE_DOCUMENT.value,
+            {"context": {"filename": "a.pdf"}},
+            seq_id=2,
+        )
+
+    assert uninitialized["code"] == 1
+    assert uninitialized["message"] == "Parser component is not initialized"
 
 
 async def test_plugin_runtime_handler_shutdown_schedules_callback():

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
+from langbot_plugin.api.entities.context import EventContext
 from langbot_plugin.entities.io.actions.enums import (
     CommonAction,
     LangBotToRuntimeAction,
 )
 from langbot_plugin.runtime.io.handlers.control import ControlConnectionHandler
+from langbot_plugin.runtime.settings import settings as runtime_settings
 
 from tests.helpers.protocol import ProtocolConnection, ProtocolSession
 
@@ -39,9 +43,17 @@ class FakePluginManager:
         self.plugins = [FakePlugin()]
         self.calls = []
 
+    async def get_plugin_icon(self, author, plugin_name):
+        self.calls.append(("get_plugin_icon", author, plugin_name))
+        return b"icon", "image/svg+xml"
+
     async def get_plugin_readme(self, author, plugin_name, language):
         self.calls.append(("get_plugin_readme", author, plugin_name, language))
         return b"# readme"
+
+    async def get_plugin_logs(self, author, plugin_name, limit=200, level=None):
+        self.calls.append(("get_plugin_logs", author, plugin_name, limit, level))
+        return [{"level": level, "text": "ready"}]
 
     async def get_plugin_assets_file(self, author, plugin_name, file_key):
         self.calls.append(("get_plugin_assets_file", author, plugin_name, file_key))
@@ -82,6 +94,15 @@ class FakePluginManager:
         self.calls.append(("delete_plugin", plugin_author, plugin_name))
         yield {"current_action": "deleted"}
 
+    async def upgrade_plugin(self, plugin_author, plugin_name):
+        self.calls.append(("upgrade_plugin", plugin_author, plugin_name))
+        yield {"current_action": "upgraded"}
+
+    async def emit_event(self, event_context, include_plugins=None):
+        self.calls.append(("emit_event", event_context, include_plugins))
+        event_context.prevent_postorder()
+        return [self.plugins[0]], event_context
+
     async def list_tools(self, include_plugins=None):
         self.calls.append(("list_tools", include_plugins))
         return [Dumpable({"name": "weather"})]
@@ -110,6 +131,24 @@ class FakePluginManager:
         self.calls.append(("list_commands", include_plugins))
         return [Dumpable({"name": "start"})]
 
+    async def execute_command(self, command_context, include_plugins=None):
+        self.calls.append(("execute_command", command_context, include_plugins))
+        yield Dumpable({"text": command_context.command})
+
+    async def retrieve_knowledge(
+        self, plugin_author, plugin_name, retriever_name, retrieval_context
+    ):
+        self.calls.append(
+            (
+                "retrieve_knowledge",
+                plugin_author,
+                plugin_name,
+                retriever_name,
+                retrieval_context,
+            )
+        )
+        return {"results": [{"id": "r1"}]}
+
     async def list_knowledge_engines(self):
         self.calls.append(("list_knowledge_engines",))
         return [{"name": "rag"}]
@@ -119,6 +158,30 @@ class FakePluginManager:
             ("rag_ingest_document", plugin_author, plugin_name, context_data)
         )
         return {"document_id": "doc"}
+
+    async def rag_delete_document(self, plugin_author, plugin_name, kb_id, document_id):
+        self.calls.append(
+            ("rag_delete_document", plugin_author, plugin_name, kb_id, document_id)
+        )
+        return {"deleted": document_id}
+
+    async def rag_on_kb_create(self, plugin_author, plugin_name, kb_id, config):
+        self.calls.append(
+            ("rag_on_kb_create", plugin_author, plugin_name, kb_id, config)
+        )
+        return {"created": kb_id}
+
+    async def rag_on_kb_delete(self, plugin_author, plugin_name, kb_id):
+        self.calls.append(("rag_on_kb_delete", plugin_author, plugin_name, kb_id))
+        return {"deleted_kb": kb_id}
+
+    async def get_rag_creation_schema(self, plugin_author, plugin_name):
+        self.calls.append(("get_rag_creation_schema", plugin_author, plugin_name))
+        return {"schema": [{"name": "api_key"}]}
+
+    async def get_rag_retrieval_schema(self, plugin_author, plugin_name):
+        self.calls.append(("get_rag_retrieval_schema", plugin_author, plugin_name))
+        return {"schema": [{"name": "top_k"}]}
 
     async def list_parsers(self):
         self.calls.append(("list_parsers",))
@@ -182,6 +245,61 @@ async def test_control_handler_get_plugin_info_returns_match_or_none():
     assert missing["data"]["plugin"] is None
 
 
+async def test_control_handler_set_runtime_config_updates_cloud_service_url(
+    monkeypatch,
+):
+    handler, _manager = _handler()
+    monkeypatch.setattr(runtime_settings, "cloud_service_url", "https://old.example")
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.SET_RUNTIME_CONFIG.value,
+            {"cloud_service_url": "https://space.example/"},
+        )
+
+    assert response["data"] == {}
+    assert runtime_settings.cloud_service_url == "https://space.example"
+
+
+async def test_control_handler_get_debug_info_returns_runtime_settings(monkeypatch):
+    handler, _manager = _handler()
+    monkeypatch.setattr(runtime_settings, "plugin_debug_key", "debug-key")
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(LangBotToRuntimeAction.GET_DEBUG_INFO.value)
+
+    assert response["data"] == {
+        "plugin_debug_key": "debug-key",
+        "ws_debug_port": 5401,
+    }
+
+
+async def test_control_handler_get_plugin_icon_sends_file_key(monkeypatch):
+    handler, manager = _handler()
+
+    async def fake_send_file(file_bytes, extension):
+        assert file_bytes == b"icon"
+        assert extension == ""
+        return "icon-key"
+
+    monkeypatch.setattr(handler, "send_file", fake_send_file)
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.GET_PLUGIN_ICON.value,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+            },
+        )
+
+    assert manager.calls == [("get_plugin_icon", "tester", "demo")]
+    assert response["data"] == {
+        "plugin_icon_file_key": "icon-key",
+        "mime_type": "image/svg+xml",
+    }
+
+
 async def test_control_handler_get_plugin_readme_sends_file_key(monkeypatch):
     handler, manager = _handler()
 
@@ -204,6 +322,48 @@ async def test_control_handler_get_plugin_readme_sends_file_key(monkeypatch):
 
     assert manager.calls == [("get_plugin_readme", "tester", "demo", "zh")]
     assert response["data"] == {"readme_file_key": "readme-key"}
+
+
+async def test_control_handler_get_plugin_readme_returns_none_for_empty_readme(
+    monkeypatch,
+):
+    handler, manager = _handler()
+
+    async def fake_get_plugin_readme(author, plugin_name, language):
+        manager.calls.append(("get_plugin_readme", author, plugin_name, language))
+        return b""
+
+    monkeypatch.setattr(manager, "get_plugin_readme", fake_get_plugin_readme)
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.GET_PLUGIN_README.value,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+            },
+        )
+
+    assert manager.calls == [("get_plugin_readme", "tester", "demo", "en")]
+    assert response["data"] == {"readme_file_key": None}
+
+
+async def test_control_handler_get_plugin_logs_delegates_limit_and_level():
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.GET_PLUGIN_LOGS.value,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "limit": "5",
+                "level": "INFO",
+            },
+        )
+
+    assert manager.calls == [("get_plugin_logs", "tester", "demo", 5, "INFO")]
+    assert response["data"] == {"logs": [{"level": "INFO", "text": "ready"}]}
 
 
 async def test_control_handler_get_plugin_assets_file_sends_file_key(monkeypatch):
@@ -231,6 +391,33 @@ async def test_control_handler_get_plugin_assets_file_sends_file_key(monkeypatch
         "file_file_key": "asset-key",
         "mime_type": "text/plain",
     }
+
+
+async def test_control_handler_get_plugin_assets_file_returns_none_for_missing_file(
+    monkeypatch,
+):
+    handler, manager = _handler()
+
+    async def fake_get_plugin_assets_file(author, plugin_name, file_key):
+        manager.calls.append(("get_plugin_assets_file", author, plugin_name, file_key))
+        return b"", ""
+
+    monkeypatch.setattr(manager, "get_plugin_assets_file", fake_get_plugin_assets_file)
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.GET_PLUGIN_ASSETS_FILE.value,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "file_path": "missing.txt",
+            },
+        )
+
+    assert manager.calls == [
+        ("get_plugin_assets_file", "tester", "demo", "missing.txt")
+    ]
+    assert response["data"] == {"file_file_key": None, "mime_type": None}
 
 
 async def test_control_handler_page_api_validates_required_fields():
@@ -327,6 +514,116 @@ async def test_control_handler_install_plugin_streams_progress_and_reads_local_p
     ]
 
 
+async def test_control_handler_install_plugin_marketplace_does_not_read_local_file():
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        responses = await session.request_messages(
+            LangBotToRuntimeAction.INSTALL_PLUGIN.value,
+            {
+                "install_source": "marketplace",
+                "install_info": {
+                    "plugin_author": "tester",
+                    "plugin_name": "demo",
+                    "plugin_version": "1.0.0",
+                },
+            },
+            count=4,
+        )
+
+    assert manager.calls == [
+        (
+            "install_plugin",
+            "marketplace",
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "plugin_version": "1.0.0",
+            },
+        )
+    ]
+    assert [response["data"] for response in responses] == [
+        {"current_action": "downloaded"},
+        {"current_action": "mounted"},
+        {"current_action": "plugin installed"},
+        {},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_call", "terminal_action"),
+    [
+        (
+            LangBotToRuntimeAction.RESTART_PLUGIN,
+            "restart_plugin",
+            "plugin restarted",
+        ),
+        (
+            LangBotToRuntimeAction.DELETE_PLUGIN,
+            "delete_plugin",
+            "plugin removed",
+        ),
+        (
+            LangBotToRuntimeAction.UPGRADE_PLUGIN,
+            "upgrade_plugin",
+            "plugin upgraded",
+        ),
+    ],
+)
+async def test_control_handler_plugin_lifecycle_actions_stream_progress(
+    action,
+    expected_call,
+    terminal_action,
+):
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        responses = await session.request_messages(
+            action.value,
+            {"plugin_author": "tester", "plugin_name": "demo"},
+            count=3,
+        )
+
+    assert manager.calls == [(expected_call, "tester", "demo")]
+    assert responses[-2]["data"] == {"current_action": terminal_action}
+    assert responses[-1]["chunk_status"] == "end"
+
+
+async def test_control_handler_emit_event_delegates_and_serializes_result():
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.EMIT_EVENT.value,
+            {
+                "include_plugins": ["tester/demo"],
+                "event_context": {
+                    "query_id": 12,
+                    "event_name": "PersonCommandSent",
+                    "event": {
+                        "event_name": "PersonCommandSent",
+                        "launcher_type": "person",
+                        "launcher_id": "launcher",
+                        "sender_id": "sender",
+                        "command": "demo",
+                        "params": [],
+                        "text_message": "/demo",
+                        "is_admin": False,
+                    },
+                },
+            },
+        )
+
+    call_name, event_context, include_plugins = manager.calls[0]
+    assert call_name == "emit_event"
+    assert isinstance(event_context, EventContext)
+    assert include_plugins == ["tester/demo"]
+    assert response["data"]["emitted_plugins"] == [
+        {"manifest": {"author": "tester", "name": "demo"}}
+    ]
+    assert response["data"]["event_context"]["is_prevent_postorder"] is True
+
+
 async def test_control_handler_parse_document_reads_transferred_file(monkeypatch):
     handler, manager = _handler()
     file_ops = []
@@ -364,6 +661,31 @@ async def test_control_handler_parse_document_reads_transferred_file(monkeypatch
     assert response["data"] == {"text": "parsed"}
 
 
+async def test_control_handler_parse_document_without_file_key_uses_empty_bytes():
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.PARSE_DOCUMENT.value,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "context": {"mime_type": "text/plain"},
+            },
+        )
+
+    assert manager.calls == [
+        (
+            "parse_document",
+            "tester",
+            "demo",
+            {"mime_type": "text/plain"},
+            b"",
+        )
+    ]
+    assert response["data"] == {"text": "parsed"}
+
+
 async def test_control_handler_lists_tools_and_commands_with_include_filter():
     handler, manager = _handler()
 
@@ -385,6 +707,41 @@ async def test_control_handler_lists_tools_and_commands_with_include_filter():
         ("list_tools", ["tester/demo"]),
         ("list_commands", ["tester/demo"]),
     ]
+
+
+async def test_control_handler_execute_command_streams_command_returns():
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        responses = await session.request_messages(
+            LangBotToRuntimeAction.EXECUTE_COMMAND.value,
+            {
+                "include_plugins": ["tester/demo"],
+                "command_context": {
+                    "query_id": 7,
+                    "session": {
+                        "launcher_type": "person",
+                        "launcher_id": "launcher",
+                        "sender_id": "sender",
+                    },
+                    "command_text": "start now",
+                    "full_command_text": "/start now",
+                    "command": "start",
+                    "crt_command": "start",
+                    "params": ["now"],
+                    "crt_params": ["now"],
+                    "privilege": 0,
+                },
+            },
+            count=2,
+        )
+
+    call_name, command_context, include_plugins = manager.calls[0]
+    assert call_name == "execute_command"
+    assert command_context.command == "start"
+    assert include_plugins == ["tester/demo"]
+    assert responses[0]["data"] == {"text": "start"}
+    assert responses[1]["chunk_status"] == "end"
 
 
 async def test_control_handler_call_tool_delegates_session_and_query_context():
@@ -455,3 +812,93 @@ async def test_control_handler_rag_ingest_document_delegates_context():
             {"document_id": "doc"},
         )
     ]
+
+
+async def test_control_handler_retrieve_knowledge_delegates_context():
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            LangBotToRuntimeAction.RETRIEVE_KNOWLEDGE.value,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "retriever_name": "kb",
+                "retrieval_context": {"query": "hello"},
+            },
+        )
+
+    assert response["data"] == {"results": [{"id": "r1"}]}
+    assert manager.calls == [
+        (
+            "retrieve_knowledge",
+            "tester",
+            "demo",
+            "kb",
+            {"query": "hello"},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("action", "payload", "expected_call", "expected_response"),
+    [
+        (
+            LangBotToRuntimeAction.RAG_DELETE_DOCUMENT,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "kb_id": "kb-1",
+                "document_id": "doc-1",
+            },
+            ("rag_delete_document", "tester", "demo", "kb-1", "doc-1"),
+            {"deleted": "doc-1"},
+        ),
+        (
+            LangBotToRuntimeAction.RAG_ON_KB_CREATE,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "kb_id": "kb-1",
+                "config": {"top_k": 3},
+            },
+            ("rag_on_kb_create", "tester", "demo", "kb-1", {"top_k": 3}),
+            {"created": "kb-1"},
+        ),
+        (
+            LangBotToRuntimeAction.RAG_ON_KB_DELETE,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "kb_id": "kb-1",
+            },
+            ("rag_on_kb_delete", "tester", "demo", "kb-1"),
+            {"deleted_kb": "kb-1"},
+        ),
+        (
+            LangBotToRuntimeAction.GET_RAG_CREATION_SETTINGS_SCHEMA,
+            {"plugin_author": "tester", "plugin_name": "demo"},
+            ("get_rag_creation_schema", "tester", "demo"),
+            {"schema": [{"name": "api_key"}]},
+        ),
+        (
+            LangBotToRuntimeAction.GET_RAG_RETRIEVAL_SETTINGS_SCHEMA,
+            {"plugin_author": "tester", "plugin_name": "demo"},
+            ("get_rag_retrieval_schema", "tester", "demo"),
+            {"schema": [{"name": "top_k"}]},
+        ),
+    ],
+)
+async def test_control_handler_rag_actions_delegate_to_plugin_manager(
+    action,
+    payload,
+    expected_call,
+    expected_response,
+):
+    handler, manager = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(action.value, payload)
+
+    assert response["data"] == expected_response
+    assert manager.calls == [expected_call]

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import pytest
 from types import SimpleNamespace
 
 from langbot_plugin.entities.io.actions.enums import (
     PluginToRuntimeAction,
+    RuntimeToPluginAction,
     RuntimeToLangBotAction,
 )
 import langbot_plugin.runtime.plugin.container  # noqa: F401
@@ -160,6 +162,195 @@ async def test_plugin_handler_forwards_invoke_llm_with_validated_timeout():
     ]
 
 
+@pytest.mark.parametrize(
+    ("action", "payload", "expected_action", "expected_payload", "expected_timeout"),
+    [
+        (
+            PluginToRuntimeAction.REPLY_MESSAGE,
+            {"query_id": 1, "message": "hi"},
+            PluginToRuntimeAction.REPLY_MESSAGE,
+            {"query_id": 1, "message": "hi"},
+            180,
+        ),
+        (
+            PluginToRuntimeAction.GET_BOT_UUID,
+            {"query_id": 2},
+            PluginToRuntimeAction.GET_BOT_UUID,
+            {"query_id": 2},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.SET_QUERY_VAR,
+            {"query_id": 3, "key": "k", "value": "v"},
+            PluginToRuntimeAction.SET_QUERY_VAR,
+            {"query_id": 3, "key": "k", "value": "v"},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.GET_QUERY_VAR,
+            {"query_id": 3, "key": "k"},
+            PluginToRuntimeAction.GET_QUERY_VAR,
+            {"query_id": 3, "key": "k"},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.GET_QUERY_VARS,
+            {"query_id": 3},
+            PluginToRuntimeAction.GET_QUERY_VARS,
+            {"query_id": 3},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.CREATE_NEW_CONVERSATION,
+            {"query_id": 4, "ignored": "value"},
+            PluginToRuntimeAction.CREATE_NEW_CONVERSATION,
+            {"query_id": 4},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.GET_LANGBOT_VERSION,
+            {},
+            PluginToRuntimeAction.GET_LANGBOT_VERSION,
+            {},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.GET_BOTS,
+            {},
+            PluginToRuntimeAction.GET_BOTS,
+            {},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.GET_BOT_INFO,
+            {"bot_uuid": "bot-1"},
+            PluginToRuntimeAction.GET_BOT_INFO,
+            {"bot_uuid": "bot-1"},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.SEND_MESSAGE,
+            {"bot_uuid": "bot-1", "message": "hi"},
+            PluginToRuntimeAction.SEND_MESSAGE,
+            {"bot_uuid": "bot-1", "message": "hi"},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.GET_LLM_MODELS,
+            {},
+            PluginToRuntimeAction.GET_LLM_MODELS,
+            {},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.INVOKE_EMBEDDING,
+            {"model": "embed", "texts": ["hello"]},
+            PluginToRuntimeAction.INVOKE_EMBEDDING,
+            {"model": "embed", "texts": ["hello"]},
+            60,
+        ),
+        (
+            PluginToRuntimeAction.INVOKE_RERANK,
+            {"model": "rerank", "query": "q", "docs": ["d"]},
+            PluginToRuntimeAction.INVOKE_RERANK,
+            {"model": "rerank", "query": "q", "docs": ["d"]},
+            60,
+        ),
+        (
+            PluginToRuntimeAction.VECTOR_UPSERT,
+            {"collection_id": "kb", "points": []},
+            PluginToRuntimeAction.VECTOR_UPSERT,
+            {"collection_id": "kb", "points": []},
+            60,
+        ),
+        (
+            PluginToRuntimeAction.VECTOR_SEARCH,
+            {"collection_id": "kb", "vector": [0.1]},
+            PluginToRuntimeAction.VECTOR_SEARCH,
+            {"collection_id": "kb", "vector": [0.1]},
+            30,
+        ),
+        (
+            PluginToRuntimeAction.VECTOR_DELETE,
+            {"collection_id": "kb", "ids": ["p1"]},
+            PluginToRuntimeAction.VECTOR_DELETE,
+            {"collection_id": "kb", "ids": ["p1"]},
+            30,
+        ),
+        (
+            PluginToRuntimeAction.LIST_KNOWLEDGE_BASES,
+            {},
+            PluginToRuntimeAction.LIST_KNOWLEDGE_BASES,
+            {},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.RETRIEVE_KNOWLEDGE,
+            {"query": "hello"},
+            PluginToRuntimeAction.RETRIEVE_KNOWLEDGE,
+            {"query": "hello"},
+            30,
+        ),
+        (
+            PluginToRuntimeAction.LIST_PIPELINE_KNOWLEDGE_BASES,
+            {"query_id": 5},
+            PluginToRuntimeAction.LIST_PIPELINE_KNOWLEDGE_BASES,
+            {"query_id": 5},
+            15.0,
+        ),
+        (
+            PluginToRuntimeAction.RETRIEVE_KNOWLEDGE_BASE,
+            {"query_id": 5, "query": "hello"},
+            PluginToRuntimeAction.RETRIEVE_KNOWLEDGE_BASE,
+            {"query_id": 5, "query": "hello"},
+            30,
+        ),
+        (
+            PluginToRuntimeAction.LIST_PARSERS,
+            {},
+            PluginToRuntimeAction.LIST_PARSERS,
+            {},
+            30,
+        ),
+        (
+            PluginToRuntimeAction.INVOKE_PARSER,
+            {"parser": "pdf", "file_key": "file"},
+            PluginToRuntimeAction.INVOKE_PARSER,
+            {"parser": "pdf", "file_key": "file"},
+            300,
+        ),
+    ],
+)
+async def test_plugin_handler_proxies_control_actions(
+    action,
+    payload,
+    expected_action,
+    expected_payload,
+    expected_timeout,
+):
+    handler, _manager, control = _handler()
+    control.results[expected_action] = {"proxied": expected_action.value}
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(action.value, dict(payload))
+
+    assert response["data"] == {"proxied": expected_action.value}
+    assert control.calls == [(expected_action, expected_payload, expected_timeout)]
+
+
+async def test_plugin_handler_forwards_invoke_llm_with_custom_timeout():
+    handler, _manager, control = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            PluginToRuntimeAction.INVOKE_LLM.value,
+            {"messages": [], "timeout": 30},
+        )
+
+    assert response["code"] == 0
+    assert control.calls == [(PluginToRuntimeAction.INVOKE_LLM, {"messages": []}, 30.0)]
+
+
 async def test_plugin_handler_adds_plugin_owner_for_binary_storage():
     handler, manager, control = _handler()
     manager.plugins = [FakePluginContainer(runtime_handler=handler)]
@@ -185,6 +376,40 @@ async def test_plugin_handler_adds_plugin_owner_for_binary_storage():
     ]
 
 
+@pytest.mark.parametrize(
+    ("action", "expected_action"),
+    [
+        (
+            PluginToRuntimeAction.GET_PLUGIN_STORAGE,
+            RuntimeToLangBotAction.GET_BINARY_STORAGE,
+        ),
+        (
+            PluginToRuntimeAction.GET_PLUGIN_STORAGE_KEYS,
+            RuntimeToLangBotAction.GET_BINARY_STORAGE_KEYS,
+        ),
+        (
+            PluginToRuntimeAction.DELETE_PLUGIN_STORAGE,
+            RuntimeToLangBotAction.DELETE_BINARY_STORAGE,
+        ),
+    ],
+)
+async def test_plugin_handler_plugin_storage_actions_add_owner(action, expected_action):
+    handler, manager, control = _handler()
+    manager.plugins = [FakePluginContainer(runtime_handler=handler)]
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(action.value, {"key": "cache"})
+
+    assert response["code"] == 0
+    assert control.calls == [
+        (
+            expected_action,
+            {"key": "cache", "owner_type": "plugin", "owner": "tester/demo"},
+            15.0,
+        )
+    ]
+
+
 async def test_plugin_handler_workspace_storage_uses_default_workspace_owner():
     handler, _manager, control = _handler()
 
@@ -198,6 +423,42 @@ async def test_plugin_handler_workspace_storage_uses_default_workspace_owner():
     assert control.calls == [
         (
             RuntimeToLangBotAction.GET_BINARY_STORAGE,
+            {"key": "shared", "owner_type": "workspace", "owner": "default"},
+            15.0,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_action"),
+    [
+        (
+            PluginToRuntimeAction.SET_WORKSPACE_STORAGE,
+            RuntimeToLangBotAction.SET_BINARY_STORAGE,
+        ),
+        (
+            PluginToRuntimeAction.GET_WORKSPACE_STORAGE_KEYS,
+            RuntimeToLangBotAction.GET_BINARY_STORAGE_KEYS,
+        ),
+        (
+            PluginToRuntimeAction.DELETE_WORKSPACE_STORAGE,
+            RuntimeToLangBotAction.DELETE_BINARY_STORAGE,
+        ),
+    ],
+)
+async def test_plugin_handler_workspace_storage_actions_use_default_owner(
+    action,
+    expected_action,
+):
+    handler, _manager, control = _handler()
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(action.value, {"key": "shared"})
+
+    assert response["code"] == 0
+    assert control.calls == [
+        (
+            expected_action,
             {"key": "shared", "owner_type": "workspace", "owner": "default"},
             15.0,
         )
@@ -262,6 +523,19 @@ async def test_plugin_handler_get_knowledge_file_stream_repackages_file(monkeypa
     assert response["data"] == {"file_key": "plugin-file"}
 
 
+async def test_plugin_handler_get_knowledge_file_stream_returns_empty_result():
+    handler, _manager, control = _handler()
+    control.results[PluginToRuntimeAction.GET_KNOWLEDEGE_FILE_STREAM] = {"file_key": ""}
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            PluginToRuntimeAction.GET_KNOWLEDEGE_FILE_STREAM.value,
+            {"storage_path": "kb/doc"},
+        )
+
+    assert response["data"] == {"file_key": ""}
+
+
 async def test_plugin_handler_lists_tools_and_reports_missing_tool_detail():
     handler, manager, _control = _handler()
     manager.tools = [FakeTool("weather")]
@@ -277,6 +551,19 @@ async def test_plugin_handler_lists_tools_and_reports_missing_tool_detail():
     assert listed["data"] == {"tools": [{"name": "weather"}]}
     assert missing["code"] == 1
     assert missing["message"] == "Tool not found: missing"
+
+
+async def test_plugin_handler_get_tool_detail_returns_matching_tool():
+    handler, manager, _control = _handler()
+    manager.tools = [FakeTool("weather")]
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            PluginToRuntimeAction.GET_TOOL_DETAIL.value,
+            {"tool_name": "weather"},
+        )
+
+    assert response["data"] == {"tool": {"name": "weather"}}
 
 
 async def test_plugin_handler_calls_registered_runtime_tool():
@@ -317,3 +604,153 @@ async def test_plugin_handler_lists_plugin_manifests():
     assert response["data"] == {
         "plugins": [{"metadata": {"author": "tester", "name": "demo"}}]
     }
+
+
+async def test_plugin_handler_lists_commands():
+    handler, manager, _control = _handler()
+    manager.commands = [Dumpable({"name": "admin"})]
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(PluginToRuntimeAction.LIST_COMMANDS.value)
+
+    assert response["data"] == {"commands": [{"name": "admin"}]}
+
+
+async def test_plugin_connection_handler_peer_call_helpers(monkeypatch):
+    handler, _manager, _control = _handler()
+    calls = []
+
+    async def fake_call_action(action, data, timeout=15.0):
+        calls.append((action, data, timeout))
+        return {"action": action.value, "data": data}
+
+    monkeypatch.setattr(handler, "call_action", fake_call_action)
+
+    assert await handler.initialize_plugin({"enabled": True}) == {
+        "action": RuntimeToPluginAction.INITIALIZE_PLUGIN.value,
+        "data": {"plugin_settings": {"enabled": True}},
+    }
+    assert await handler.get_plugin_container() == {
+        "action": RuntimeToPluginAction.GET_PLUGIN_CONTAINER.value,
+        "data": {},
+    }
+    assert await handler.get_plugin_icon() == {
+        "action": RuntimeToPluginAction.GET_PLUGIN_ICON.value,
+        "data": {},
+    }
+    assert await handler.get_plugin_readme("zh") == {
+        "action": RuntimeToPluginAction.GET_PLUGIN_README.value,
+        "data": {"language": "zh"},
+    }
+    assert await handler.get_plugin_assets_file("asset.txt") == {
+        "action": RuntimeToPluginAction.GET_PLUGIN_ASSETS_FILE.value,
+        "data": {"file_key": "asset.txt"},
+    }
+    assert await handler.call_page_api(
+        page_id="settings",
+        endpoint="/save",
+        method="POST",
+        body={"enabled": True},
+    ) == {
+        "action": RuntimeToPluginAction.PAGE_API.value,
+        "data": {
+            "page_id": "settings",
+            "endpoint": "/save",
+            "method": "POST",
+            "body": {"enabled": True},
+        },
+    }
+    assert await handler.emit_event({"event_name": "PersonMessageReceived"}) == {
+        "action": RuntimeToPluginAction.EMIT_EVENT.value,
+        "data": {"event_context": {"event_name": "PersonMessageReceived"}},
+    }
+    assert await handler.call_tool("weather", {"city": "Paris"}, {"id": "s"}, 9) == {
+        "action": RuntimeToPluginAction.CALL_TOOL.value,
+        "data": {
+            "tool_name": "weather",
+            "tool_parameters": {"city": "Paris"},
+            "session": {"id": "s"},
+            "query_id": 9,
+        },
+    }
+    assert await handler.retrieve_knowledge("kb", {"query": "hi"}) == {
+        "action": RuntimeToPluginAction.RETRIEVE_KNOWLEDGE.value,
+        "data": {"retriever_name": "kb", "retrieval_context": {"query": "hi"}},
+    }
+    assert await handler.shutdown_plugin() == {
+        "action": RuntimeToPluginAction.SHUTDOWN.value,
+        "data": {},
+    }
+    assert await handler.rag_ingest_document({"document_id": "doc-1"}) == {
+        "action": RuntimeToPluginAction.INGEST_DOCUMENT.value,
+        "data": {"context": {"document_id": "doc-1"}},
+    }
+    assert await handler.rag_delete_document("kb-1", "doc-1") == {
+        "action": RuntimeToPluginAction.DELETE_DOCUMENT.value,
+        "data": {"kb_id": "kb-1", "document_id": "doc-1"},
+    }
+    assert await handler.rag_on_kb_create("kb-1", {"top_k": 3}) == {
+        "action": RuntimeToPluginAction.ON_KB_CREATE.value,
+        "data": {"kb_id": "kb-1", "config": {"top_k": 3}},
+    }
+    assert await handler.rag_on_kb_delete("kb-1") == {
+        "action": RuntimeToPluginAction.ON_KB_DELETE.value,
+        "data": {"kb_id": "kb-1"},
+    }
+    assert await handler.get_rag_capabilities() == {
+        "action": RuntimeToPluginAction.GET_RAG_CAPABILITIES.value,
+        "data": {},
+    }
+    assert calls[-1] == (RuntimeToPluginAction.GET_RAG_CAPABILITIES, {}, 10)
+
+
+async def test_plugin_connection_handler_execute_command_and_parse_document_helpers(
+    monkeypatch,
+):
+    handler, _manager, _control = _handler()
+    calls = []
+
+    async def fake_generator(action, data, timeout=15.0):
+        calls.append(("generator", action, data, timeout))
+        yield {"command_response": {"text": "one"}}
+        yield {"command_response": {"text": "two"}}
+
+    async def fake_send_file(file_bytes, extension):
+        calls.append(("send_file", file_bytes, extension))
+        return "file-key"
+
+    async def fake_call_action(action, data, timeout=15.0):
+        calls.append(("call_action", action, data, timeout))
+        return {"parsed": data}
+
+    monkeypatch.setattr(handler, "call_action_generator", fake_generator)
+    monkeypatch.setattr(handler, "send_file", fake_send_file)
+    monkeypatch.setattr(handler, "call_action", fake_call_action)
+
+    command_chunks = [
+        chunk async for chunk in handler.execute_command({"command": "admin"})
+    ]
+    parse_result = await handler.parse_document({"filename": "a.pdf"}, b"pdf")
+
+    assert command_chunks == [
+        {"command_response": {"text": "one"}},
+        {"command_response": {"text": "two"}},
+    ]
+    assert calls[0] == (
+        "generator",
+        RuntimeToPluginAction.EXECUTE_COMMAND,
+        {"command_context": {"command": "admin"}},
+        plugin_handler_module.LONG_RUNNING_OPERATION_TIMEOUT,
+    )
+    assert parse_result == {
+        "parsed": {"context": {"filename": "a.pdf", "file_key": "file-key"}}
+    }
+    assert calls[-2:] == [
+        ("send_file", b"pdf", ""),
+        (
+            "call_action",
+            RuntimeToPluginAction.PARSE_DOCUMENT,
+            {"context": {"filename": "a.pdf", "file_key": "file-key"}},
+            300,
+        ),
+    ]

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -14,12 +14,14 @@ from langbot_plugin.api.definition.plugin import NonePlugin
 from langbot_plugin.api.entities.builtin.command.context import CommandReturn
 from langbot_plugin.api.entities.context import EventContext
 from langbot_plugin.api.entities.events import PersonCommandSent
+from langbot_plugin.runtime.helper import marketplace as marketplace_helper
 from langbot_plugin.runtime.plugin.container import (
     ComponentContainer,
     PluginContainer,
     RuntimeContainerStatus,
 )
 from langbot_plugin.runtime.plugin.mgr import PluginInstallSource, PluginManager
+from langbot_plugin.entities.io.actions.enums import RuntimeToLangBotAction
 from langbot_plugin.entities.io.errors import (
     DependencyInstallError,
     DependencyVerificationError,
@@ -129,6 +131,11 @@ class FakeConnection:
         self.closed = True
 
 
+class FakeLogBuffer:
+    def get_logs(self, limit=200, level=None):
+        return [{"limit": limit, "level": level, "text": "ready"}]
+
+
 class FakeHandler:
     def __init__(self, plugin: PluginContainer):
         self.plugin = plugin
@@ -137,6 +144,7 @@ class FakeHandler:
         self.stdio_process = None
         self.initialized_with = None
         self.shutdown_calls = 0
+        self.log_buffer = FakeLogBuffer()
         self.files = {
             "icon-key": b"<svg/>",
             "readme-key": b"# Demo",
@@ -199,6 +207,12 @@ class FakeHandler:
 
     async def get_rag_capabilities(self):
         return {"capabilities": ["ingest", "retrieve"]}
+
+    async def retrieve_knowledge(self, retriever_name, retrieval_context):
+        return {
+            "retriever_name": retriever_name,
+            "retrieval_context": retrieval_context,
+        }
 
     async def rag_ingest_document(self, context_data):
         return {"ingested": context_data["document_id"]}
@@ -405,6 +419,36 @@ async def test_register_plugin_initializes_settings_and_refreshes_container():
 
 
 @pytest.mark.asyncio
+async def test_register_debug_plugin_initializes_settings_first():
+    manager = _manager()
+    control_handler = FakeControlHandler()
+    manager.context = SimpleNamespace(control_handler=control_handler)
+    plugin = _plugin(name="debug", status=RuntimeContainerStatus.MOUNTED)
+    handler = FakeHandler(plugin)
+    handler.debug_plugin = True
+
+    await manager.register_plugin(handler, plugin.model_dump(), debug_plugin=True)
+
+    assert [call[0] for call in control_handler.calls] == [
+        RuntimeToLangBotAction.INITIALIZE_PLUGIN_SETTINGS,
+        RuntimeToLangBotAction.GET_PLUGIN_SETTINGS,
+    ]
+    assert (
+        control_handler.calls[0][1]["install_source"] == PluginInstallSource.DEBUG.value
+    )
+    assert manager.plugins[0].debug is True
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_requires_control_handler():
+    manager = _manager()
+    plugin = _plugin(status=RuntimeContainerStatus.MOUNTED)
+
+    with pytest.raises(ValueError, match="Failed to get plugin settings"):
+        await manager.register_plugin(FakeHandler(plugin), plugin.model_dump())
+
+
+@pytest.mark.asyncio
 async def test_call_tool_and_execute_command_delegate_to_connected_plugin():
     manager = _manager()
     plugin = _plugin(
@@ -441,6 +485,39 @@ async def test_call_tool_and_execute_command_delegate_to_connected_plugin():
 
 
 @pytest.mark.asyncio
+async def test_call_tool_and_execute_command_return_empty_when_filtered_or_disconnected():
+    manager = _manager()
+    plugin = _plugin(
+        components=[
+            _component("Tool", "lookup"),
+            _component("Command", "admin"),
+        ]
+    )
+    manager.plugins = [plugin]
+
+    assert (
+        await manager.call_tool(
+            "lookup",
+            {},
+            {},
+            query_id=1,
+            include_plugins=["tester/other"],
+        )
+        == {}
+    )
+    assert await manager.call_tool("lookup", {}, {}, query_id=1) == {}
+    assert [
+        response
+        async for response in manager.execute_command(
+            SimpleNamespace(
+                command="admin",
+                model_dump=lambda mode="json": {"command": "admin"},
+            )
+        )
+    ] == []
+
+
+@pytest.mark.asyncio
 async def test_shutdown_plugin_closes_connection_and_removes_container():
     manager = _manager()
     plugin = _plugin()
@@ -455,6 +532,100 @@ async def test_shutdown_plugin_closes_connection_and_removes_container():
     assert manager.plugin_handlers == []
     assert handler.shutdown_calls == 1
     assert handler.conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_restart_plugin_debug_skips_relaunch_and_missing_plugin_errors():
+    manager = _manager()
+    plugin = _plugin(debug=True)
+    handler = FakeHandler(plugin)
+    plugin._runtime_plugin_handler = handler
+    manager.plugins = [plugin]
+    manager.plugin_handlers = [handler]
+
+    actions = [
+        item["current_action"]
+        async for item in manager.restart_plugin("tester", "demo")
+    ]
+
+    assert actions == [
+        "shutting down plugin",
+        "removing plugin container",
+        "plugin restarted",
+    ]
+    assert manager.plugin_run_tasks == []
+    assert manager.plugins == []
+
+    with pytest.raises(ValueError, match="Plugin tester/missing not found"):
+        async for _ in manager.restart_plugin("tester", "missing"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_delete_plugin_removes_files_and_rejects_debug_plugins(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    manager = _manager()
+    plugin_path = tmp_path / "data/plugins/tester__demo"
+    plugin_path.mkdir(parents=True)
+    (plugin_path / "manifest.yaml").write_text("kind: Plugin\n", encoding="utf-8")
+    plugin = _plugin()
+    handler = FakeHandler(plugin)
+    plugin._runtime_plugin_handler = handler
+    manager.plugins = [plugin]
+    manager.plugin_handlers = [handler]
+
+    actions = [
+        item["current_action"] async for item in manager.delete_plugin("tester", "demo")
+    ]
+
+    assert actions == [
+        "shutting down plugin",
+        "removing plugin container",
+        "deleting plugin files",
+        "plugin deleted",
+    ]
+    assert not plugin_path.exists()
+
+    debug = _plugin(debug=True)
+    manager.plugins = [debug]
+    with pytest.raises(ValueError, match="is a debugging plugin"):
+        async for _ in manager.delete_plugin("tester", "demo"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_upgrade_plugin_validates_source_and_reports_up_to_date(monkeypatch):
+    manager = _manager()
+    debug = _plugin(debug=True)
+    manager.plugins = [debug]
+
+    with pytest.raises(ValueError, match="is a debugging plugin"):
+        async for _ in manager.upgrade_plugin("tester", "demo"):
+            pass
+
+    local = _plugin()
+    manager.plugins = [local]
+    with pytest.raises(ValueError, match="not installed from marketplace"):
+        async for _ in manager.upgrade_plugin("tester", "demo"):
+            pass
+
+    marketplace = _plugin()
+    marketplace.install_source = PluginInstallSource.MARKETPLACE.value
+    manager.plugins = [marketplace]
+
+    async def fake_get_plugin_info(author, name):
+        return SimpleNamespace(latest_version="1.0.0")
+
+    monkeypatch.setattr(marketplace_helper, "get_plugin_info", fake_get_plugin_info)
+
+    actions = [
+        item["current_action"]
+        async for item in manager.upgrade_plugin("tester", "demo")
+    ]
+
+    assert actions == ["checking for latest version", "plugin is up to date"]
 
 
 @pytest.mark.asyncio
@@ -500,6 +671,34 @@ async def test_plugin_resource_and_page_methods_delegate_to_connected_handler():
         endpoint="/save",
         method="POST",
     ) == {"data": None, "error": "Plugin not found"}
+
+
+@pytest.mark.asyncio
+async def test_plugin_logs_and_resource_methods_handle_missing_connections():
+    manager = _manager()
+    assert await manager.get_plugin_logs("tester", "missing") == []
+    assert await manager.get_plugin_readme("tester", "missing") == b""
+    assert await manager.get_plugin_assets_file("tester", "missing", "asset.txt") == (
+        b"",
+        "",
+    )
+
+    plugin = _plugin()
+    manager.plugins = [plugin]
+    assert await manager.get_plugin_logs("tester", "demo") == []
+    assert await manager.handle_page_api(
+        "tester",
+        "demo",
+        page_id="settings",
+        endpoint="/save",
+        method="POST",
+    ) == {"data": None, "error": "Plugin is not connected"}
+
+    handler = FakeHandler(plugin)
+    plugin._runtime_plugin_handler = handler
+    assert await manager.get_plugin_logs("tester", "demo", limit=3, level="INFO") == [
+        {"limit": 3, "level": "INFO", "text": "ready"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -551,6 +750,39 @@ async def test_knowledge_engine_methods_validate_components_and_delegate_to_hand
 
 
 @pytest.mark.asyncio
+async def test_knowledge_engine_errors_and_retrieve_knowledge_delegate():
+    manager = _manager()
+
+    with pytest.raises(ValueError, match="Plugin tester/missing not found"):
+        await manager.retrieve_knowledge("tester", "missing", "kb", {"query": "hi"})
+
+    plugin = _plugin(components=[_component("KnowledgeEngine", "kb")])
+    manager.plugins = [plugin]
+    with pytest.raises(ValueError, match="is not connected"):
+        await manager.retrieve_knowledge("tester", "demo", "kb", {"query": "hi"})
+
+    handler = FakeHandler(plugin)
+    plugin._runtime_plugin_handler = handler
+    assert await manager.retrieve_knowledge(
+        "tester", "demo", "kb", {"query": "hi"}
+    ) == {
+        "retriever_name": "kb",
+        "retrieval_context": {"query": "hi"},
+    }
+    assert await manager.get_rag_creation_schema("tester", "missing") == {"schema": []}
+    assert await manager.get_rag_retrieval_schema("tester", "missing") == {"schema": []}
+
+    manager.plugins = [_plugin(components=[])]
+    with pytest.raises(ValueError, match="has no KnowledgeEngine component"):
+        await manager.rag_delete_document("tester", "demo", "kb-1", "doc-1")
+
+    plugin_without_handler = _plugin(components=[_component("KnowledgeEngine", "kb")])
+    manager.plugins = [plugin_without_handler]
+    with pytest.raises(ValueError, match="is not connected"):
+        await manager.rag_on_kb_create("tester", "demo", "kb-1", {})
+
+
+@pytest.mark.asyncio
 async def test_parser_methods_validate_components_and_delegate_to_handler():
     manager = _manager()
     parser = _component(
@@ -578,6 +810,18 @@ async def test_parser_methods_validate_components_and_delegate_to_handler():
 
 
 @pytest.mark.asyncio
+async def test_parser_errors_for_missing_plugin_and_component():
+    manager = _manager()
+
+    with pytest.raises(ValueError, match="Plugin tester/missing not found"):
+        await manager.parse_document("tester", "missing", {}, b"")
+
+    manager.plugins = [_plugin(components=[])]
+    with pytest.raises(ValueError, match="has no Parser component"):
+        await manager.parse_document("tester", "demo", {}, b"")
+
+
+@pytest.mark.asyncio
 async def test_emit_event_should_report_each_emitting_plugin_once():
     manager = _manager()
     plugin = _plugin()
@@ -600,3 +844,70 @@ async def test_emit_event_should_report_each_emitting_plugin_once():
     emitted_plugins, _ = await manager.emit_event(event_context)
 
     assert emitted_plugins == [plugin]
+
+
+@pytest.mark.asyncio
+async def test_install_plugin_marketplace_streams_progress_and_launches(monkeypatch):
+    manager = _manager()
+    control_handler = FakeControlHandler()
+    manager.context = SimpleNamespace(control_handler=control_handler)
+
+    async def fake_download_plugin_streaming(author, name, version):
+        yield {
+            "done": False,
+            "downloaded": 5,
+            "total": 10,
+            "speed": 2,
+        }
+        yield {"done": True, "data": b"zip"}
+
+    async def fake_install_plugin_from_file(plugin_file):
+        assert plugin_file == b"zip"
+        return "data/plugins/tester__demo", "tester", "demo", "1.0.0"
+
+    launched = []
+
+    async def fake_launch_plugin(plugin_path):
+        launched.append(plugin_path)
+
+    monkeypatch.setattr(
+        marketplace_helper,
+        "download_plugin_streaming",
+        fake_download_plugin_streaming,
+    )
+    monkeypatch.setattr(
+        manager, "install_plugin_from_file", fake_install_plugin_from_file
+    )
+    monkeypatch.setattr(manager, "launch_plugin", fake_launch_plugin)
+
+    progress = [
+        item
+        async for item in manager.install_plugin(
+            PluginInstallSource.MARKETPLACE,
+            {
+                "plugin_author": "tester",
+                "plugin_name": "demo",
+                "plugin_version": "1.0.0",
+            },
+        )
+    ]
+    await asyncio.gather(*manager.plugin_run_tasks)
+
+    assert [item["current_action"] for item in progress] == [
+        "downloading plugin package",
+        "downloading plugin package",
+        "installing dependencies",
+        "initializing plugin settings",
+        "launching plugin",
+    ]
+    assert progress[1]["metadata"] == {
+        "download_current": 5,
+        "download_total": 10,
+        "download_speed": 2,
+    }
+    assert control_handler.calls[-1][1]["install_info"] == {
+        "plugin_author": "tester",
+        "plugin_name": "demo",
+        "plugin_version": "1.0.0",
+    }
+    assert launched == ["data/plugins/tester__demo"]


### PR DESCRIPTION
## Summary

- Add runtime handler tests for tool signatures, KnowledgeEngine actions, Parser actions, and missing/uninitialized component states.
- Add plugin manager coverage for debug registration, restart/delete/upgrade edges, marketplace install progress, resources/logs, and RAG/parser error paths.
- Add plugin connection handler protocol coverage for host-side action proxying, storage owner injection, file stream repackaging, tool/command listing, and peer-call helper methods.
- Add control connection handler protocol coverage for runtime config, plugin lifecycle streaming, resources/logs, event dispatch, tools/commands, RAG/schema, parser, and debug info.
- Raise the CI coverage ratchet from 79% to 84%.

## Validation

- `uv run pytest -q --ignore=tests/packaging --cov=langbot_plugin --cov-report=term --cov-fail-under=84`
- `uv run pytest -q tests/packaging`
- `uv run ruff check src tests --output-format=concise`
- `uv run ruff format --check src tests`
- `uv run mypy src/langbot_plugin/entities/io src/langbot_plugin/runtime/plugin/logbuffer.py src/langbot_plugin/utils/platform.py`
- workflow YAML parse check