### PR TITLE
chore(release): bump version to 0.4.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.13"
+version = "0.4.14"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- bump the package metadata to `0.4.14` so the existing release workflow builds a publishable artifact

## Context
- the first `0.4.14` release run correctly refused to overwrite the existing `0.4.13` files on PyPI because `pyproject.toml` had not been bumped