### PR TITLE
feat(runtime): report deferred response sources

### DIFF
--- a/docs/communication/apis/lb2rt.md
+++ b/docs/communication/apis/lb2rt.md
@@ -39,12 +39,33 @@
 ### Request
 
 ```json
+{
+    "event_context": {},
+    "include_plugins": ["author/name"]
+}
 ```
 
 ### Response
 
 ```json
+{
+    "emitted_plugins": [],
+    "response_sources": [
+        {
+            "kind": "reply_message_chain",
+            "plugin": {
+                "author": "plugin_author",
+                "name": "plugin_name"
+            }
+        }
+    ],
+    "event_context": {}
+}
 ```
+
+`emitted_plugins` contains plugins whose event handlers ran. `response_sources`
+contains plugins that changed a deferred response field on the event context, such
+as `reply_message_chain`.
 
 ## `list_tools`
 

--- a/src/langbot_plugin/runtime/io/handlers/control.py
+++ b/src/langbot_plugin/runtime/io/handlers/control.py
@@ -226,9 +226,11 @@ class ControlConnectionHandler(handler.Handler):
             event_context = EventContext.model_validate(event_context_data)
             include_plugins = data.get("include_plugins")
 
-            emitted_plugins, event_context = await self.context.plugin_mgr.emit_event(
-                event_context, include_plugins
-            )
+            (
+                emitted_plugins,
+                event_context,
+                response_sources,
+            ) = await self.context.plugin_mgr.emit_event(event_context, include_plugins)
 
             event_context_dump = event_context.model_dump()
 
@@ -237,6 +239,7 @@ class ControlConnectionHandler(handler.Handler):
                     "emitted_plugins": [
                         plugin.model_dump() for plugin in emitted_plugins
                     ],
+                    "response_sources": response_sources,
                     "event_context": event_context_dump,
                 }
             )

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -719,8 +719,13 @@ class PluginManager:
 
     async def emit_event(
         self, event_context: EventContext, include_plugins: list[str] | None = None
-    ) -> tuple[list[runtime_plugin_container.PluginContainer], EventContext]:
+    ) -> tuple[
+        list[runtime_plugin_container.PluginContainer],
+        EventContext,
+        list[dict[str, typing.Any]],
+    ]:
         emitted_plugins: list[runtime_plugin_container.PluginContainer] = []
