### PR TITLE
test(cli): cover run controller hot reload

### DIFF
--- a/src/langbot_plugin/cli/run/hotreload.py
+++ b/src/langbot_plugin/cli/run/hotreload.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 import logging
 import importlib
+from pathlib import Path
 from typing import Callable, Coroutine, Any
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
@@ -97,7 +97,7 @@ def reload_plugin_modules(plugin_path: str):
     logger.info(f"Reloading plugin modules from {plugin_path}")
 
     # Get absolute path
-    abs_plugin_path = os.path.abspath(plugin_path)
+    abs_plugin_path = Path(plugin_path).resolve()
 
     # Find all modules that belong to this plugin
     modules_to_reload = []
@@ -111,8 +111,12 @@ def reload_plugin_modules(plugin_path: str):
             continue
 
         # Check if module belongs to this plugin
-        abs_module_path = os.path.abspath(module_file)
-        if abs_module_path.startswith(abs_plugin_path):
+        abs_module_path = Path(module_file).resolve()
+        try:
+            abs_module_path.relative_to(abs_plugin_path)
+        except ValueError:
+            continue
+        else:
             modules_to_reload.append((name, module))
 
     # Reload modules in reverse order (to handle dependencies)

--- a/tests/cli/run/test_controller.py
+++ b/tests/cli/run/test_controller.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import Any
 
 import pytest
@@ -10,7 +12,9 @@ from langbot_plugin.api.definition.components.manifest import ComponentManifest
 from langbot_plugin.api.definition.components.tool.tool import Tool
 from langbot_plugin.api.definition.plugin import BasePlugin, NonePlugin
 from langbot_plugin.api.entities.builtin.provider import session as provider_session
+from langbot_plugin.cli.run import controller as controller_module
 from langbot_plugin.cli.run.controller import PluginRuntimeController
+from langbot_plugin.entities.io.errors import ConnectionClosedError
 from langbot_plugin.runtime.plugin.container import RuntimeContainerStatus
 
 
@@ -73,6 +77,140 @@ def _controller() -> PluginRuntimeController:
         stdio=True,
         ws_debug_url="ws://runtime/plugin/ws",
     )
