### PR TITLE
fix(entities): add provider_specific_fields to carry Gemini thought_signature

### DIFF
--- a/src/langbot_plugin/api/entities/builtin/provider/message.py
+++ b/src/langbot_plugin/api/entities/builtin/provider/message.py
@@ -13,11 +13,22 @@ class FunctionCall(pydantic.BaseModel):
 
 
 class ToolCall(pydantic.BaseModel):
+    """Tool call from LLM.
+
+    The `provider_specific_fields` dict carries provider-specific metadata
+    that must be round-tripped between requests and responses. For example,
+    Gemini models require `thought_signature` in function call parts for
+    tool calls to work correctly.
+    """
+
     id: str
 
     type: str
 
     function: FunctionCall
+
+    provider_specific_fields: typing.Optional[dict[str, typing.Any]] = None
+    """Provider-specific fields (e.g., Gemini thought_signature) to round-trip."""
 
 
 class ImageURLContentObject(pydantic.BaseModel):
@@ -79,7 +90,13 @@ class ContentElement(pydantic.BaseModel):
 
 
 class Message(pydantic.BaseModel):
-    """Message for AI"""
+    """Message for AI.
+
+    The `provider_specific_fields` dict carries provider-specific metadata
+    that must be round-tripped between requests and responses. For example,
+    Gemini models require `thought_signatures` to be preserved across
+    conversation turns for tool calls to work correctly.
+    """
 
     role: str  # user, system, assistant, tool, command, plugin
     """Role of the message"""
@@ -97,6 +114,9 @@ class Message(pydantic.BaseModel):
 
     resp_message_id: typing.Optional[str] = None
     """Response message ID for tracking"""
+
+    provider_specific_fields: typing.Optional[dict[str, typing.Any]] = None
+    """Provider-specific fields (e.g., Gemini thought_signatures) to round-trip."""
 
     def readable_str(self) -> str:
         if self.content is not None:
@@ -191,6 +211,9 @@ class MessageChunk(pydantic.BaseModel):
     msg_sequence: int = 0
     """消息迭代次数"""
 
+    provider_specific_fields: typing.Optional[dict[str, typing.Any]] = None
+    """Provider-specific fields (e.g., Gemini thought_signatures) to round-trip."""
+
     def readable_str(self) -> str:
         if self.content is not None:
             return (
@@ -265,6 +288,9 @@ class ToolCallChunk(pydantic.BaseModel):
 
     function: FunctionCall
     """函数调用"""
+
+    provider_specific_fields: typing.Optional[dict[str, typing.Any]] = None
+    """Provider-specific fields (e.g., Gemini thought_signature) to round-trip."""
 
 
 class LLMTokenUsage(pydantic.BaseModel):


### PR DESCRIPTION
## Background

Related to langbot-app/LangBot#1899 — Gemini models (especially `gemini-3-flash-preview`) require a `thought_signature` in `functionCall` parts for tool calls to work correctly. See https://ai.google.dev/gemini-api/docs/thought-signatures.

LiteLLM already extracts `thought_signature` from Gemini responses (into `provider_specific_fields`) and re-emits it on the next request. The break is in **LangBot's shared message entities**: `Message` / `ToolCall` had no field to carry this metadata, so `Message(**message_data)` silently dropped it (Pydantic ignores unknown fields), and the signature was lost before the next tool-call round.

## Change

Add an optional `provider_specific_fields: dict[str, Any] | None` to:
- `Message`
- `ToolCall`
- `MessageChunk`
- `ToolCallChunk`

This lets provider-specific metadata (Gemini `thought_signature` / `thought_signatures`, and any future provider extension) round-trip through the entity layer without being dropped.

The field is optional and defaults to `None`, so it is fully backward-compatible.

## Paired change

The LangBot-side change that actually preserves and re-emits the field lives in langbot-app/LangBot (the LiteLLM requester). That PR depends on this one (it needs the new field on the entities).

## Verification

Verified end-to-end against the live Gemini API (`gemini-3-flash-preview`): the real `thought_signature` returned by Gemini now round-trips through the `Message` entity and is accepted by Gemini on the next tool-call round (instead of being dropped, which forces LiteLLM to fall back to a dummy signature that Google warns degrades model performance).