### PR TITLE
fix(models): add memory_mb field to BoxManagedProcessSpec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.10"
+version = "0.4.12"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/box/models.py
+++ b/src/langbot_plugin/box/models.py
@@ -278,6 +278,8 @@ class BoxManagedProcessSpec(pydantic.BaseModel):
     args: list[str] = pydantic.Field(default_factory=list)
     env: dict[str, str] = pydantic.Field(default_factory=dict)
     cwd: str = DEFAULT_BOX_MOUNT_PATH
+    # Per-process memory override in MB. 0 = inherit from session default.
+    memory_mb: int = 0
 
     @pydantic.field_validator("command")
     @classmethod


### PR DESCRIPTION
BoxManagedProcessSpec was missing memory_mb so the per-process override in nsjail_backend raised AttributeError. Default 0 = inherit session value. Bumps to 0.4.12.