+
+
+class FakeConnection:
+    def __init__(self):
+        self.closed = False
+        self.closed_event = asyncio.Event()
+
+    async def send(self, message: str) -> None:
+        pass
+
+    async def receive(self) -> str:
+        await asyncio.Future()
+
+    async def close(self) -> None:
+        self.closed = True
+        self.closed_event.set()
+
+
+class FakeHotReloader:
+    instances: list["FakeHotReloader"] = []
+
+    def __init__(self, watch_path, on_reload_callback):
+        self.watch_path = watch_path
+        self.on_reload_callback = on_reload_callback
+        self.started = False
+        self.stopped = False
+        self.__class__.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
+def _fake_handler_class(*, run_forever: bool = False):
+    instances = []
+
+    class FakePluginRuntimeHandler:
+        def __init__(self, connection, initialize_callback):
+            self.connection = connection
+            self.initialize_callback = initialize_callback
+            self.disconnect_callback = None
+            self.shutdown_callback = None
+            self.plugin_container = None
+            self.register_calls = []
+            self.run_started = asyncio.Event()
+            self.registered = asyncio.Event()
+            self.cancelled = asyncio.Event()
+            instances.append(self)
+
+        def set_disconnect_callback(self, callback):
+            self.disconnect_callback = callback
+
+        async def run(self):
+            self.run_started.set()
+            if not run_forever:
+                return
+
+            try:
+                await asyncio.Future()
+            finally:
+                self.cancelled.set()
+
+        async def register_plugin(self, prod_mode: bool = False):
+            self.register_calls.append(prod_mode)
+            self.registered.set()
+            return {"ok": True}
+
+        async def get_plugin_container(self):
+            return {
+                "enabled": True,
+                "priority": 7,
+                "plugin_config": {"mode": "debug"},
+            }
+
+    FakePluginRuntimeHandler.instances = instances
+    return FakePluginRuntimeHandler
+
+
+def _install_stdio_controller(monkeypatch, *behaviors: str):
+    controllers = []
+
+    class FakeStdioServerController:
+        def __init__(self):
+            self.index = len(controllers)
+            self.connection = FakeConnection()
+            controllers.append(self)
+
+        async def run(self, new_connection_callback):
+            behavior = behaviors[self.index] if self.index < len(behaviors) else "wait"
+            if behavior == "connect":
+                await new_connection_callback(self.connection)
+                return
+            if behavior == "wait":
+                await asyncio.Future()
+                return
+            raise AssertionError(f"Unknown fake controller behavior: {behavior}")
+
+    monkeypatch.setattr(
+        controller_module.stdio_controller_server,
+        "StdioServerController",
+        FakeStdioServerController,
+    )
+    return controllers
+
+
+def _install_ws_failure_controller(monkeypatch, failure: Exception):
+    controllers = []
+
+    class FakeWebSocketClientController:
+        def __init__(self, ws_url, make_connection_failed_callback):
+            self.ws_url = ws_url
+            self.make_connection_failed_callback = make_connection_failed_callback
+            controllers.append(self)
+
+        async def run(self, new_connection_callback):
+            await self.make_connection_failed_callback(self, failure)
+
+    monkeypatch.setattr(
+        controller_module.ws_controller_client,
+        "WebSocketClientController",
+        FakeWebSocketClientController,
+    )
+    return controllers
+
+
+async def _wait_until(predicate, timeout: float = 1.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("Timed out waiting for predicate")
 
 
 def test_controller_builds_unmounted_placeholder_container():
@@ -164,6 +302,215 @@ async def test_cleanup_instances_resets_runtime_objects(monkeypatch):
     await controller.initialize({"enabled": True, "priority": 0, "plugin_config": {}})
     await controller.cleanup_instances()
 
+    assert isinstance(controller.plugin_container.plugin_instance, NonePlugin)
+    assert controller.plugin_container.status is RuntimeContainerStatus.UNMOUNTED
+    assert all(
+        isinstance(component.component_instance, NoneComponent)
+        for component in controller.plugin_container.components
+    )
+
+
+@pytest.mark.asyncio
+async def test_mount_stdio_prod_registers_plugin(monkeypatch):
+    fake_handler_cls = _fake_handler_class()
+    monkeypatch.setattr(controller_module, "PluginRuntimeHandler", fake_handler_cls)
+    controllers = _install_stdio_controller(monkeypatch, "connect")
+    controller = PluginRuntimeController(
+        plugin_manifest=_manifest("Plugin", "demo"),
+        component_manifests=[],
+        stdio=True,
+        ws_debug_url="ws://runtime/plugin/ws",
+        prod_mode=True,
+    )
+
+    await controller.mount()
+
+    assert len(controllers) == 1
+    handler = fake_handler_cls.instances[0]
+    assert handler.plugin_container is controller.plugin_container
+    assert handler.register_calls == [True]
+    assert controller.plugin_container.status is RuntimeContainerStatus.MOUNTED
+
+
+@pytest.mark.asyncio
+async def test_mount_prod_connection_failure_sets_waiter_and_exits(monkeypatch):
+    controller = PluginRuntimeController(
+        plugin_manifest=_manifest("Plugin", "demo"),
+        component_manifests=[],
+        stdio=False,
+        ws_debug_url="ws://runtime/plugin/ws",
+        prod_mode=True,
+    )
+    controllers = _install_ws_failure_controller(monkeypatch, RuntimeError("boom"))
+    exit_calls = []
+
+    def fake_exit(code):
+        exit_calls.append(code)
+
+    monkeypatch.setattr(controller_module, "exit", fake_exit, raising=False)
+
+    with pytest.raises(ConnectionClosedError, match="Connection failed: boom"):
+        await controller.mount()
+
+    assert controllers[0].ws_url == "ws://runtime/plugin/ws"
+    assert exit_calls == [1]
+    assert controller._connection_waiter.done()
+
+
+@pytest.mark.asyncio
+async def test_mount_debug_connection_failure_sets_waiter_exception_without_exit(
+    monkeypatch,
+):
+    class StopMount(Exception):
+        pass
+
+    controller = PluginRuntimeController(
+        plugin_manifest=_manifest("Plugin", "demo"),
+        component_manifests=[],
+        stdio=False,
+        ws_debug_url="ws://runtime/plugin/ws",
+        prod_mode=False,
+    )
+    FakeHotReloader.instances = []
+    monkeypatch.setattr(controller_module, "HotReloader", FakeHotReloader)
+    _install_ws_failure_controller(monkeypatch, RuntimeError("boom"))
+
+    def fail_exit(code):
+        raise AssertionError(f"debug mode should not exit with {code}")
+
+    async def stop_on_retry(delay):
+        assert delay == 3
+        raise StopMount
+
+    monkeypatch.setattr(controller_module, "exit", fail_exit, raising=False)
+    monkeypatch.setattr(controller_module.asyncio, "sleep", stop_on_retry)
+
+    with pytest.raises(StopMount):
+        await controller.mount()
+
+    assert controller._connection_waiter.done()
+    with pytest.raises(ConnectionClosedError, match="Connection failed: boom"):
+        controller._connection_waiter.result()
+    assert FakeHotReloader.instances[0].started is True
+    assert FakeHotReloader.instances[0].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_mount_debug_shutdown_callback_closes_connection_and_reconnects(
+    monkeypatch,
+):
+    fake_handler_cls = _fake_handler_class(run_forever=True)
+    monkeypatch.setattr(controller_module, "PluginRuntimeHandler", fake_handler_cls)
+    FakeHotReloader.instances = []
+    monkeypatch.setattr(controller_module, "HotReloader", FakeHotReloader)
+    controllers = _install_stdio_controller(monkeypatch, "connect", "wait")
+    controller = _controller()
+
+    mount_task = asyncio.create_task(controller.mount())
+    await _wait_until(lambda: len(fake_handler_cls.instances) == 1)
+    handler = fake_handler_cls.instances[0]
+    await asyncio.wait_for(handler.registered.wait(), timeout=1)
+
+    assert handler.shutdown_callback is not None
+    await handler.shutdown_callback()
+
+    await asyncio.wait_for(controllers[0].connection.closed_event.wait(), timeout=1)
+    await asyncio.wait_for(handler.cancelled.wait(), timeout=1)
+    await _wait_until(
+        lambda: controller.plugin_container.status is RuntimeContainerStatus.UNMOUNTED
+    )
+
+    mount_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await mount_task
+    if hasattr(controller, "_controller_task"):
+        controller._controller_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await controller._controller_task
+
+    assert len(controllers) == 2
+    assert FakeHotReloader.instances[0].started is True
+    assert FakeHotReloader.instances[0].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_mount_hot_reload_callback_reinitializes_current_settings(
+    monkeypatch,
+    tmp_path,
+):
+    controller = _controller()
+    controller.handler = _fake_handler_class()(
+        FakeConnection(),
+        controller.initialize,
+    )
+    cleanup_calls = []
+    initialize_calls = []
+    reload_calls = []
+    FakeHotReloader.instances = []
+
+    async def fake_cleanup():
+        cleanup_calls.append(True)
+
+    async def fake_initialize(plugin_settings):
+        initialize_calls.append(plugin_settings)
+
+    def fake_reload_plugin_modules(path):
+        reload_calls.append(path)
+
+    monkeypatch.setattr(controller, "cleanup_instances", fake_cleanup)
+    monkeypatch.setattr(controller, "initialize", fake_initialize)
+    monkeypatch.setattr(
+        controller_module, "reload_plugin_modules", fake_reload_plugin_modules
+    )
+    monkeypatch.setattr(controller_module.os, "getcwd", lambda: str(tmp_path))
+    monkeypatch.setattr(controller_module, "HotReloader", FakeHotReloader)
+    _install_stdio_controller(monkeypatch, "wait")
+
+    mount_task = asyncio.create_task(controller.mount())
+    await _wait_until(lambda: len(FakeHotReloader.instances) == 1)
+
+    await FakeHotReloader.instances[0].on_reload_callback()
+
+    assert cleanup_calls == [True]
+    assert reload_calls == [str(tmp_path)]
+    assert initialize_calls == [
+        {
+            "enabled": True,
+            "priority": 7,
+            "plugin_config": {"mode": "debug"},
+        }
+    ]
+
+    mount_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await mount_task
+    controller._controller_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await controller._controller_task
+    assert FakeHotReloader.instances[0].stopped is True
+
+
+@pytest.mark.asyncio
+async def test_reload_and_reinitialize_cleans_instances_and_reloads_cwd(
+    monkeypatch,
+    tmp_path,
+):
+    controller = _controller()
+    controller.plugin_container.plugin_instance = DemoPlugin()
+    controller.plugin_container.components[0].component_instance = DemoTool()
+    controller.plugin_container.status = RuntimeContainerStatus.INITIALIZED
+    reload_calls = []
+
+    monkeypatch.setattr(controller_module.os, "getcwd", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        controller_module,
+        "reload_plugin_modules",
+        lambda path: reload_calls.append(path),
+    )
+
+    await controller.reload_and_reinitialize()
+
+    assert reload_calls == [str(tmp_path)]
     assert isinstance(controller.plugin_container.plugin_instance, NonePlugin)
     assert controller.plugin_container.status is RuntimeContainerStatus.UNMOUNTED
     assert all(

--- a/tests/cli/run/test_hotreload.py
+++ b/tests/cli/run/test_hotreload.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import types
+from types import SimpleNamespace
+
+from langbot_plugin.cli.run import hotreload
+from langbot_plugin.cli.run.hotreload import (
+    HotReloader,
+    PythonFileChangeHandler,
+    reload_plugin_modules,
+)
+
+
+class FakeObserver:
+    instances: list["FakeObserver"] = []
+
+    def __init__(self):
+        self.scheduled = []
+        self.started = False
+        self.stopped = False
+        self.joined = False
+        self.__class__.instances.append(self)
+
+    def schedule(self, handler, path, recursive=False):
+        self.scheduled.append((handler, path, recursive))
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def join(self):
+        self.joined = True
+
+
+async def test_python_file_change_handler_debounces_python_file_events():
+    calls = []
+
+    async def on_change():
+        calls.append("reload")
+
+    handler = PythonFileChangeHandler(on_change, debounce_delay=0.01)
+
+    handler.on_modified(SimpleNamespace(is_directory=True, src_path="plugin.py"))
+    handler.on_modified(SimpleNamespace(is_directory=False, src_path="README.md"))
+    handler.on_modified(
+        SimpleNamespace(is_directory=False, src_path="__pycache__/plugin.py")
+    )
+    handler.on_modified(SimpleNamespace(is_directory=False, src_path="plugin.pyc"))
+
+    assert handler._pending_reload is None
+
+    handler.on_modified(SimpleNamespace(is_directory=False, src_path="plugin.py"))
+    first_reload = handler._pending_reload
+    handler.on_modified(SimpleNamespace(is_directory=False, src_path="components/a.py"))
+
+    assert first_reload.cancelled()
+
+    await asyncio.wrap_future(handler._pending_reload)
+    assert calls == ["reload"]
+
+
+async def test_python_file_change_handler_cancels_existing_pending_reload():
+    calls = []
+
+    async def on_change():
+        calls.append("reload")
+
+    handler = PythonFileChangeHandler(on_change, debounce_delay=10)
+
+    handler.on_modified(SimpleNamespace(is_directory=False, src_path="plugin.py"))
+    first_reload = handler._pending_reload
+    assert first_reload is not None
+
+    handler.on_modified(SimpleNamespace(is_directory=False, src_path="plugin.py"))
+
+    assert first_reload.cancelled()
+    handler._pending_reload.cancel()
+    try:
+        await asyncio.wrap_future(handler._pending_reload)
+    except asyncio.CancelledError:
+        pass
+    assert calls == []
+
+
+async def test_hot_reloader_start_and_stop_lifecycle(monkeypatch, tmp_path):
+    FakeObserver.instances = []
+    monkeypatch.setattr(hotreload, "Observer", FakeObserver)
+
+    async def on_reload():
+        pass
+
+    reloader = HotReloader(str(tmp_path), on_reload)
+    reloader.start()
+
+    observer = FakeObserver.instances[0]
+    assert observer.started is True
+    assert observer.scheduled == [(reloader.event_handler, str(tmp_path), True)]
+    assert isinstance(reloader.event_handler, PythonFileChangeHandler)
+
+    reloader.stop()
+
+    assert observer.stopped is True
+    assert observer.joined is True
+    assert reloader.observer is None
+    assert reloader.event_handler is None
+
+    reloader.stop()
+    assert observer.stopped is True
+
+
+def test_reload_plugin_modules_only_reloads_modules_under_plugin_path(
+    monkeypatch,
+    tmp_path,
+):
+    plugin_root = tmp_path / "plugin"
+    plugin_pkg = plugin_root / "pkg"
+    sibling_pkg = tmp_path / "plugin-extra"
+    sdk_pkg = tmp_path / "sdk"
+    plugin_pkg.mkdir(parents=True)
+    sibling_pkg.mkdir()
+    sdk_pkg.mkdir()
+
+    plugin_module = types.ModuleType("plugin.main")
+    plugin_module.__file__ = str(plugin_pkg / "main.py")
+    nested_module = types.ModuleType("plugin.pkg.module")
+    nested_module.__file__ = str(plugin_pkg / "module.py")
+    sibling_module = types.ModuleType("plugin_extra.main")
+    sibling_module.__file__ = str(sibling_pkg / "main.py")
+    sdk_module = types.ModuleType("langbot_plugin.api")
+    sdk_module.__file__ = str(sdk_pkg / "api.py")
+    builtin_like_module = types.ModuleType("json")
+    builtin_like_module.__file__ = None
+
+    modules = {
+        "plugin.main": plugin_module,
+        "plugin.pkg.module": nested_module,
+        "plugin_extra.main": sibling_module,
+        "langbot_plugin.api": sdk_module,
+        "json": builtin_like_module,
+        "none_module": None,
+    }
+    reloaded = []
+
+    monkeypatch.setattr(hotreload.sys, "modules", modules)
+    monkeypatch.setattr(
+        hotreload.importlib,
+        "reload",
+        lambda module: reloaded.append(module.__name__),
+    )
+
+    reload_plugin_modules(str(plugin_root))
+
+    assert reloaded == ["plugin.pkg.module", "plugin.main"]
+
+
+def test_reload_plugin_modules_continues_when_reload_fails(monkeypatch, tmp_path):
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    first = types.ModuleType("plugin.first")
+    first.__file__ = str(plugin_root / "first.py")
+    second = types.ModuleType("plugin.second")
+    second.__file__ = str(plugin_root / "second.py")
+    modules = {"plugin.first": first, "plugin.second": second}
+    attempted = []
+
+    def fake_reload(module):
+        attempted.append(module.__name__)
+        if module is second:
+            raise RuntimeError("reload failed")
+        return module
+
+    monkeypatch.setattr(hotreload.sys, "modules", modules)
+    monkeypatch.setattr(hotreload.importlib, "reload", fake_reload)
+
+    reload_plugin_modules(str(plugin_root))
+
+    assert attempted == ["plugin.second", "plugin.first"]


### PR DESCRIPTION
## Summary
- add unit coverage for CLI run controller mount success, connection failure, debug reconnect, hot reload callback, and reload cleanup paths
- add hot reload tests for watcher lifecycle, debounce/filter behavior, and plugin-scoped module reloads
- tighten reload_plugin_modules path matching to avoid reloading modules from same-prefix sibling directories

## Tests
- uv run ruff format src/langbot_plugin/cli/run/hotreload.py tests/cli/run/test_controller.py tests/cli/run/test_hotreload.py
- uv run ruff check src/langbot_plugin/cli/run/hotreload.py tests/cli/run/test_controller.py tests/cli/run/test_hotreload.py
- uv run pytest tests/cli/run/test_controller.py tests/cli/run/test_hotreload.py tests/cli/run/test_runtime_handler.py -q
- uv run pytest -q
- uv run pytest tests/cli/run/test_controller.py tests/cli/run/test_hotreload.py --cov=langbot_plugin.cli.run.controller --cov=langbot_plugin.cli.run.hotreload --cov-report=term-missing -q