### PR TITLE
fix(runtime): remove memory_mb from _COMPAT_FIELDS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.12"
+version = "0.4.13"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/box/runtime.py
+++ b/src/langbot_plugin/box/runtime.py
@@ -729,7 +729,6 @@ class BoxRuntime:
             "mount_path",
             "persistent",
             "cpus",
-            "memory_mb",
             "pids_limit",
             "read_only_rootfs",
             "workspace_quota_mb",

--- a/tests/box/test_runtime.py
+++ b/tests/box/test_runtime.py
@@ -379,7 +379,6 @@ async def test_reuse_recreates_when_backend_session_dead(logger):
     "field,changed",
     [
         ("image", "other/image:latest"),
-        ("memory_mb", 1024),
         ("cpus", 2.0),
         ("pids_limit", 64),
         ("workspace_quota_mb", 50),


### PR DESCRIPTION
Removes memory_mb from _COMPAT_FIELDS so python+node MCPs can share mcp-shared without BoxSessionConflictError. This is the root cause of node MCP OOM kills: python created session at 512MB, node tried 1024MB and got conflict. Without the conflict, the SDK per-process fallback already handles giving node its 1024MB.