### PR TITLE
feat(rag): add trace context support

### DIFF
--- a/src/langbot_plugin/api/entities/builtin/rag/__init__.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/__init__.py
@@ -41,6 +41,7 @@ from .context import (
     RetrievalContext,
     RetrievalResponse,
 )
+from .trace import TraceContext
 
 __all__ = [
     # Enums
@@ -70,4 +71,5 @@ __all__ = [
     "RetrievalResultEntry",
     "RetrievalContext",
     "RetrievalResponse",
+    "TraceContext",
 ]

--- a/src/langbot_plugin/api/entities/builtin/rag/context.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/context.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import Field
 
 from langbot_plugin.api.entities.builtin.provider.message import ContentElement
+from langbot_plugin.api.entities.builtin.rag.trace import TraceContext
 
 
 class RetrievalResultEntry(pydantic.BaseModel):
@@ -46,6 +47,9 @@ class RetrievalContext(pydantic.BaseModel):
 
     filters: dict[str, Any] = Field(default_factory=dict)
     """Metadata filters for retrieval."""
+
+    trace_context: TraceContext | None = None
+    """Optional host trace context for end-to-end observability."""
 
     def get_collection_id(self) -> str:
         """Get the collection ID, falling back to knowledge_base_id.

--- a/src/langbot_plugin/api/entities/builtin/rag/models.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/models.py
@@ -7,6 +7,7 @@ import pydantic
 from pydantic import Field
 
 from .enums import DocumentStatus
+from .trace import TraceContext
 
 
 class FileMetadata(pydantic.BaseModel):
@@ -128,6 +129,9 @@ class IngestionContext(pydantic.BaseModel):
 
     parsed_content: ParseResult | None = None
     """Pre-parsed content from an external Parser plugin. If present, KnowledgeEngine can skip its own parsing."""
+
+    trace_context: TraceContext | None = None
+    """Optional host trace context for end-to-end observability."""
 
     def get_collection_id(self) -> str:
         """Get the collection ID, falling back to knowledge_base_id."""

--- a/src/langbot_plugin/api/entities/builtin/rag/trace.py
+++ b/src/langbot_plugin/api/entities/builtin/rag/trace.py
@@ -1,0 +1,39 @@
+"""Trace context models shared by LangBot and KnowledgeEngine plugins."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pydantic
+from pydantic import Field
+
+
+class TraceContext(pydantic.BaseModel):
+    """Host trace context propagated to plugin RAG operations."""
+
+    trace_id: str
+    """Identifier for the end-to-end LangBot request trace."""
+
+    parent_span_id: str | None = None
+    """Span that plugin-generated spans should attach to."""
+
+    message_id: str | None = None
+    """Monitoring message identifier associated with the user request."""
+
+    query_id: int | None = None
+    """LangBot in-process query identifier, if available."""
+
+    session_id: str | None = None
+    """Monitoring session identifier."""
+
+    bot_id: str | None = None
+    """Bot UUID associated with the request."""
+
+    pipeline_id: str | None = None
+    """Pipeline UUID associated with the request."""
+
+    knowledge_base_id: str | None = None
+    """Knowledge base identifier associated with the RAG operation."""
+
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    """Additional privacy-conscious host attributes."""

--- a/src/langbot_plugin/cli/run/handler.py
+++ b/src/langbot_plugin/cli/run/handler.py
@@ -184,6 +184,8 @@ class PluginRuntimeHandler(Handler):
                     endpoint=data.get("endpoint", ""),
                     method=data.get("method", "POST"),
                     body=data.get("body"),
+                    caller=data.get("caller"),
+                    headers=data.get("headers") or {},
                 )
                 response = await component.component_instance.handle_api(request)
                 if not isinstance(response, PageResponse):

--- a/src/langbot_plugin/runtime/io/handlers/control.py
+++ b/src/langbot_plugin/runtime/io/handlers/control.py
@@ -163,6 +163,8 @@ class ControlConnectionHandler(handler.Handler):
                 data["endpoint"],
                 data["method"],
                 data.get("body"),
+                data.get("caller"),
+                data.get("headers") or {},
             )
             return handler.ActionResponse.success(result)
 

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -614,6 +614,8 @@ class PluginConnectionHandler(handler.Handler):
         endpoint: str,
         method: str,
         body: Any = None,
+        caller: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         resp = await self.call_action(
             RuntimeToPluginAction.PAGE_API,
@@ -622,6 +624,8 @@ class PluginConnectionHandler(handler.Handler):
                 "endpoint": endpoint,
                 "method": method,
                 "body": body,
+                "caller": caller,
+                "headers": headers or {},
             },
             timeout=30,
         )

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -778,6 +778,8 @@ class PluginManager:
         endpoint: str,
         method: str,
         body: typing.Any = None,
+        caller: dict[str, typing.Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, typing.Any]:
         plugin = self.find_plugin(plugin_author, plugin_name)
         if plugin is None:
@@ -789,6 +791,8 @@ class PluginManager:
             endpoint=endpoint,
             method=method,
             body=body,
