### PR TITLE
chore: release v0.4.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.7"
+version = "0.4.8"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Release v0.4.8. Includes #95 (server-driven WS heartbeat on the managed-process relay), which fixes long-lived Box stdio MCP servers dropping with `Box managed process exited unexpectedly`. Pairs with LangBot#2303.