### PR TITLE
fix(box): allow disabling Docker CPU limit

### DIFF
--- a/src/langbot_plugin/box/backend.py
+++ b/src/langbot_plugin/box/backend.py
@@ -26,6 +26,7 @@ from .security import validate_sandbox_security
 # produce large output within the time limit.  After this many bytes the
 # remaining output is discarded before decoding.
 _MAX_RAW_OUTPUT_BYTES = 1_048_576  # 1 MB per stream
+_FALSE_VALUES = {"0", "false"}
 
 
 @dataclasses.dataclass(slots=True)
@@ -80,6 +81,7 @@ class CLISandboxBackend(BaseSandboxBackend):
         super().__init__(logger)
         self.command = command
         self.name = backend_name
+        self.cpu_limit_enabled = True
 
     async def is_available(self) -> bool:
         if shutil.which(self.command) is None:
@@ -121,10 +123,7 @@ class CLISandboxBackend(BaseSandboxBackend):
         if spec.network == BoxNetworkMode.OFF:
             args.extend(["--network", "none"])
 
-        # Resource limits
-        args.extend(["--cpus", str(spec.cpus)])
-        args.extend(["--memory", f"{spec.memory_mb}m"])
-        args.extend(["--pids-limit", str(spec.pids_limit)])
+        args.extend(self._build_resource_limit_args(spec))
 
         if spec.read_only_rootfs:
             args.append("--read-only")
@@ -149,7 +148,8 @@ class CLISandboxBackend(BaseSandboxBackend):
             f"session_id={spec.session_id} container_name={container_name} "
             f"image={spec.image} network={spec.network.value} "
             f"host_path={spec.host_path} host_path_mode={spec.host_path_mode.value} mount_path={spec.mount_path} "
-            f"cpus={spec.cpus} memory_mb={spec.memory_mb} pids_limit={spec.pids_limit} "
+            f"cpus={spec.cpus} cpu_limit_enabled={self.cpu_limit_enabled} "
+            f"memory_mb={spec.memory_mb} pids_limit={spec.pids_limit} "
             f"read_only_rootfs={spec.read_only_rootfs} workspace_quota_mb={spec.workspace_quota_mb}"
         )
 
@@ -333,6 +333,14 @@ class CLISandboxBackend(BaseSandboxBackend):
         suffix = uuid.uuid4().hex[:8]
         return f"langbot-box-{normalized[:32]}-{suffix}"
 
+    def _build_resource_limit_args(self, spec: BoxSpec) -> list[str]:
+        args: list[str] = []
+        if self.cpu_limit_enabled:
+            args.extend(["--cpus", str(spec.cpus)])
+        args.extend(["--memory", f"{spec.memory_mb}m"])
+        args.extend(["--pids-limit", str(spec.pids_limit)])
+        return args
+
     def _build_exec_command(self, workdir: str, cmd: str) -> str:
         quoted_workdir = shlex.quote(workdir)
         return f"mkdir -p {quoted_workdir} && cd {quoted_workdir} && {cmd}"
@@ -430,3 +438,16 @@ class CLISandboxBackend(BaseSandboxBackend):
 class DockerBackend(CLISandboxBackend):
     def __init__(self, logger: logging.Logger):
         super().__init__(logger=logger, command="docker", backend_name="docker")
+
+    def configure(self, config: dict) -> None:
+        raw_value = config.get("cpu_limit_enabled", True)
+        if isinstance(raw_value, bool):
+            enabled = raw_value
+        else:
+            enabled = str(raw_value).strip().lower() not in _FALSE_VALUES
+        self.cpu_limit_enabled = enabled
+        if not enabled:
+            self.logger.warning(
+                "Docker sandbox CPU limit is disabled by config "
+                "(box.docker.cpu_limit_enabled=false); containers will be started without --cpus."
+            )

--- a/tests/box/test_backend.py
+++ b/tests/box/test_backend.py
@@ -134,6 +134,14 @@ def test_backend_name_and_command(backend):
     assert backend.command == "docker"
 
 
+def test_configure_logs_when_docker_cpu_limit_is_disabled(backend, caplog):
+    with caplog.at_level(logging.WARNING, logger=backend.logger.name):
+        backend.configure({"cpu_limit_enabled": False})
+
+    assert "Docker sandbox CPU limit is disabled by config" in caplog.text
+    assert "containers will be started without --cpus" in caplog.text
+
+
 # ── is_available ──────────────────────────────────────────────────────
 
 
@@ -281,6 +289,38 @@ async def test_start_session_custom_resource_limits(backend):
     assert info.cpus == 2.5
     assert info.memory_mb == 1024
     assert info.pids_limit == 256
+
+
+@pytest.mark.anyio
+async def test_start_session_can_disable_docker_cpu_limit(backend):
+    backend.configure({"cpu_limit_enabled": False})
+    proc = _FakeProcess(returncode=0)
+    patcher, mock_exec = _patch_exec(proc)
+    spec = BoxSpec(session_id="no-cpu-limit", cmd="x")
+
+    with patcher:
+        await backend.start_session(spec)
+
+    argv = _argv_of(mock_exec)
+    assert "--cpus" not in argv
+    assert _value_after(argv, "--memory") == "512m"
+    assert _value_after(argv, "--pids-limit") == "128"
+
+
+@pytest.mark.anyio
+async def test_start_session_can_disable_docker_cpu_limit_from_string_config(backend):
+    backend.configure({"cpu_limit_enabled": "false"})
+    proc = _FakeProcess(returncode=0)
+    patcher, mock_exec = _patch_exec(proc)
+    spec = BoxSpec(session_id="no-cpu-limit-env", cmd="x")
+
+    with patcher:
+        await backend.start_session(spec)
+
+    argv = _argv_of(mock_exec)
+    assert "--cpus" not in argv
+    assert _value_after(argv, "--memory") == "512m"
+    assert _value_after(argv, "--pids-limit") == "128"
 
 
 @pytest.mark.anyio

--- a/tests/box/test_runtime.py
+++ b/tests/box/test_runtime.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 import pytest
 
-from langbot_plugin.box.backend import BaseSandboxBackend
+from langbot_plugin.box.backend import BaseSandboxBackend, DockerBackend
 from langbot_plugin.box.errors import (
     BoxBackendUnavailableError,
     BoxManagedProcessNotFoundError,
@@ -216,6 +216,17 @@ def test_init_method_applies_config_and_resets_backend(logger):
     backend.configure.assert_called_once_with({"cpus": 2})
     # No active sessions → backend reset so it re-selects with new config.
     assert runtime._backend is None
+
+
+def test_init_method_applies_docker_cpu_limit_config(logger):
+    """box.docker.cpu_limit_enabled is forwarded to the Docker backend."""
+    backend = DockerBackend(logger)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend])
+
+    runtime.init({"docker": {"cpu_limit_enabled": "false"}})
+
+    assert backend.cpu_limit_enabled is False
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Add a Docker backend config flag to skip the Docker --cpus argument.
- Keep Docker CPU limits enabled by default for compatibility and safety.
- Preserve memory and pids limit arguments when CPU limits are disabled.

## Usage
box.docker.cpu_limit_enabled: false

For Docker Compose deployments, set BOX__DOCKER__CPU_LIMIT_ENABLED=false on the langbot service so LangBot forwards it to the Box runtime.

## Validation
- uv run pytest tests\box\test_backend.py tests\box\test_runtime.py -q
- uv run ruff check src\langbot_plugin\box\backend.py tests\box\test_backend.py tests\box\test_runtime.py