### PR TITLE
fix(runtime): log recoverable cleanup failures

### DIFF
--- a/src/langbot_plugin/api/proxies/agent_run/common.py
+++ b/src/langbot_plugin/api/proxies/agent_run/common.py
@@ -38,23 +38,27 @@ def _build_agent_api_exception(
     error: ActionCallError,
 ) -> AgentAPIException:
     data = error.data or {}
+    parse_error: str | None = None
     raw_error = data.get("error") if isinstance(data, dict) else None
     if isinstance(raw_error, dict):
         try:
             return AgentAPIException(AgentAPIError.model_validate(raw_error))
-        except Exception:
-            pass
+        except Exception as exc:
+            parse_error = str(exc)
     if isinstance(data, dict) and {"code", "message"}.issubset(data.keys()):
         try:
             return AgentAPIException(AgentAPIError.model_validate(data))
-        except Exception:
-            pass
+        except Exception as exc:
+            parse_error = str(exc)
+    details = {"action": action.value, "response_data": data}
+    if parse_error:
+        details["parse_error"] = parse_error
     return AgentAPIException(
         AgentAPIError(
             code="host.action_error",
             message=str(error),
             retryable=False,
-            details={"action": action.value, "response_data": data},
+            details=details,
         )
     )
 

--- a/src/langbot_plugin/box/client.py
+++ b/src/langbot_plugin/box/client.py
@@ -198,8 +198,8 @@ class ActionRPCBoxClient(BoxRuntimeClient):
         if self._handler is not None:
             try:
                 await self._call(LangBotToBoxAction.SHUTDOWN, {})
-            except Exception:
-                pass
+            except Exception as exc:
+                self._logger.debug("Box runtime shutdown action failed during cleanup: %s", exc, exc_info=True)
             self._handler = None
 
     async def get_status(self) -> dict:

--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -22,6 +22,8 @@ from .models import (
 )
 from .security import validate_sandbox_security
 
+_LOGGER = logging.getLogger(__name__)
+
 # System directories to mount read-only inside the sandbox.
 # Only well-known paths needed for running Python/Node/shell commands.
 _READONLY_SYSTEM_MOUNTS: list[str] = [
@@ -623,8 +625,13 @@ class NsjailBackend(BaseSandboxBackend):
                 subtree_control.write_text(f"+{probe_controller}")
                 try:
                     subtree_control.write_text(f"-{probe_controller}")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    _LOGGER.warning(
+                        "Failed to restore cgroup controller delegation after probe: controller=%s error=%s",
+                        probe_controller,
+                        exc,
+                    )
+                    return False
         except Exception:
             return False
         return True

--- a/src/langbot_plugin/box/runtime.py
+++ b/src/langbot_plugin/box/runtime.py
@@ -594,22 +594,22 @@ class BoxRuntime:
         try:
             if process.stdin is not None:
                 process.stdin.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            self.logger.debug("Failed to close managed process stdin: %s", exc, exc_info=True)
 
         try:
             if process.returncode is None:
                 try:
                     process.terminate()
-                except ProcessLookupError:
-                    pass
+                except ProcessLookupError as exc:
+                    self.logger.debug("Managed process exited before terminate: %s", exc)
             await asyncio.wait_for(asyncio.shield(process.wait()), timeout=5)
         except asyncio.TimeoutError:
             if process.returncode is None:
                 try:
                     process.kill()
-                except ProcessLookupError:
-                    pass
+                except ProcessLookupError as exc:
+                    self.logger.debug("Managed process exited before kill: %s", exc)
             await process.wait()
         finally:
             managed_process.exit_code = process.returncode

--- a/src/langbot_plugin/cli/run/handler.py
+++ b/src/langbot_plugin/cli/run/handler.py
@@ -114,8 +114,8 @@ async def _iter_runner_results_with_deadline(
     finally:
         try:
             await result_gen.aclose()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to close AgentRunner result generator: %s", exc, exc_info=True)
 
 
 class PluginRuntimeHandler(Handler):

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.metadata
 import importlib.util
+import logging
 import os
 import re
 import subprocess
@@ -13,6 +14,7 @@ from pip._internal import main as pipmain
 PYPI_INDEX_URL_ENV = "LANGBOT_PLUGIN_PYPI_INDEX_URL"
 PYPI_TRUSTED_HOST_ENV = "LANGBOT_PLUGIN_PYPI_TRUSTED_HOST"
 DEFAULT_PYPI_INDEX_URL = "https://pypi.org/simple"
+logger = logging.getLogger(__name__)
 
 
 def get_pip_index_args() -> list[str]:
@@ -182,8 +184,8 @@ def _resolve_import_names(pkg_name: str) -> set[str]:
                 for dist_name in dist_names:
                     key = dist_name.lower().replace("_", "-")
                     _dist_to_packages.setdefault(key, set()).add(top_pkg)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Failed to load package distribution metadata: %s", exc, exc_info=True)
 
     key = pkg_name.lower().replace("_", "-")
     names = _dist_to_packages.get(key, set()).copy()


### PR DESCRIPTION
## Summary

- Preserve parse diagnostics when Host AgentRunner error payloads fail SDK validation.
- Replace silent cleanup fallbacks in Box runtime/client, CLI runner cleanup, and package metadata resolution with debug/warning logs.
- Treat nsjail cgroup delegation rollback failure as a failed cgroup-v2 probe instead of silently continuing.

## Verification

- `uv run ruff check src/langbot_plugin/api/proxies/agent_run/common.py src/langbot_plugin/box/client.py src/langbot_plugin/box/nsjail_backend.py src/langbot_plugin/box/runtime.py src/langbot_plugin/cli/run/handler.py src/langbot_plugin/runtime/helper/pkgmgr.py`
- `uv run pytest tests/runtime/helper/test_pkgmgr.py tests/box/test_server.py tests/cli/run/test_controller.py -q`