### PR TITLE
fix(box): use per-process memory_mb instead of session-level fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.9"
+version = "0.4.10"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/box/nsjail_backend.py
+++ b/src/langbot_plugin/box/nsjail_backend.py
@@ -282,7 +282,11 @@ class NsjailBackend(BaseSandboxBackend):
             host_path_mode=session.host_path_mode,
             mount_path=session.mount_path,
             cpus=session.cpus,
-            memory_mb=session.memory_mb,
+            # Allow per-process memory override: if the ManagedProcessSpec
+            # sets a memory_mb > 0 it wins; otherwise fall back to the session
+            # default.  This lets node/npx processes request more RAM than the
+            # shared session default without requiring a separate session.
+            memory_mb=spec.memory_mb if spec.memory_mb > 0 else session.memory_mb,
             pids_limit=session.pids_limit,
             read_only_rootfs=session.read_only_rootfs,
         )


### PR DESCRIPTION
BoxManagedProcessSpec.memory_mb was silently ignored — every process got the session default (512 MB). Node/npx MCPs kept getting OOM-killed (137). Fix: prefer spec.memory_mb when >0. Also bumps to 0.4.10.