### PR TITLE
chore: release v0.4.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.8"
+version = "0.4.9"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Release v0.4.9. Includes #97 (raise nsjail RLIMIT_AS to hard so node/npx MCP servers like firecrawl-mcp no longer OOM on WASM instantiate).