### PR TITLE
fix(box): server-driven WS heartbeat for managed-process relay

### DIFF
--- a/src/langbot_plugin/box/server.py
+++ b/src/langbot_plugin/box/server.py
@@ -304,6 +304,13 @@ class BoxServerHandler(Handler):
             return ActionResponse.success({})
 
 
+# Server-driven WebSocket keepalive interval (seconds) for the managed-process
+# stdio relay. The Box runtime is lightly loaded and answers pings reliably;
+# emitting pings from the server keeps a long-idle relay alive even when the
+# LangBot client's event loop stalls briefly (which would otherwise trip the
+# mcp websocket client's 20s ping/pong timeout and drop the connection).
+_MANAGED_PROCESS_WS_HEARTBEAT_SEC = 30.0
+
 # ── Managed process WebSocket relay ──────────────────────────────────
 
 
@@ -339,7 +346,10 @@ async def handle_managed_process_ws(request: web.Request) -> web.StreamResponse:
             )
         )
 
-    ws = web.WebSocketResponse(protocols=("mcp",))
+    ws = web.WebSocketResponse(
+        protocols=("mcp",),
+        heartbeat=_MANAGED_PROCESS_WS_HEARTBEAT_SEC,
+    )
     await ws.prepare(request)
 
     async with managed_process.attach_lock:


### PR DESCRIPTION
## Problem

Box-backed stdio MCP servers (e.g. `pab1it0/prometheus` on demo.langbot.dev) periodically fail with `Box managed process exited unexpectedly` / `Failed after 4 attempts` once a session has been alive for a while.

## Root cause

The managed-process stdio relay (`handle_managed_process_ws`) opened its WebSocket with **no heartbeat**. A long-idle relay then relied entirely on the mcp websocket client's default 20s ping / 20s pong window. A brief stall on the LangBot side (single-worker event loop) makes the client miss a pong, the connection drops with `Connection closed`, and LangBot's MCP session lifecycle tears the managed process down and retries.

## Fix

Add a **server-driven** heartbeat (30s) to the managed-process relay WebSocket. The Box runtime is lightly loaded and emits/answers pings reliably even when the LangBot side is momentarily busy, keeping the relay alive across those stalls. aiohttp still auto-answers client pings.

## Verification

- `pytest tests/box` green (119 passed).
- Integration check in the demo box container: heartbeat wired (`_MANAGED_PROCESS_WS_HEARTBEAT_SEC=30`), managed process survives a transient WS drop and is re-attachable.

Pairs with a LangBot main-repo PR that makes the client side reuse the live process on a transport reconnect instead of rebuilding it.