### PR TITLE
fix(runtime): wire INVOKE_LLM_STREAM enum + streaming forwarder

### DIFF
--- a/scripts/check_action_consistency.py
+++ b/scripts/check_action_consistency.py
@@ -58,15 +58,7 @@ IN_REPO_RECEIVERS = {"Runtime", "Plugin"}
 # Accepted, documented exceptions to keep the gate green while tracking known debt.
 # Map (EnumClassName, MEMBER) -> reason. Remove an entry once the underlying issue
 # is fixed; the checker reports any entry that has become unnecessary.
-KNOWN_EXCEPTIONS: dict[tuple[str, str], str] = {
-    # invoke_llm_stream_events() references this member, but on the 0.4.x line the
-    # enum member and its runtime forwarder are absent (both exist and are wired on
-    # feat/agent-runner-plugin). Tracked for forward-port; the LangBot host already
-    # registers PluginToRuntimeAction.INVOKE_LLM_STREAM.
-    ("PluginToRuntimeAction", "INVOKE_LLM_STREAM"): (
-        "streaming LLM forwarder not yet ported to this branch; see feat/agent-runner-plugin"
-    ),
-}
+KNOWN_EXCEPTIONS: dict[tuple[str, str], str] = {}
 
 
 class Ref:

--- a/src/langbot_plugin/entities/io/actions/enums.py
+++ b/src/langbot_plugin/entities/io/actions/enums.py
@@ -40,7 +40,7 @@ class PluginToRuntimeAction(ActionType):
     GET_LLM_MODELS = "get_llm_models"
     # GET_LLM_MODEL_INFO = "get_llm_model_info"
     INVOKE_LLM = "invoke_llm"
-    # INVOKE_LLM_STREAMING = "invoke_llm_streaming"
+    INVOKE_LLM_STREAM = "invoke_llm_stream"
 
     SET_PLUGIN_STORAGE = "set_plugin_storage"
     GET_PLUGIN_STORAGE = "get_plugin_storage"

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -231,6 +231,24 @@ class PluginConnectionHandler(handler.Handler):
             )
             return handler.ActionResponse.success(result)
 
+        @self.action(PluginToRuntimeAction.INVOKE_LLM_STREAM)
+        async def invoke_llm_stream(
+            data: dict[str, Any],
+        ) -> AsyncGenerator[handler.ActionResponse, None]:
+            """Forward INVOKE_LLM_STREAM to LangBot control handler."""
+            timeout = data.pop("timeout", 120.0)
+            if not isinstance(timeout, (int, float)) or timeout <= 0:
+                timeout = 120.0
+
+            async for chunk in self.context.control_handler.call_action_generator(
+                PluginToRuntimeAction.INVOKE_LLM_STREAM,
+                {
+                    **data,
+                },
+                timeout=float(timeout),
+            ):
+                yield handler.ActionResponse.success(chunk)
+
         @self.action(PluginToRuntimeAction.INVOKE_EMBEDDING)
         async def invoke_embedding(data: dict[str, Any]) -> handler.ActionResponse:
             result = await self.context.control_handler.call_action(


### PR DESCRIPTION
> **Stacked on #85** (base branch = `fix/vector-list-action-forwarder`). Review/merge #85 first; this PR's diff is only the streaming forwarder once #85 is in.

## Problem (found by the consistency check added in #85)

`api/proxies/langbot_api.py::invoke_llm_stream_events()` calls
`call_action(PluginToRuntimeAction.INVOKE_LLM_STREAM, ...)`, but on the 0.4.x line:

- the enum member `INVOKE_LLM_STREAM` was **absent** (only a commented-out
  `INVOKE_LLM_STREAMING`), so the reference would raise `AttributeError`;
- no runtime forwarder was registered, so even with the member it would fail with
  `Action invoke_llm_stream not found`.

The LangBot host already registers `@self.action(PluginToRuntimeAction.INVOKE_LLM_STREAM)`,
so only the SDK side was missing. (Both pieces already exist on `feat/agent-runner-plugin`;
this forward-ports them to the release line.)

## Fix

- Add `INVOKE_LLM_STREAM = "invoke_llm_stream"` to `PluginToRuntimeAction`.
- Register the streaming forwarder in `runtime/io/handlers/plugin.py`, mirroring the
  existing non-streaming `INVOKE_LLM` forwarder but streaming via
  `control_handler.call_action_generator(...)` and yielding `ActionResponse.success(chunk)`.
  (Adapted to the main line — no agent-runner caller-identity injection, matching the
  sibling `INVOKE_LLM` handler here.)
- Remove the now-unnecessary `KNOWN_EXCEPTIONS` entry; the check's stale-allowlist
  guard would otherwise fail, and it now passes with **0** exceptions.

## Verification

- `python scripts/check_action_consistency.py` → passes, 0 known exceptions.
- `ruff check` / `ruff format --check` clean; 142 runtime + proxy + consistency tests pass.
- Runtime streaming dispatch support confirmed (`handler.py` handles async-generator
  action handlers; `call_action_generator` present).

⚠️ **Not exercised against a live streaming LLM** (needs a real model + streaming chat).
The change is structurally faithful to the host handler and the feat-branch impl, but
please validate the live streaming path during review.

> Please review manually — do not auto-merge.
