### PR TITLE
fix(runtime): forward VECTOR_LIST action (+ action-protocol consistency CI)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,3 +77,17 @@ jobs:
             src/langbot_plugin/entities/io \
             src/langbot_plugin/runtime/plugin/logbuffer.py \
             src/langbot_plugin/utils/platform.py
+
+  action-consistency:
+    name: Action Protocol Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check action enum / proxy / handler consistency
+        run: python scripts/check_action_consistency.py

--- a/scripts/check_action_consistency.py
+++ b/scripts/check_action_consistency.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Static consistency check for the action-based runtime protocol.
+
+The runtime protocol (``runtime/io/``) dispatches calls by action name: a sender
+calls ``call_action(SomeAction.MEMBER, ...)`` and a receiver must have registered
+a handler with ``@handler.action(SomeAction.MEMBER)``. If the handler is missing,
+the call fails *at runtime* with ``ValueError: Action <name> not found`` — a class
+of bug that unit tests miss because they mock the proxy layer, and that only shows
+up end-to-end (this is exactly how ``vector_list`` shipped broken: the enum member,
+the plugin-side proxy, and a proxy-level test all existed, but no runtime forwarder
+was registered).
+
+This checker parses the SDK with ``ast`` (no imports, no side effects) and enforces:
+
+1. ERROR: every action *invoked* in-repo (``call_action`` / ``call_action_generator``
+   with a literal ``EnumClass.MEMBER`` argument) has a matching ``.action(...)``
+   registration in-repo — UNLESS the action's receiver is an external process
+   (the LangBot host), whose handlers live in a different repository. This is the
+   invariant ``vector_list`` violated.
+2. ERROR: every ``EnumClass.MEMBER`` referenced by an invocation or registration
+   actually exists on that enum class (guards against typos / renames).
+3. WARN: enum members that are neither invoked nor registered anywhere in-repo —
+   candidate dead wiring ("enum without action"). Warning only, because a member
+   may legitimately be invoked or handled by the LangBot host (a separate repo).
+
+Action enum classes follow the ``<Sender>To<Receiver>Action`` naming convention.
+The *receiver* is what must hold the handler, so Rule 1 only applies when the
+receiver lives in this repository (Runtime or Plugin); actions received by the
+LangBot host are handled there and cannot be checked from here.
+
+Known, accepted exceptions are listed in ``KNOWN_EXCEPTIONS`` with a reason so the
+gate can go green on a branch while pre-existing debt is tracked explicitly rather
+than hidden.
+
+Exit code is non-zero if any unexpected ERROR is found. Run from the repo root:
+
+    python scripts/check_action_consistency.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src" / "langbot_plugin"
+ENUMS_FILE = SRC_ROOT / "entities" / "io" / "actions" / "enums.py"
+
+INVOKE_METHODS = {"call_action", "call_action_generator"}
+REGISTER_METHODS = {"action"}
+
+# Receivers whose action handlers live in THIS repository. Actions whose receiver
+# is anything else (e.g. the LangBot host) are handled in another repo, so Rule 1
+# (invoked => registered) cannot and must not be enforced here.
+IN_REPO_RECEIVERS = {"Runtime", "Plugin"}
+
+# Accepted, documented exceptions to keep the gate green while tracking known debt.
+# Map (EnumClassName, MEMBER) -> reason. Remove an entry once the underlying issue
+# is fixed; the checker reports any entry that has become unnecessary.
+KNOWN_EXCEPTIONS: dict[tuple[str, str], str] = {
+    # invoke_llm_stream_events() references this member, but on the 0.4.x line the
+    # enum member and its runtime forwarder are absent (both exist and are wired on
+    # feat/agent-runner-plugin). Tracked for forward-port; the LangBot host already
+    # registers PluginToRuntimeAction.INVOKE_LLM_STREAM.
+    ("PluginToRuntimeAction", "INVOKE_LLM_STREAM"): (
+        "streaming LLM forwarder not yet ported to this branch; see feat/agent-runner-plugin"
+    ),
+}
+
+
+class Ref:
+    """A literal ``EnumClass.MEMBER`` reference at a source location."""
+
+    __slots__ = ("enum", "member", "file", "line")
+
+    def __init__(self, enum: str, member: str, file: Path, line: int):
+        self.enum = enum
+        self.member = member
+        self.file = file
+        self.line = line
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.enum, self.member)
+
+    def where(self) -> str:
+        rel = self.file.relative_to(REPO_ROOT)
+        return f"{rel}:{self.line}"
+
+
+def action_receiver(enum_name: str) -> str | None:
+    """Return the receiver segment of a ``<Sender>To<Receiver>Action`` enum name.
+
+    Returns ``None`` for names without a ``To`` segment (e.g. ``CommonAction``),
+    which are treated as in-repo.
+    """
+    if not enum_name.endswith("Action"):
+        return None
+    core = enum_name[: -len("Action")]
+    if "To" not in core:
+        return None
+    return core.rsplit("To", 1)[1]
+
+
+def receiver_in_repo(enum_name: str) -> bool:
+    receiver = action_receiver(enum_name)
+    return receiver is None or receiver in IN_REPO_RECEIVERS
+
+
+def load_enum_members() -> dict[str, set[str]]:
+    """Return {EnumClassName: {MEMBER, ...}} for every action enum class."""
+    tree = ast.parse(ENUMS_FILE.read_text(encoding="utf-8"), filename=str(ENUMS_FILE))
+    enums: dict[str, set[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        members: set[str] = set()
+        for stmt in node.body:
+            targets: list[ast.expr] = []
+            if isinstance(stmt, ast.Assign):
+                targets = stmt.targets
+            elif isinstance(stmt, ast.AnnAssign) and stmt.target is not None:
+                targets = [stmt.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id.isupper():
+                    members.add(target.id)
+        if members:
+            enums[node.name] = members
+    return enums
+
+
+def _enum_member_arg(arg: ast.expr, enum_names: set[str]) -> tuple[str, str] | None:
+    """If ``arg`` is ``EnumClass.MEMBER`` for a known enum, return (enum, member)."""
+    if (
+        isinstance(arg, ast.Attribute)
+        and isinstance(arg.value, ast.Name)
+        and arg.value.id in enum_names
+    ):
+        return (arg.value.id, arg.attr)
+    return None
+
+
+def scan(enum_names: set[str]) -> tuple[list[Ref], list[Ref]]:
+    """Walk the source tree, returning (invocations, registrations)."""
+    invocations: list[Ref] = []
+    registrations: list[Ref] = []
+
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:  # pragma: no cover - defensive
+            print(f"WARN: could not parse {path}: {exc}", file=sys.stderr)
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            method = node.func.attr
+            if not node.args:
+                continue
+            ref = _enum_member_arg(node.args[0], enum_names)
+            if ref is None:
+                continue
+            enum, member = ref
+            location = Ref(enum, member, path, node.lineno)
+            if method in INVOKE_METHODS:
+                invocations.append(location)
+            elif method in REGISTER_METHODS:
+                registrations.append(location)
+
+    return invocations, registrations
+
+
+def main() -> int:
+    if not ENUMS_FILE.exists():
+        print(f"ERROR: enum file not found: {ENUMS_FILE}", file=sys.stderr)
+        return 2
+
+    enums = load_enum_members()
+    enum_names = set(enums)
+    invocations, registrations = scan(enum_names)
+
+    registered_keys = {ref.key for ref in registrations}
+    invoked_keys = {ref.key for ref in invocations}
+
+    errors: list[str] = []
+    acknowledged: list[str] = []
+    used_exceptions: set[tuple[str, str]] = set()
+
+    # Rule 2: referenced members must exist on their enum (typo / rename guard).
+    for ref in invocations + registrations:
+        if ref.member in enums.get(ref.enum, set()):
+            continue
+        if ref.key in KNOWN_EXCEPTIONS:
+            used_exceptions.add(ref.key)
+            acknowledged.append(
+                f"{ref.enum}.{ref.member} at {ref.where()} — {KNOWN_EXCEPTIONS[ref.key]}"
+            )
+            continue
+        errors.append(
+            f"unknown action member {ref.enum}.{ref.member} referenced at "
+            f"{ref.where()} (not defined in {ENUMS_FILE.name})"
+        )
+
+    # Rule 1: every invoked action whose receiver is in-repo must be registered.
+    for ref in invocations:
+        if not receiver_in_repo(ref.enum):
+            continue  # receiver is the external LangBot host; handler lives there
+        if ref.key in registered_keys:
+            continue
+        if ref.key in KNOWN_EXCEPTIONS:
+            used_exceptions.add(ref.key)
+            acknowledged.append(
+                f"{ref.enum}.{ref.member} invoked at {ref.where()} but not registered "
+                f"— {KNOWN_EXCEPTIONS[ref.key]}"
+            )
+            continue
+        errors.append(
+            f"{ref.enum}.{ref.member} is invoked at {ref.where()} but no "
+            f"`.action({ref.enum}.{ref.member})` handler is registered anywhere in "
+            f'src/ — calls will fail at runtime with "Action {ref.member.lower()} not found"'
+        )
+
+    # Stale-allowlist guard: every KNOWN_EXCEPTIONS entry should still be needed.
+    for key in KNOWN_EXCEPTIONS:
+        if key not in used_exceptions:
+            errors.append(
+                f"stale KNOWN_EXCEPTIONS entry {key[0]}.{key[1]} — the underlying "
+                f"inconsistency is gone; remove it from {Path(__file__).name}"
+            )
+
+    # Rule 3 (warning): enum members with no invocation and no registration in-repo.
+    warnings: list[str] = []
+    for enum, members in sorted(enums.items()):
+        for member in sorted(members):
+            key = (enum, member)
+            if key not in invoked_keys and key not in registered_keys:
+                warnings.append(
+                    f"{enum}.{member} is never invoked nor registered in src/ "
+                    f"(handled by the LangBot host, or dead wiring?)"
+                )
+
+    print(
+        f"action-consistency: {len(enums)} enums, "
+        f"{len(invoked_keys)} invoked, {len(registered_keys)} registered"
+    )
+
+    if acknowledged:
+        print(f"\n{len(acknowledged)} known exception(s) (tracked debt):")
+        for line in acknowledged:
+            print(f"  KNOWN: {line}")
+
+    if warnings:
+        print(f"\n{len(warnings)} warning(s):")
+        for line in warnings:
+            print(f"  WARN: {line}")
+
+    if errors:
+        print(f"\n{len(errors)} error(s):", file=sys.stderr)
+        for line in errors:
+            print(f"  ERROR: {line}", file=sys.stderr)
+        print(
+            "\nAction protocol consistency check FAILED. "
+            "Register the missing handler(s) or fix the reference.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAction protocol consistency check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -302,6 +302,15 @@ class PluginConnectionHandler(handler.Handler):
             )
             return handler.ActionResponse.success(result)
 
+        @self.action(PluginToRuntimeAction.VECTOR_LIST)
+        async def vector_list(data: dict[str, Any]) -> handler.ActionResponse:
+            result = await _proxy_rag_action(
+                PluginToRuntimeAction.VECTOR_LIST,
+                data,
+                timeout=30,
+            )
+            return handler.ActionResponse.success(result)
+
         @self.action(PluginToRuntimeAction.GET_KNOWLEDEGE_FILE_STREAM)
         async def get_knowledge_file_stream(
             data: dict[str, Any],

--- a/tests/runtime/io/test_action_consistency.py
+++ b/tests/runtime/io/test_action_consistency.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/check_action_consistency.py.
+
+The integration test (``test_repo_action_protocol_is_consistent``) is the live
+guard: it fails CI if any action is invoked without a registered handler — the
+class of bug that shipped ``vector_list`` broken. The unit tests pin the
+receiver-direction logic that decides which actions are checkable from this repo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest  # type: ignore
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_action_consistency.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_action_consistency", SCRIPT_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def test_script_exists():
+    assert SCRIPT_PATH.is_file()
+
+
+@pytest.mark.parametrize(
+    ("enum_name", "expected"),
+    [
+        ("PluginToRuntimeAction", "Runtime"),
+        ("RuntimeToPluginAction", "Plugin"),
+        ("LangBotToRuntimeAction", "Runtime"),
+        ("RuntimeToLangBotAction", "LangBot"),
+        ("CommonAction", None),
+        ("NotAnActionEnum", None),
+    ],
+)
+def test_action_receiver(enum_name, expected):
+    assert checker.action_receiver(enum_name) == expected
+
+
+@pytest.mark.parametrize(
+    ("enum_name", "in_repo"),
+    [
+        ("PluginToRuntimeAction", True),
+        ("RuntimeToPluginAction", True),
+        ("LangBotToRuntimeAction", True),
+        ("CommonAction", True),
+        ("RuntimeToLangBotAction", False),  # receiver is the external LangBot host
+    ],
+)
+def test_receiver_in_repo(enum_name, in_repo):
+    assert checker.receiver_in_repo(enum_name) is in_repo
+
+
+def test_enum_members_load():
+    enums = checker.load_enum_members()
+    assert "PluginToRuntimeAction" in enums
+    # VECTOR_LIST must exist on the enum (referenced by the proxy + runtime forwarder).
+    assert "VECTOR_LIST" in enums["PluginToRuntimeAction"]
+
+
+def test_repo_action_protocol_is_consistent(capsys):
+    """Every in-repo-received action that is invoked must have a handler."""
+    exit_code = checker.main()
+    captured = capsys.readouterr()
+    assert exit_code == 0, (
+        f"Action protocol consistency check failed:\n{captured.out}\n{captured.err}"
+    )


### PR DESCRIPTION
## Problem

`vector_list` is fully declared on every layer **except** the one that routes the call:

- `api/proxies/langbot_api.py` → `vector_list()` proxy calls `call_action(PluginToRuntimeAction.VECTOR_LIST, ...)`
- `entities/io/actions/enums.py` → `VECTOR_LIST = "vector_list"`
- LangBot host → registers `@self.action(PluginToRuntimeAction.VECTOR_LIST)`
- **`runtime/io/handlers/plugin.py` → no forwarder registered** ❌

So the runtime dispatcher rejects the action before it ever reaches the host:

```
ValueError: Action vector_list not found
```

Any plugin that calls `vector_list` is affected. For **LongTermMemory** this breaks
`!memory list` / `search` / `export l2` / bulk delete and the Memory Console's
Episodes/Export tabs. Proxy-level unit tests don't catch it because they mock the
proxy, not the runtime forwarder — it only reproduces end-to-end.

## Fix

Register the `VECTOR_LIST` forwarder in the runtime, mirroring `VECTOR_DELETE`
(9 lines). No behaviour change for any other action.

### Verified end-to-end

Against a real LangBot + LongTermMemory + Chroma memory KB:

| | before | after |
|---|---|---|
| health probe `list` step | `vector_list probe failed: Action vector_list not found` | `vector_list respects user_key metadata filter` ✅ |
| `/episodes/list` | `code:-1 Action vector_list not found` | `code:0` clean result ✅ |

## Regression guard (2nd commit)

Adds `scripts/check_action_consistency.py` + a CI job (`action-consistency`) +
a unit test. It statically asserts that **every action invoked in-repo has a
registered handler whose receiver lives in this repo**, and that referenced enum
members exist. Running it on `main` flags exactly this `vector_list` gap (and a
second pre-existing one — see below).

## Follow-up (separate PR)

The new check also surfaced that `invoke_llm_stream_events()` references
`PluginToRuntimeAction.INVOKE_LLM_STREAM`, which is absent from this branch's enum
(present and wired on `feat/agent-runner-plugin`; the host already handles it). It
is recorded as a documented `KNOWN_EXCEPTIONS` entry here and fixed in a stacked
follow-up PR.

> Please review manually — do not auto-merge.