+        response_sources: list[dict[str, typing.Any]] = []
 
         for plugin in self.plugins:
             if (
@@ -743,6 +748,7 @@ class PluginManager:
                 if plugin_id not in include_plugins:
                     continue
 
+            reply_message_chain_before = _dump_reply_message_chain(event_context)
             resp = await plugin._runtime_plugin_handler.emit_event(
                 event_context.model_dump()
             )
@@ -751,11 +757,19 @@ class PluginManager:
                 emitted_plugins.append(plugin)
 
             event_context = EventContext.model_validate(resp["event_context"])
+            reply_message_chain_after = _dump_reply_message_chain(event_context)
+            if reply_message_chain_after != reply_message_chain_before:
+                response_sources.append(
+                    {
+                        "kind": "reply_message_chain",
+                        "plugin": _plugin_ref(plugin),
+                    }
+                )
 
             if event_context.is_prevented_postorder():
                 break
 
-        return emitted_plugins, event_context
+        return emitted_plugins, event_context, response_sources
 
     async def get_plugin_icon(
         self, plugin_author: str, plugin_name: str
@@ -1283,4 +1297,22 @@ def _to_plugin_diagnostic(
         "code": diagnostic.get("code", "plugin_diagnostic"),
         "message": diagnostic.get("message", "Plugin diagnostic"),
         "details": details,
+    }
+
+
+def _dump_reply_message_chain(
+    event_context: EventContext,
+) -> list[dict[str, typing.Any]] | None:
+    reply_message_chain = getattr(event_context.event, "reply_message_chain", None)
+    if reply_message_chain is None:
+        return None
+    return reply_message_chain.model_dump()
+
+
+def _plugin_ref(
+    plugin: runtime_plugin_container.PluginContainer,
+) -> dict[str, str]:
+    return {
+        "author": str(plugin.manifest.metadata.author),
+        "name": str(plugin.manifest.metadata.name),
     }

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -104,7 +104,18 @@ class FakePluginManager:
     async def emit_event(self, event_context, include_plugins=None):
         self.calls.append(("emit_event", event_context, include_plugins))
         event_context.prevent_postorder()
-        return [self.plugins[0]], event_context
+        return (
+            [
+                self.plugins[0],
+            ],
+            event_context,
+            [
+                {
+                    "kind": "reply_message_chain",
+                    "plugin": {"author": "tester", "name": "demo"},
+                }
+            ],
+        )
 
     async def list_tools(self, include_plugins=None):
         self.calls.append(("list_tools", include_plugins))
@@ -642,6 +653,12 @@ async def test_control_handler_emit_event_delegates_and_serializes_result():
     assert include_plugins == ["tester/demo"]
     assert response["data"]["emitted_plugins"] == [
         {"manifest": {"author": "tester", "name": "demo"}}
+    ]
+    assert response["data"]["response_sources"] == [
+        {
+            "kind": "reply_message_chain",
+            "plugin": {"author": "tester", "name": "demo"},
+        }
     ]
     assert response["data"]["event_context"]["is_prevent_postorder"] is True
 

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -13,7 +13,11 @@ from langbot_plugin.api.definition.components.manifest import ComponentManifest
 from langbot_plugin.api.definition.plugin import NonePlugin
 from langbot_plugin.api.entities.builtin.command.context import CommandReturn
 from langbot_plugin.api.entities.context import EventContext
-from langbot_plugin.api.entities.events import PersonCommandSent
+from langbot_plugin.api.entities.builtin.platform import message as platform_message
+from langbot_plugin.api.entities.events import (
+    PersonCommandSent,
+    PersonNormalMessageReceived,
+)
 from langbot_plugin.runtime.helper import marketplace as marketplace_helper
 from langbot_plugin.runtime.plugin.container import (
     ComponentContainer,
@@ -241,6 +245,14 @@ class FakeHandler:
 
     async def parse_document(self, context_data, file_bytes):
         return {"context": context_data, "text": file_bytes.decode()}
+
+
+class ReplyChangingFakeHandler(FakeHandler):
+    async def emit_event(self, event_context):
+        event_context["event"]["reply_message_chain"] = [
+            {"type": "Plain", "text": "plugin reply"}
+        ]
+        return {"emitted": True, "event_context": event_context}
 
 
 def test_plugin_manager_instances_should_not_share_plugin_state():
@@ -951,9 +963,51 @@ async def test_emit_event_should_report_each_emitting_plugin_once():
         ),
     )
 
-    emitted_plugins, _ = await manager.emit_event(event_context)
+    emitted_plugins, _, _ = await manager.emit_event(event_context)
 
     assert emitted_plugins == [plugin]
+
+
+@pytest.mark.asyncio
+async def test_emit_event_reports_only_plugins_that_changed_reply_message_chain():
+    manager = _manager()
+    observer = _plugin(name="observer")
+    responder = _plugin(name="responder")
+    observer._runtime_plugin_handler = FakeHandler(observer)
+    responder._runtime_plugin_handler = ReplyChangingFakeHandler(responder)
+    manager.plugins = [observer, responder]
+    event_context = EventContext(
+        query_id=1,
+        event_name="PersonNormalMessageReceived",
+        event=PersonNormalMessageReceived(
+            launcher_type="person",
+            launcher_id="launcher",
+            sender_id="sender",
+            text_message="hello",
+            message_event={
+                "time": 0.0,
+                "self_id": "bot",
+                "sender": {"id": "sender", "nickname": "Sender", "remark": ""},
+                "message_chain": [{"type": "Plain", "text": "hello"}],
+            },
+            message_chain=platform_message.MessageChain(
+                [platform_message.Plain(text="hello")]
+            ),
+        ),
+    )
+
+    emitted_plugins, event_context, response_sources = await manager.emit_event(
+        event_context
+    )
+
+    assert emitted_plugins == [observer, responder]
+    assert response_sources == [
+        {
+            "kind": "reply_message_chain",
+            "plugin": {"author": "tester", "name": "responder"},
+        }
+    ]
+    assert str(event_context.event.reply_message_chain) == "plugin reply"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add response_sources to emit_event results for deferred response attribution
- detect plugins that actually changed event.reply_message_chain instead of treating all emitted plugins as response authors
- document the LangBot-to-runtime emit_event response shape

## Validation
- uv run --frozen ruff check src tests --output-format=concise
- uv run --frozen ruff format --check src tests
- uv run --frozen pytest tests/runtime/plugin/test_manager.py tests/runtime/io/handlers/test_control_handler.py -q