+            caller=caller,
+            headers=headers or {},
         )
 
     async def list_tools(

--- a/tests/api/entities/builtin/test_rag_models.py
+++ b/tests/api/entities/builtin/test_rag_models.py
@@ -24,6 +24,7 @@ from langbot_plugin.api.entities.builtin.rag.models import (
     TextChunk,
     TextSection,
 )
+from langbot_plugin.api.entities.builtin.rag.trace import TraceContext
 
 
 def test_rag_file_and_parse_models_keep_metadata_isolated():
@@ -86,6 +87,34 @@ def test_ingestion_context_collection_id_falls_back_to_knowledge_base_id():
     assert context.get_collection_id() == "collection"
 
 
+def test_ingestion_context_accepts_trace_context():
+    trace_context = TraceContext(
+        trace_id="trace-ingest-1",
+        parent_span_id="span-ingest-1",
+        message_id="message-1",
+        query_id=7,
+        session_id="person_1",
+        bot_id="bot-1",
+        pipeline_id="pipe-1",
+        knowledge_base_id="kb",
+    )
+    metadata = FileMetadata(
+        filename="a.txt",
+        file_size=3,
+        mime_type="text/plain",
+        document_id="doc",
+        knowledge_base_id="kb",
+    )
+    context = IngestionContext(
+        file_object=FileObject(metadata=metadata, storage_path="files/a.txt"),
+        knowledge_base_id="kb",
+        trace_context=trace_context,
+    )
+
+    assert context.trace_context.trace_id == "trace-ingest-1"
+    assert context.trace_context.parent_span_id == "span-ingest-1"
+
+
 def test_ingestion_result_serializes_document_status_enum():
     result = IngestionResult(
         document_id="doc",
@@ -97,9 +126,24 @@ def test_ingestion_result_serializes_document_status_enum():
 
 
 def test_retrieval_context_collection_id_fallbacks_and_response_model():
-    context = RetrievalContext(query="hello", knowledge_base_id="kb")
+    trace_context = TraceContext(
+        trace_id="trace-1",
+        parent_span_id="span-1",
+        message_id="message-1",
+        query_id=7,
+        session_id="person_1",
+        bot_id="bot-1",
+        pipeline_id="pipe-1",
+        knowledge_base_id="kb",
+    )
+    context = RetrievalContext(
+        query="hello",
+        knowledge_base_id="kb",
+        trace_context=trace_context,
+    )
     assert context.get_collection_id() == "kb"
     assert RetrievalContext(query="hello").get_collection_id() == ""
+    assert context.trace_context.trace_id == "trace-1"
 
     entry = RetrievalResultEntry(
         id="chunk",

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -67,6 +67,8 @@ class FakePluginManager:
         endpoint,
         method,
         body,
+        caller=None,
+        headers=None,
     ):
         self.calls.append(
             (
@@ -77,6 +79,8 @@ class FakePluginManager:
                 endpoint,
                 method,
                 body,
+                caller,
+                headers,
             )
         )
         return {"data": {"ok": True}, "error": None}
@@ -449,6 +453,8 @@ async def test_control_handler_page_api_delegates_to_plugin_manager():
                 "endpoint": "/save",
                 "method": "POST",
                 "body": {"enabled": True},
+                "caller": {"origin": "https://example.test"},
+                "headers": {"x-request-id": "req-1"},
             },
         )
 
@@ -461,6 +467,8 @@ async def test_control_handler_page_api_delegates_to_plugin_manager():
             "/save",
             "POST",
             {"enabled": True},
+            {"origin": "https://example.test"},
+            {"x-request-id": "req-1"},
         )
     ]
     assert response["data"] == {"data": {"ok": True}, "error": None}

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -658,6 +658,8 @@ async def test_plugin_connection_handler_peer_call_helpers(monkeypatch):
             "endpoint": "/save",
             "method": "POST",
             "body": {"enabled": True},
+            "caller": None,
+            "headers": {},
         },
     }
     assert await handler.emit_event({"event_name": "PersonMessageReceived"}) == {

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -194,13 +194,23 @@ class FakeHandler:
     async def delete_local_file(self, file_key):
         del self.files[file_key]
 
-    async def call_page_api(self, page_id, endpoint, method, body):
+    async def call_page_api(
+        self,
+        page_id,
+        endpoint,
+        method,
+        body,
+        caller=None,
+        headers=None,
+    ):
         return {
             "data": {
                 "page_id": page_id,
                 "endpoint": endpoint,
                 "method": method,
                 "body": body,
+                "caller": caller,
+                "headers": headers,
             },
             "error": None,
         }
@@ -661,9 +671,13 @@ async def test_plugin_resource_and_page_methods_delegate_to_connected_handler():
         endpoint="/save",
         method="POST",
         body={"enabled": True},
+        caller={"origin": "https://example.test"},
+        headers={"x-request-id": "req-1"},
     )
     assert page_response["data"]["page_id"] == "settings"
     assert page_response["data"]["body"] == {"enabled": True}
+    assert page_response["data"]["caller"] == {"origin": "https://example.test"}
+    assert page_response["data"]["headers"] == {"x-request-id": "req-1"}
     assert await manager.handle_page_api(
         "tester",
         "missing",


### PR DESCRIPTION
## Summary
- add TraceContext for host-propagated RAG observability
- allow RetrievalContext and IngestionContext to carry optional trace_context
- forward Page API caller/header context through runtime paths
- cover trace_context with RAG model tests

## Tests
- python3 -m compileall -q src tests
- PYTHONPATH=src /home/yhh/workspace/langbot/.venv/bin/python -m pytest tests/api/entities/builtin/test_rag_models.py -q
- git diff --check

## Notes
- This is additive and optional; existing plugins do not need to pass trace_context.