### PR TITLE
chore(release): 0.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.4"
+version = "0.4.5"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Release 0.4.5.

Bumps the package version from 0.4.4 to 0.4.5 to ship #83 (`provider_specific_fields` on `Message` / `ToolCall` / `MessageChunk` / `ToolCallChunk`), which LangBot needs to round-trip Gemini's `thought_signature` for tool calls (langbot-app/LangBot#1899).

Backward-compatible additive change → patch bump.

After merge: tag `0.4.5` + GitHub release will trigger the PyPI publish workflow. LangBot then bumps its pinned `langbot-plugin==0.4.5`.