### PR TITLE
feat(agent-runner): expose run create admin proxy

### DIFF
--- a/src/langbot_plugin/api/proxies/agent_run/admin.py
+++ b/src/langbot_plugin/api/proxies/agent_run/admin.py
@@ -51,6 +51,51 @@ class AgentRunAdminAPIProxy:
     def __init__(self, plugin_runtime_handler: Handler):
         self.plugin_runtime_handler = plugin_runtime_handler
 
+    async def run_create(
+        self,
+        *,
+        runner_id: str,
+        input: dict[str, Any] | None = None,
+        event: dict[str, Any] | None = None,
+        binding: dict[str, Any] | None = None,
+        runner_config: dict[str, Any] | None = None,
+        resource_policy: dict[str, Any] | None = None,
+        state_policy: dict[str, Any] | None = None,
+        delivery_policy: dict[str, Any] | None = None,
+        delivery: dict[str, Any] | None = None,
+        agent_id: str | None = None,
+        conversation_id: str | None = None,
+        thread_id: str | None = None,
+        workspace_id: str | None = None,
+        bot_id: str | None = None,
+        run_id: str | None = None,
+        wait_for_completion: bool = False,
+    ) -> AgentRun:
+        payload: dict[str, Any] = {
+            "runner_id": runner_id,
+            "input": input,
+            "event": event,
+            "binding": binding,
+            "runner_config": runner_config,
+            "resource_policy": resource_policy,
+            "state_policy": state_policy,
+            "delivery_policy": delivery_policy,
+            "delivery": delivery,
+            "agent_id": agent_id,
+            "conversation_id": conversation_id,
+            "thread_id": thread_id,
+            "workspace_id": workspace_id,
+            "bot_id": bot_id,
+            "run_id": run_id,
+            "wait_for_completion": wait_for_completion,
+        }
+        resp = await self._call_action(
+            PluginToRuntimeAction.RUN_CREATE,
+            payload,
+            120.0 if wait_for_completion else 15.0,
+        )
+        return AgentRun.model_validate(resp)
+
     async def _call_action(
         self,
         action: PluginToRuntimeAction,

--- a/src/langbot_plugin/entities/io/actions/enums.py
+++ b/src/langbot_plugin/entities/io/actions/enums.py
@@ -92,6 +92,7 @@ class PluginToRuntimeAction(ActionType):
     STEERING_PULL = "steering_pull"
 
     """Agent Run Ledger APIs (run-scoped, requires run_id authorization)"""
+    RUN_CREATE = "run_create"
     RUN_GET = "run_get"
     RUN_LIST = "run_list"
     RUN_EVENTS_PAGE = "run_events_page"

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -794,6 +794,12 @@ class PluginConnectionHandler(handler.Handler):
         # ================= Agent Run Ledger and Runtime Registry Handlers =================
         # These handlers forward Host-owned run/runtime primitives with caller_plugin_identity injection.
 
+        @self.action(PluginToRuntimeAction.RUN_CREATE)
+        async def run_create(data: dict[str, Any]) -> handler.ActionResponse:
+            return await _forward_to_host(
+                PluginToRuntimeAction.RUN_CREATE, data, timeout=120
+            )
+
         @self.action(PluginToRuntimeAction.RUN_GET)
         async def run_get(data: dict[str, Any]) -> handler.ActionResponse:
             return await _forward_to_host(

--- a/tests/api/proxies/test_agent_run_api_proxy.py
+++ b/tests/api/proxies/test_agent_run_api_proxy.py
@@ -1366,6 +1366,35 @@ class TestAgentRunAdminAPIProxy:
     """Tests for Host-authorized admin proxy methods."""
 
     @pytest.mark.anyio
+    async def test_admin_run_create_serializes_public_method_payload(self):
+        mock_handler = MockHandler()
+        mock_handler.call_action_mock.return_value = {
+            "run_id": "run_created",
+            "runner_id": "plugin:test/plugin/default",
+            "status": "created",
+            "metadata": {},
+        }
+        proxy = AgentRunAdminAPIProxy(plugin_runtime_handler=mock_handler)
+
+        run = await proxy.run_create(
+            runner_id="plugin:test/plugin/default",
+            input={"text": "ship it"},
+            conversation_id="conv_1",
+            wait_for_completion=False,
+        )
+
+        assert run.run_id == "run_created"
+        action, data, timeout = mock_handler.call_action_mock.call_args.args
+        assert action == PluginToRuntimeAction.RUN_CREATE
+        assert "run_id" in data
+        assert data["run_id"] is None
+        assert data["runner_id"] == "plugin:test/plugin/default"
+        assert data["input"] == {"text": "ship it"}
+        assert data["conversation_id"] == "conv_1"
+        assert data["wait_for_completion"] is False
+        assert timeout == 15.0
+
+    @pytest.mark.anyio
     async def test_admin_run_list_omits_run_id(self):
         mock_handler = MockHandler()
         mock_handler.call_action_mock.return_value = {

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -396,6 +396,40 @@ async def test_plugin_handler_forwards_invoke_rerank_with_caller_identity():
     ]
 
 
+async def test_plugin_handler_forwards_run_create_with_caller_identity():
+    handler, manager, control = _handler()
+    manager.plugins = [FakePluginContainer(runtime_handler=handler)]
+    control.results[PluginToRuntimeAction.RUN_CREATE] = {
+        "run_id": "run-created",
+        "runner_id": "plugin:test/plugin/default",
+        "status": "created",
+        "metadata": {},
+    }
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            PluginToRuntimeAction.RUN_CREATE.value,
+            {
+                "runner_id": "plugin:test/plugin/default",
+                "input": {"text": "ship it"},
+                "caller_plugin_identity": "spoofed/plugin",
+            },
+        )
+
+    assert response["data"]["run_id"] == "run-created"
+    assert control.calls == [
+        (
+            PluginToRuntimeAction.RUN_CREATE,
+            {
+                "runner_id": "plugin:test/plugin/default",
+                "input": {"text": "ship it"},
+                "caller_plugin_identity": "tester/demo",
+            },
+            120,
+        )
+    ]
+
+
 async def test_plugin_handler_adds_plugin_owner_for_binary_storage():
     handler, manager, control = _handler()
     manager.plugins = [FakePluginContainer(runtime_handler=handler)]


### PR DESCRIPTION
## Summary
- add RUN_CREATE to the plugin-runtime action enum and forwarding layer
- expose AgentRunAdminAPIProxy.run_create for authorized control-plane plugins
- cover the new proxy action in tests

## Tests
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/api/proxies/test_agent_run_api_proxy.py tests/runtime/io/handlers/test_plugin_handler.py tests/runtime/io/test_action_consistency.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/langbot_plugin/api/proxies/agent_run/admin.py src/langbot_plugin/entities/io/actions/enums.py src/langbot_plugin/runtime/io/handlers/plugin.py tests/api/proxies/test_agent_run_api_proxy.py