### PR TITLE
fix(box/nsjail): raise RLIMIT_AS to hard so node/npx MCP servers do not OOM

### DIFF
--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -501,11 +501,12 @@ class NsjailBackend(BaseSandboxBackend):
             # rlimit fallback – used whenever cgroup v2 delegation is not usable
             # (private cgroup namespace -> EBUSY, or read-only /sys/fs/cgroup).
             #
-            # We deliberately do NOT set --rlimit_as for the memory cap.
-            # RLIMIT_AS limits *virtual* address space, not resident memory, and
-            # modern runtimes reserve huge virtual mappings up front: uv/Rust
-            # (and Go/JVM/Node) mmap gigabytes of address space even to do tiny
-            # work, so a 512 MB --rlimit_as aborts them instantly with
+            # We do NOT set a SMALL --rlimit_as as a memory cap (see the
+            # --rlimit_as hard note below). RLIMIT_AS limits *virtual* address
+            # space, not resident memory, and modern runtimes reserve huge
+            # virtual mappings up front: uv/Rust (and Go/JVM/Node) mmap
+            # gigabytes of address space even to do tiny work, so a 512 MB
+            # --rlimit_as aborts them instantly with
             # "memory allocation of N bytes failed" (exit 255) — which is what
             # silently broke every uvx-based stdio MCP server in containerized
             # nsjail deployments. There is no RSS-based rlimit on modern Linux
@@ -517,8 +518,27 @@ class NsjailBackend(BaseSandboxBackend):
             # which is a real rlimit that does not break runtimes.
             args.extend(["--rlimit_nproc", str(spec.pids_limit)])
 
+        # nsjail defaults --rlimit_as to 512 MB. RLIMIT_AS caps *virtual*
+        # address space, and modern runtimes reserve huge virtual mappings up
+        # front regardless of actual memory use: Node.js/V8 alone reserves well
+        # over 512 MB of address space at startup, and its built-in undici HTTP
+        # client instantiates an llhttp WebAssembly module during boot. Under
+        # the default 512 MB RLIMIT_AS that WASM allocation fails with
+        # "WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm
+        # memory for new instance", crashing every node/npx-based stdio MCP
+        # server (e.g. firecrawl-mcp) even when cgroup_mem_max is generous.
+        # Python/uvx servers reserve far less address space and were unaffected,
+        # which made this look like "npx isn't supported".
+        #
+        # So we explicitly raise RLIMIT_AS to the current hard limit ("hard")
+        # rather than leaving it at nsjail's small default. Real memory pressure
+        # is still bounded by --cgroup_mem_max (cgroup v2 branch) or by the
+        # container-level mem_limit (rlimit fallback branch) — both of which cap
+        # RESIDENT memory, the thing that actually matters.
+        args.extend(["--rlimit_as", "hard"])
+
         # Always set these rlimits regardless of cgroup mode. These are safe
-        # for modern runtimes (unlike RLIMIT_AS).
+        # for modern runtimes (unlike a small RLIMIT_AS).
         args.extend(["--rlimit_fsize", "512"])  # max file size 512 MB
         args.extend(["--rlimit_nofile", "256"])  # max open fds
 

--- a/tests/box/test_nsjail_backend.py
+++ b/tests/box/test_nsjail_backend.py
@@ -412,6 +412,13 @@ def test_build_resource_limits_cgroup(backend):
     cpu_idx = args.index("--cgroup_cpu_ms_per_sec")
     assert args[cpu_idx + 1] == "2000"
 
+    # Virtual address space must be raised to the hard limit so node/V8 WASM
+    # (and other runtimes reserving large vaddr) can boot; physical memory is
+    # still bounded by --cgroup_mem_max above.
+    assert "--rlimit_as" in args
+    ras_idx = args.index("--rlimit_as")
+    assert args[ras_idx + 1] == "hard"
+
 
 def test_build_resource_limits_rlimit_fallback(backend):
     backend._cgroup_v2_available = False
@@ -419,13 +426,16 @@ def test_build_resource_limits_rlimit_fallback(backend):
 
     args = backend._build_resource_limits(spec)
 
-    # Bug regression: --rlimit_as must NOT be used as the memory cap. It limits
-    # virtual address space, which uv/node/Rust/JVM reserve in huge amounts, so
-    # a small --rlimit_as aborts them instantly ("memory allocation failed",
-    # exit 255) and silently broke every uvx stdio MCP server. There is no
-    # RSS-based rlimit on modern Linux, so memory capping requires cgroups;
-    # the fallback runs without a hard memory cap by design.
-    assert "--rlimit_as" not in args
+    # Bug regression: --rlimit_as must be set to "hard" (the current hard
+    # limit), NOT a small value. A small RLIMIT_AS caps *virtual* address space,
+    # which uv/node/Rust/JVM reserve in huge amounts, so it aborts them
+    # instantly ("memory allocation failed" / node WASM "Cannot allocate Wasm
+    # memory") and silently broke every uvx/npx stdio MCP server. "hard" leaves
+    # virtual address space uncapped; resident memory is bounded by cgroups
+    # (cgroup branch) or the container mem_limit (fallback branch).
+    assert "--rlimit_as" in args
+    ras_idx = args.index("--rlimit_as")
+    assert args[ras_idx + 1] == "hard"
 
     nproc_idx = args.index("--rlimit_nproc")
     assert args[nproc_idx + 1] == "128"


### PR DESCRIPTION
## Problem

node/npx-based stdio MCP servers (e.g. `firecrawl-mcp` via `npx -y firecrawl-mcp`) crash on the nsjail Box backend in a restart loop:

```
node:internal/deps/undici/undici:5982
RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
    at lazyllhttp
```

It looked like "npx/node isn't supported", but node and npx run fine — the process dies during boot.

## Root cause

nsjail defaults `--rlimit_as` (**virtual** address space) to **512 MB**. `_build_resource_limits` never set `--rlimit_as` explicitly, on the assumption that omitting it means unlimited. It does not: nsjail's 512 MB default stays in force, in **both** the cgroup-v2 and rlimit-fallback branches.

Node.js/V8 reserves >512 MB of virtual address space at startup, and node's built-in undici instantiates an llhttp **WebAssembly** module during boot. Under the 512 MB `RLIMIT_AS`, that WASM allocation fails → crash loop. Python/uvx servers reserve much less vaddr, so they were unaffected — hence the misleading "only python MCP works" symptom.

## Fix

Always pass `--rlimit_as hard`. RLIMIT_AS caps virtual address space, not resident memory; raising it to the hard limit lets V8/WASM (and Go/JVM/Rust) boot. **Physical** memory is still bounded by `--cgroup_mem_max` (cgroup v2) or the container `mem_limit` (fallback) — the limits that actually cap resident memory.

## Verification

- `pytest tests/box/test_nsjail_backend.py` green (24 passed; updated the regression test that asserted rlimit_as absence).
- Demo box container, end-to-end: `firecrawl-mcp` OOM-crashed at both 512 MB and 1024 MB `cgroup_mem_max` before this change, and **boots + stays alive** at the same limits after it.

Separate from #95 (that was WS-transport resilience); this is the nsjail address-space cap.