### PR TITLE
fix(runtime): harden plugin and box lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.14"
+version = "0.4.15"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/box/client.py
+++ b/src/langbot_plugin/box/client.py
@@ -125,6 +125,7 @@ def _translate_action_error(exc: Exception) -> BoxError:
     """Convert an ActionCallError message back into the appropriate BoxError subclass."""
     from .errors import (
         BoxBackendUnavailableError,
+        BoxCapacityExceededError,
         BoxManagedProcessConflictError,
         BoxManagedProcessNotFoundError,
         BoxSessionConflictError,
@@ -140,6 +141,7 @@ def _translate_action_error(exc: Exception) -> BoxError:
         ("BoxManagedProcessNotFoundError:", BoxManagedProcessNotFoundError),
         ("BoxManagedProcessConflictError:", BoxManagedProcessConflictError),
         ("BoxBackendUnavailableError:", BoxBackendUnavailableError),
+        ("BoxCapacityExceededError:", BoxCapacityExceededError),
     ]
     for prefix, cls in _ERROR_PREFIX_MAP:
         if prefix in msg:
@@ -160,7 +162,7 @@ class ActionRPCBoxClient(BoxRuntimeClient):
             raise BoxRuntimeUnavailableError("box runtime not connected")
         return self._handler
 
-    def set_handler(self, handler: Handler) -> None:
+    def set_handler(self, handler: Handler | None) -> None:
         self._handler = handler
 
     async def _call(

--- a/src/langbot_plugin/box/e2b_backend.py
+++ b/src/langbot_plugin/box/e2b_backend.py
@@ -468,9 +468,7 @@ class E2BSandboxBackend(BaseSandboxBackend):
         if self._api_url:
             kwargs["domain"] = self._api_url
         try:
-            await _AsyncSandbox.connect(
-                sandbox_id=session.backend_session_id, **kwargs
-            )
+            await _AsyncSandbox.connect(sandbox_id=session.backend_session_id, **kwargs)
             return True
         except Exception as exc:
             self.logger.info(

--- a/src/langbot_plugin/box/e2b_backend.py
+++ b/src/langbot_plugin/box/e2b_backend.py
@@ -458,6 +458,28 @@ class E2BSandboxBackend(BaseSandboxBackend):
         except Exception as exc:
             self.logger.warning(f"Failed to kill E2B sandbox: {exc}")
 
+    async def is_session_alive(self, session: BoxSessionInfo) -> bool:
+        """Probe the remote sandbox rather than trusting stale local metadata."""
+        if not _check_e2b_available():
+            return False
+        kwargs = {}
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        if self._api_url:
+            kwargs["domain"] = self._api_url
+        try:
+            await _AsyncSandbox.connect(
+                sandbox_id=session.backend_session_id, **kwargs
+            )
+            return True
+        except Exception as exc:
+            self.logger.info(
+                "E2B sandbox liveness probe failed for %s: %s",
+                session.backend_session_id,
+                exc,
+            )
+            return False
+
     def _truncate_output(self, output: str, limit: int = _MAX_RAW_OUTPUT_BYTES) -> str:
         """Truncate output if exceeds the limit."""
         if len(output.encode("utf-8", errors="replace")) > limit:

--- a/src/langbot_plugin/box/errors.py
+++ b/src/langbot_plugin/box/errors.py
@@ -17,6 +17,10 @@ class BoxRuntimeUnavailableError(BoxError):
     """Raised when the standalone Box Runtime service is unavailable."""
 
 
+class BoxCapacityExceededError(BoxError):
+    """Raised when a configured runtime capacity limit is reached."""
+
+
 class BoxSessionConflictError(BoxError):
     """Raised when an existing session cannot satisfy a new request."""
 

--- a/src/langbot_plugin/box/runtime.py
+++ b/src/langbot_plugin/box/runtime.py
@@ -663,7 +663,9 @@ class BoxRuntime:
 
                 async with self._lock:
                     if (
-                        len(self._sessions) + len(self._creating_session_tasks)
+                        len(self._sessions)
+                        + len(self._creating_session_tasks)
+                        + len(self._closing_session_tasks)
                         >= self.max_sessions
                     ):
                         raise BoxCapacityExceededError(

--- a/src/langbot_plugin/box/runtime.py
+++ b/src/langbot_plugin/box/runtime.py
@@ -444,14 +444,9 @@ class BoxRuntime:
                     for session in self._sessions.values()
                     for managed_id, managed in session.managed_processes.items()
                     if managed.is_running
-                    and not (
-                        session is runtime_session and managed_id == process_id
-                    )
+                    and not (session is runtime_session and managed_id == process_id)
                 )
-                if (
-                    running + self._managed_starting_count
-                    >= self.max_managed_processes
-                ):
+                if running + self._managed_starting_count >= self.max_managed_processes:
                     raise BoxCapacityExceededError(
                         "Box managed process capacity reached "
                         f"({self.max_managed_processes})"
@@ -484,16 +479,20 @@ class BoxRuntime:
             )
             runtime_session.managed_processes[process_id] = managed_process
             runtime_session.info.last_used_at = dt.datetime.now(_UTC)
-            self._track_background_task(asyncio.create_task(
-                self._drain_managed_process_stderr(
-                    runtime_session.info.session_id, process_id, managed_process
+            self._track_background_task(
+                asyncio.create_task(
+                    self._drain_managed_process_stderr(
+                        runtime_session.info.session_id, process_id, managed_process
+                    )
                 )
-            ))
-            self._track_background_task(asyncio.create_task(
-                self._watch_managed_process(
-                    runtime_session.info.session_id, process_id, managed_process
+            )
+            self._track_background_task(
+                asyncio.create_task(
+                    self._watch_managed_process(
+                        runtime_session.info.session_id, process_id, managed_process
+                    )
                 )
-            ))
+            )
             return self._managed_process_to_dict(
                 runtime_session.info.session_id, process_id, managed_process
             )
@@ -593,9 +592,7 @@ class BoxRuntime:
                 existing: _RuntimeSession | None = None
                 async with self._lock:
                     if self._shutdown_in_progress:
-                        raise BoxRuntimeUnavailableError(
-                            "Box runtime is shutting down"
-                        )
+                        raise BoxRuntimeUnavailableError("Box runtime is shutting down")
                     await self._reap_expired_sessions_locked()
                     cleanup_task = self._closing_session_tasks.get(spec.session_id)
                     if cleanup_task is None:
@@ -615,9 +612,7 @@ class BoxRuntime:
                                 self._session_leases[spec.session_id] += 1
 
                 if cleanup_task is not None:
-                    await self._wait_for_session_cleanup(
-                        spec.session_id, cleanup_task
-                    )
+                    await self._wait_for_session_cleanup(spec.session_id, cleanup_task)
                     continue
 
                 backend = await self._get_backend()
@@ -667,7 +662,10 @@ class BoxRuntime:
                     continue
 
                 async with self._lock:
-                    if len(self._sessions) + len(self._creating_session_tasks) >= self.max_sessions:
+                    if (
+                        len(self._sessions) + len(self._creating_session_tasks)
+                        >= self.max_sessions
+                    ):
                         raise BoxCapacityExceededError(
                             f"Box session capacity reached ({self.max_sessions})"
                         )
@@ -692,14 +690,13 @@ class BoxRuntime:
                                 self._active_exec_counts[spec.session_id] += 1
                     if runtime_session.closing:
                         await backend.stop_session(info)
-                        raise BoxRuntimeUnavailableError(
-                            "Box runtime is shutting down"
-                        )
+                        raise BoxRuntimeUnavailableError("Box runtime is shutting down")
                 finally:
                     async with self._lock:
-                        if self._creating_session_tasks.get(
-                            spec.session_id
-                        ) is asyncio.current_task():
+                        if (
+                            self._creating_session_tasks.get(spec.session_id)
+                            is asyncio.current_task()
+                        ):
                             self._creating_session_tasks.pop(spec.session_id, None)
 
                 self.logger.info(
@@ -827,9 +824,7 @@ class BoxRuntime:
         deadline = now - dt.timedelta(seconds=self.completed_process_retention_sec)
         completed: list[tuple[dt.datetime, _RuntimeSession, str, _ManagedProcess]] = []
         for session in self._sessions.values():
-            for process_id, managed_process in list(
-                session.managed_processes.items()
-            ):
+            for process_id, managed_process in list(session.managed_processes.items()):
                 if managed_process.is_running or managed_process.exited_at is None:
                     continue
                 if (

--- a/src/langbot_plugin/box/runtime.py
+++ b/src/langbot_plugin/box/runtime.py
@@ -10,15 +10,18 @@ import logging
 import os
 from pathlib import Path
 import uuid
+import weakref
 from typing import TYPE_CHECKING
 
 from .backend import BaseSandboxBackend, DockerBackend
 from .nsjail_backend import NsjailBackend
 from .errors import (
     BoxBackendUnavailableError,
+    BoxCapacityExceededError,
     BoxManagedProcessNotFoundError,
     BoxSessionConflictError,
     BoxSessionNotFoundError,
+    BoxRuntimeUnavailableError,
     BoxValidationError,
 )
 from .models import (
@@ -73,6 +76,7 @@ class _RuntimeSession:
     # Signature of the extra bind mounts the container was created with. Used
     # to detect when a reused session would be missing newly-requested mounts.
     extra_mounts_key: frozenset[tuple[str, str, str]] = frozenset()
+    closing: bool = False
 
 
 def _compute_extra_mounts_key(spec: BoxSpec) -> frozenset[tuple[str, str, str]]:
@@ -100,6 +104,10 @@ class BoxRuntime:
         logger: logging.Logger,
         backends: list[BaseSandboxBackend] | None = None,
         session_ttl_sec: int = 300,
+        max_sessions: int = 64,
+        max_managed_processes: int = 64,
+        max_completed_processes: int = 256,
+        completed_process_retention_sec: int = 300,
     ):
         self.logger = logger
 
@@ -124,12 +132,34 @@ class BoxRuntime:
 
         self.backends = backends
         self.session_ttl_sec = session_ttl_sec
+        limits = self._box_config.get("limits") or {}
+        self.max_sessions = int(limits.get("max_sessions", max_sessions))
+        self.max_managed_processes = int(
+            limits.get("max_managed_processes", max_managed_processes)
+        )
+        self.max_completed_processes = int(
+            limits.get("max_completed_processes", max_completed_processes)
+        )
+        self.completed_process_retention_sec = int(
+            limits.get(
+                "completed_process_retention_sec", completed_process_retention_sec
+            )
+        )
         self._backend: BaseSandboxBackend | None = None
+        self._backend_lock = asyncio.Lock()
         self._sessions: dict[str, _RuntimeSession] = {}
         self._lock = asyncio.Lock()
+        self._session_operation_locks: weakref.WeakValueDictionary[
+            str, asyncio.Lock
+        ] = weakref.WeakValueDictionary()
+        self._session_leases: collections.Counter[str] = collections.Counter()
+        self._creating_session_tasks: dict[str, asyncio.Task] = {}
+        self._managed_starting_count = 0
+        self._shutdown_in_progress = False
         self._reaper_task: asyncio.Task | None = None
         self._active_exec_counts: collections.Counter[str] = collections.Counter()
         self._closing_session_tasks: dict[str, asyncio.Task[None]] = {}
+        self._background_tasks: set[asyncio.Task] = set()
         self.instance_id = uuid.uuid4().hex[:12]
         self.skill_store = BoxSkillStore(self._box_config)
 
@@ -167,6 +197,20 @@ class BoxRuntime:
         Called via RPC (INIT action) when connecting over WebSocket.
         """
         self._box_config.update(config)
+        limits = self._box_config.get("limits") or {}
+        self.max_sessions = int(limits.get("max_sessions", self.max_sessions))
+        self.max_managed_processes = int(
+            limits.get("max_managed_processes", self.max_managed_processes)
+        )
+        self.max_completed_processes = int(
+            limits.get("max_completed_processes", self.max_completed_processes)
+        )
+        self.completed_process_retention_sec = int(
+            limits.get(
+                "completed_process_retention_sec",
+                self.completed_process_retention_sec,
+            )
+        )
         self._apply_config_to_backends(config)
         self.skill_store.update_config(self._box_config)
         self._ensure_default_workspace()
@@ -205,7 +249,10 @@ class BoxRuntime:
         for root in configured_roots or []:
             root_value = str(root or "").strip()
             if root_value:
-                roots.append(_resolve_local_path(root_value, base=host_root))
+                # Mount allow-list entries are host paths. Relative values in
+                # the shipped config (for example ``./data/box``) are relative
+                # to the runtime working directory, not nested under host_root.
+                roots.append(_resolve_local_path(root_value))
 
         if not roots and host_root is not None:
             roots.append(host_root)
@@ -260,6 +307,10 @@ class BoxRuntime:
         cleanup_task: asyncio.Task[None] | None = None
         try:
             async with session.lock:
+                if session.closing:
+                    raise BoxSessionNotFoundError(
+                        f"session {spec.session_id} is being deleted"
+                    )
                 self.logger.info(
                     "LangBot Box execute: "
                     f"session_id={spec.session_id} "
@@ -319,33 +370,55 @@ class BoxRuntime:
                 )
 
     async def shutdown(self):
-        cleanup_tasks: list[asyncio.Task[None]]
-        async with self._lock:
-            cleanup_tasks = list(self._closing_session_tasks.values())
-            session_ids = list(self._sessions.keys())
-            for session_id in session_ids:
-                session = self._sessions.get(session_id)
-                if session is not None and session.info.persistent:
-                    continue
-                cleanup_task = self._drop_session_locked(session_id)
-                if cleanup_task is not None:
-                    cleanup_tasks.append(cleanup_task)
-        await self._wait_for_session_cleanups(cleanup_tasks)
+        self._shutdown_in_progress = True
+        try:
+            while True:
+                async with self._lock:
+                    creating = [
+                        task
+                        for task in self._creating_session_tasks.values()
+                        if task is not asyncio.current_task()
+                    ]
+                if not creating:
+                    break
+                await asyncio.gather(*creating, return_exceptions=True)
+
+            async with self._lock:
+                cleanup_tasks = list(self._closing_session_tasks.values())
+                for session_id in list(self._sessions):
+                    cleanup_task = self._drop_session_locked(session_id)
+                    if cleanup_task is not None:
+                        cleanup_tasks.append(cleanup_task)
+            await self._wait_for_session_cleanups(cleanup_tasks)
+
+            tasks = list(self._background_tasks)
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            self._background_tasks.clear()
+        finally:
+            self._shutdown_in_progress = False
 
     async def create_session(self, spec: BoxSpec) -> dict:
         session = await self._get_or_create_session(spec)
         return self._session_to_dict(session.info)
 
     async def delete_session(self, session_id: str) -> None:
-        cleanup_task: asyncio.Task[None] | None
-        async with self._lock:
-            cleanup_task = self._closing_session_tasks.get(session_id)
-            if cleanup_task is None and session_id not in self._sessions:
-                raise BoxSessionNotFoundError(f"session {session_id} not found")
-            if cleanup_task is None:
-                cleanup_task = self._drop_session_locked(session_id)
-        if cleanup_task is not None:
-            await self._wait_for_session_cleanup(session_id, cleanup_task)
+        # Serialize against a session that is still being created. Otherwise a
+        # delete can return "not found" while start_session is in flight and
+        # leave the just-created backend resource alive.
+        operation_lock = await self._get_session_operation_lock(session_id)
+        async with operation_lock:
+            cleanup_task: asyncio.Task[None] | None
+            async with self._lock:
+                cleanup_task = self._closing_session_tasks.get(session_id)
+                if cleanup_task is None and session_id not in self._sessions:
+                    raise BoxSessionNotFoundError(f"session {session_id} not found")
+                if cleanup_task is None:
+                    cleanup_task = self._drop_session_locked(session_id)
+            if cleanup_task is not None:
+                await self._wait_for_session_cleanup(session_id, cleanup_task)
 
     async def start_managed_process(
         self, session_id: str, spec: BoxManagedProcessSpec
@@ -357,20 +430,51 @@ class BoxRuntime:
 
         async with runtime_session.lock:
             process_id = spec.process_id
-            existing = runtime_session.managed_processes.get(process_id)
-            if existing is not None and existing.is_running:
-                # Terminate the stale process before starting a new one.
-                # This happens when LangBot restarts while the Box runtime
-                # keeps the persistent session alive.
-                self.logger.info(
-                    f"LangBot Box terminating stale managed process before restart: "
-                    f"session_id={session_id} process_id={process_id}"
+            async with self._lock:
+                self._reap_completed_processes()
+                if (
+                    runtime_session.closing
+                    or self._sessions.get(session_id) is not runtime_session
+                ):
+                    raise BoxSessionNotFoundError(
+                        f"session {session_id} is being deleted"
+                    )
+                running = sum(
+                    1
+                    for session in self._sessions.values()
+                    for managed_id, managed in session.managed_processes.items()
+                    if managed.is_running
+                    and not (
+                        session is runtime_session and managed_id == process_id
+                    )
                 )
-                await self._terminate_managed_process(existing)
-                del runtime_session.managed_processes[process_id]
+                if (
+                    running + self._managed_starting_count
+                    >= self.max_managed_processes
+                ):
+                    raise BoxCapacityExceededError(
+                        "Box managed process capacity reached "
+                        f"({self.max_managed_processes})"
+                    )
+                self._managed_starting_count += 1
+            try:
+                existing = runtime_session.managed_processes.get(process_id)
+                if existing is not None and existing.is_running:
+                    # A reconnect may legitimately replace the old generation.
+                    self.logger.info(
+                        "LangBot Box terminating stale managed process before restart: "
+                        f"session_id={session_id} process_id={process_id}"
+                    )
+                    await self._terminate_managed_process(existing)
+                    del runtime_session.managed_processes[process_id]
 
-            backend = await self._get_backend()
-            process = await backend.start_managed_process(runtime_session.info, spec)
+                backend = await self._get_backend()
+                process = await backend.start_managed_process(
+                    runtime_session.info, spec
+                )
+            finally:
+                async with self._lock:
+                    self._managed_starting_count -= 1
             managed_process = _ManagedProcess(
                 spec=spec,
                 process=process,
@@ -380,16 +484,16 @@ class BoxRuntime:
             )
             runtime_session.managed_processes[process_id] = managed_process
             runtime_session.info.last_used_at = dt.datetime.now(_UTC)
-            asyncio.create_task(
+            self._track_background_task(asyncio.create_task(
                 self._drain_managed_process_stderr(
                     runtime_session.info.session_id, process_id, managed_process
                 )
-            )
-            asyncio.create_task(
+            ))
+            self._track_background_task(asyncio.create_task(
                 self._watch_managed_process(
                     runtime_session.info.session_id, process_id, managed_process
                 )
-            )
+            ))
             return self._managed_process_to_dict(
                 runtime_session.info.session_id, process_id, managed_process
             )
@@ -428,7 +532,9 @@ class BoxRuntime:
 
     async def get_backend_info(self) -> dict:
         if self._backend is None:
-            self._backend = await self._select_backend()
+            async with self._backend_lock:
+                if self._backend is None:
+                    self._backend = await self._select_backend()
         backend = self._backend
         if backend is None:
             return {"name": None, "available": False}
@@ -468,96 +574,159 @@ class BoxRuntime:
                 if mp.is_running
             ),
             "session_ttl_sec": self.session_ttl_sec,
+            "limits": {
+                "max_sessions": self.max_sessions,
+                "max_managed_processes": self.max_managed_processes,
+                "max_completed_processes": self.max_completed_processes,
+            },
         }
 
     async def _get_or_create_session(
         self, spec: BoxSpec, *, track_active_exec: bool = False
     ) -> _RuntimeSession:
         new_extra_mounts_key = _compute_extra_mounts_key(spec)
+        operation_lock = await self._get_session_operation_lock(spec.session_id)
 
-        while True:
-            cleanup_task: asyncio.Task[None] | None = None
-            async with self._lock:
-                await self._reap_expired_sessions_locked()
-                cleanup_task = self._closing_session_tasks.get(spec.session_id)
+        async with operation_lock:
+            while True:
+                cleanup_task: asyncio.Task[None] | None = None
+                existing: _RuntimeSession | None = None
+                async with self._lock:
+                    if self._shutdown_in_progress:
+                        raise BoxRuntimeUnavailableError(
+                            "Box runtime is shutting down"
+                        )
+                    await self._reap_expired_sessions_locked()
+                    cleanup_task = self._closing_session_tasks.get(spec.session_id)
+                    if cleanup_task is None:
+                        existing = self._sessions.get(spec.session_id)
+                        if existing is not None:
+                            self._assert_session_compatible(existing.info, spec)
+                            if existing.extra_mounts_key != new_extra_mounts_key:
+                                self.logger.info(
+                                    "LangBot Box session extra_mounts changed, "
+                                    f"recreating: session_id={spec.session_id}"
+                                )
+                                cleanup_task = self._drop_session_locked(
+                                    spec.session_id
+                                )
+                                existing = None
+                            else:
+                                self._session_leases[spec.session_id] += 1
 
-                existing = None
-                if cleanup_task is None:
-                    existing = self._sessions.get(spec.session_id)
-                    if existing is not None:
-                        self._assert_session_compatible(existing.info, spec)
-                        backend = await self._get_backend()
-                        if existing.extra_mounts_key != new_extra_mounts_key:
-                            # A bind mount cannot be added to an already-running
-                            # container, so a session whose mount set changed (e.g. a
-                            # skill registered and activated after the container was
-                            # first created) must be recreated for the new mounts to
-                            # take effect. Without this the activated skill path
-                            # /workspace/.skills/<name> stays empty in the reused
-                            # container.
-                            self.logger.info(
-                                "LangBot Box session extra_mounts changed, recreating: "
-                                f"session_id={spec.session_id} "
-                                f"backend_session_id={existing.info.backend_session_id} "
-                                f"backend={existing.info.backend_name} "
-                                f"old_mounts={sorted(existing.extra_mounts_key)} "
-                                f"new_mounts={sorted(new_extra_mounts_key)}"
-                            )
-                            cleanup_task = self._drop_session_locked(spec.session_id)
-                            existing = None
-                        elif not await backend.is_session_alive(existing.info):
+                if cleanup_task is not None:
+                    await self._wait_for_session_cleanup(
+                        spec.session_id, cleanup_task
+                    )
+                    continue
+
+                backend = await self._get_backend()
+                if existing is not None:
+                    try:
+                        try:
+                            alive = await backend.is_session_alive(existing.info)
+                        except Exception as exc:
+                            alive = False
                             self.logger.warning(
-                                "LangBot Box session backend disappeared, recreating: "
+                                "LangBot Box session liveness probe failed: "
+                                f"session_id={spec.session_id} error={exc}"
+                            )
+                    finally:
+                        async with self._lock:
+                            self._session_leases[spec.session_id] -= 1
+                            if self._session_leases[spec.session_id] <= 0:
+                                self._session_leases.pop(spec.session_id, None)
+
+                    async with self._lock:
+                        current = self._sessions.get(spec.session_id)
+                        if current is existing and not existing.closing and alive:
+                            existing.info.last_used_at = dt.datetime.now(_UTC)
+                            if track_active_exec:
+                                self._active_exec_counts[spec.session_id] += 1
+                            self.logger.info(
+                                "LangBot Box session reused: "
                                 f"session_id={spec.session_id} "
                                 f"backend_session_id={existing.info.backend_session_id} "
                                 f"backend={existing.info.backend_name}"
                             )
+                            return existing
+                        if current is existing:
+                            self.logger.warning(
+                                "LangBot Box session backend disappeared, "
+                                f"recreating: session_id={spec.session_id}"
+                            )
                             cleanup_task = self._drop_session_locked(spec.session_id)
-                            existing = None
+                        else:
+                            cleanup_task = self._closing_session_tasks.get(
+                                spec.session_id
+                            )
+                    if cleanup_task is not None:
+                        await self._wait_for_session_cleanup(
+                            spec.session_id, cleanup_task
+                        )
+                    continue
 
-                if cleanup_task is None and existing is not None:
-                    existing.info.last_used_at = dt.datetime.now(_UTC)
-                    self.logger.info(
-                        "LangBot Box session reused: "
-                        f"session_id={spec.session_id} "
-                        f"backend_session_id={existing.info.backend_session_id} "
-                        f"backend={existing.info.backend_name}"
-                    )
-                    if track_active_exec:
-                        self._active_exec_counts[spec.session_id] += 1
-                    return existing
+                async with self._lock:
+                    if len(self._sessions) + len(self._creating_session_tasks) >= self.max_sessions:
+                        raise BoxCapacityExceededError(
+                            f"Box session capacity reached ({self.max_sessions})"
+                        )
+                    current_task = asyncio.current_task()
+                    if current_task is not None:
+                        self._creating_session_tasks[spec.session_id] = current_task
 
-                if cleanup_task is None:
-                    backend = await self._get_backend()
+                info: BoxSessionInfo | None = None
+                try:
                     info = await backend.start_session(spec)
                     runtime_session = _RuntimeSession(
                         info=info,
                         lock=asyncio.Lock(),
                         extra_mounts_key=new_extra_mounts_key,
                     )
-                    self._sessions[spec.session_id] = runtime_session
-                    self.logger.info(
-                        "LangBot Box session created: "
-                        f"session_id={spec.session_id} "
-                        f"backend_session_id={info.backend_session_id} "
-                        f"backend={info.backend_name} "
-                        f"image={info.image} "
-                        f"network={info.network.value} "
-                        f"host_path={info.host_path} "
-                        f"host_path_mode={info.host_path_mode.value} "
-                        f"mount_path={info.mount_path} "
-                        f"workspace_quota_mb={info.workspace_quota_mb}"
-                    )
-                    if track_active_exec:
-                        self._active_exec_counts[spec.session_id] += 1
-                    return runtime_session
+                    async with self._lock:
+                        if self._shutdown_in_progress:
+                            runtime_session.closing = True
+                        else:
+                            self._sessions[spec.session_id] = runtime_session
+                            if track_active_exec:
+                                self._active_exec_counts[spec.session_id] += 1
+                    if runtime_session.closing:
+                        await backend.stop_session(info)
+                        raise BoxRuntimeUnavailableError(
+                            "Box runtime is shutting down"
+                        )
+                finally:
+                    async with self._lock:
+                        if self._creating_session_tasks.get(
+                            spec.session_id
+                        ) is asyncio.current_task():
+                            self._creating_session_tasks.pop(spec.session_id, None)
 
-            if cleanup_task is not None:
-                await self._wait_for_session_cleanup(spec.session_id, cleanup_task)
+                self.logger.info(
+                    "LangBot Box session created: "
+                    f"session_id={spec.session_id} "
+                    f"backend_session_id={info.backend_session_id} "
+                    f"backend={info.backend_name} image={info.image} "
+                    f"network={info.network.value} host_path={info.host_path} "
+                    f"host_path_mode={info.host_path_mode.value} "
+                    f"mount_path={info.mount_path} "
+                    f"workspace_quota_mb={info.workspace_quota_mb}"
+                )
+                return runtime_session
+
+    async def _get_session_operation_lock(self, session_id: str) -> asyncio.Lock:
+        async with self._lock:
+            lock = self._session_operation_locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._session_operation_locks[session_id] = lock
+            return lock
 
     async def _get_backend(self) -> BaseSandboxBackend:
         if self._backend is None:
-            self._backend = await self._select_backend()
+            async with self._backend_lock:
+                if self._backend is None:
+                    self._backend = await self._select_backend()
         if self._backend is None:
             raise BoxBackendUnavailableError(
                 "LangBot Box backend unavailable. Install and start Docker or nsjail before using exec."
@@ -630,6 +799,7 @@ class BoxRuntime:
         return None
 
     async def _reap_expired_sessions_locked(self) -> list[asyncio.Task[None]]:
+        self._reap_completed_processes()
         if self.session_ttl_sec <= 0:
             return []
 
@@ -640,6 +810,7 @@ class BoxRuntime:
             if not session.info.persistent
             and session.info.last_used_at < deadline
             and self._active_exec_counts.get(session_id, 0) <= 0
+            and self._session_leases.get(session_id, 0) <= 0
             and not any(mp.is_running for mp in session.managed_processes.values())
         ]
 
@@ -650,12 +821,50 @@ class BoxRuntime:
                 cleanup_tasks.append(cleanup_task)
         return cleanup_tasks
 
+    def _reap_completed_processes(self) -> None:
+        """Bound retained diagnostics without one sleeping task per process."""
+        now = dt.datetime.now(_UTC)
+        deadline = now - dt.timedelta(seconds=self.completed_process_retention_sec)
+        completed: list[tuple[dt.datetime, _RuntimeSession, str, _ManagedProcess]] = []
+        for session in self._sessions.values():
+            for process_id, managed_process in list(
+                session.managed_processes.items()
+            ):
+                if managed_process.is_running or managed_process.exited_at is None:
+                    continue
+                if (
+                    self.completed_process_retention_sec <= 0
+                    or managed_process.exited_at <= deadline
+                ):
+                    if session.managed_processes.get(process_id) is managed_process:
+                        session.managed_processes.pop(process_id, None)
+                    continue
+                completed.append(
+                    (
+                        managed_process.exited_at,
+                        session,
+                        process_id,
+                        managed_process,
+                    )
+                )
+
+        overflow = len(completed) - max(self.max_completed_processes, 0)
+        if overflow <= 0:
+            return
+        for _, session, process_id, managed_process in sorted(
+            completed, key=lambda item: item[0]
+        )[:overflow]:
+            if session.managed_processes.get(process_id) is managed_process:
+                session.managed_processes.pop(process_id, None)
+
     def _drop_session_locked(self, session_id: str) -> asyncio.Task[None] | None:
         closing_task = self._closing_session_tasks.get(session_id)
         if closing_task is not None:
             return closing_task
 
         runtime_session = self._sessions.pop(session_id, None)
+        if runtime_session is not None:
+            runtime_session.closing = True
         self._active_exec_counts.pop(session_id, None)
         backend = self._backend
         if runtime_session is None or backend is None:
@@ -674,21 +883,23 @@ class BoxRuntime:
         backend: BaseSandboxBackend,
     ) -> None:
         try:
-            for mp in runtime_session.managed_processes.values():
-                await self._terminate_managed_process(mp)
+            async with runtime_session.lock:
+                for mp in list(runtime_session.managed_processes.values()):
+                    await self._terminate_managed_process(mp)
+                runtime_session.managed_processes.clear()
 
-            try:
-                self.logger.info(
-                    "LangBot Box session cleanup: "
-                    f"session_id={session_id} "
-                    f"backend_session_id={runtime_session.info.backend_session_id} "
-                    f"backend={runtime_session.info.backend_name}"
-                )
-                await backend.stop_session(runtime_session.info)
-            except Exception as exc:
-                self.logger.warning(
-                    f"Failed to clean up box session {session_id}: {exc}"
-                )
+                try:
+                    self.logger.info(
+                        "LangBot Box session cleanup: "
+                        f"session_id={session_id} "
+                        f"backend_session_id={runtime_session.info.backend_session_id} "
+                        f"backend={runtime_session.info.backend_name}"
+                    )
+                    await backend.stop_session(runtime_session.info)
+                except Exception as exc:
+                    self.logger.warning(
+                        f"Failed to clean up box session {session_id}: {exc}"
+                    )
         except Exception as exc:
             self.logger.warning(
                 f"Failed to finalize box session cleanup {session_id}: {exc}",
@@ -729,6 +940,7 @@ class BoxRuntime:
             "mount_path",
             "persistent",
             "cpus",
+            "memory_mb",
             "pids_limit",
             "read_only_rootfs",
             "workspace_quota_mb",
@@ -790,6 +1002,14 @@ class BoxRuntime:
         self.logger.info(
             f"LangBot Box managed process exited: session_id={session_id} process_id={process_id} return_code={return_code}"
         )
+        # Retention is reaped synchronously from the in-memory registry. This
+        # avoids accumulating one five-minute sleeping task for every short-
+        # lived process while still preserving bounded exit diagnostics.
+        self._reap_completed_processes()
+
+    def _track_background_task(self, task: asyncio.Task) -> None:
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     async def _terminate_managed_process(
         self, managed_process: _ManagedProcess

--- a/src/langbot_plugin/box/server.py
+++ b/src/langbot_plugin/box/server.py
@@ -33,7 +33,7 @@ from aiohttp import web
 from langbot_plugin.entities.io.actions.enums import CommonAction
 from langbot_plugin.entities.io.errors import ConnectionClosedError
 from langbot_plugin.entities.io.resp import ActionResponse
-from langbot_plugin.runtime.io.connection import Connection
+from langbot_plugin.runtime.io.connection import Connection, MAX_MESSAGE_BYTES
 from langbot_plugin.runtime.io.handler import Handler
 from langbot_plugin.utils.log import configure_process_logging
 
@@ -68,6 +68,10 @@ class AiohttpWSConnection(Connection):
         self._send_lock = asyncio.Lock()
 
     async def send(self, message: str) -> None:
+        if len(message.encode("utf-8")) > MAX_MESSAGE_BYTES:
+            raise ValueError(
+                f"Runtime message exceeds {MAX_MESSAGE_BYTES} byte limit"
+            )
         async with self._send_lock:
             try:
                 await self._ws.send_str(message)
@@ -394,6 +398,10 @@ async def handle_managed_process_ws(request: web.Request) -> web.StreamResponse:
             for task in done:
                 task.result()
         finally:
+            for task in (stdout_task, stdin_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(stdout_task, stdin_task, return_exceptions=True)
             await ws.close()
 
     return ws
@@ -406,7 +414,7 @@ async def handle_rpc_ws(request: web.Request) -> web.StreamResponse:
     """Handle action RPC over a single aiohttp WebSocket connection."""
     runtime: BoxRuntime = request.app["runtime"]
 
-    ws = web.WebSocketResponse()
+    ws = web.WebSocketResponse(max_msg_size=MAX_MESSAGE_BYTES)
     await ws.prepare(request)
 
     connection = AiohttpWSConnection(ws)
@@ -416,6 +424,11 @@ async def handle_rpc_ws(request: web.Request) -> web.StreamResponse:
     return ws
 
 
+async def handle_healthz(request: web.Request) -> web.Response:
+    """Return a lightweight liveness response for container orchestrators."""
+    return web.Response(text="ok\n")
+
+
 # ── App factory ──────────────────────────────────────────────────────
 
 
@@ -423,6 +436,7 @@ def create_app(runtime: BoxRuntime) -> web.Application:
     """Create the aiohttp app with all WebSocket routes on a single port."""
     app = web.Application()
     app["runtime"] = runtime
+    app.router.add_get("/healthz", handle_healthz)
     app.router.add_get("/rpc/ws", handle_rpc_ws)
     app.router.add_get(
         "/v1/sessions/{session_id}/managed-process/{process_id}/ws",
@@ -502,4 +516,7 @@ def main(args: argparse.Namespace) -> None:
     control_mode = "stdio" if args.stdio_control else "ws"
 
     configure_process_logging(stream=sys.stderr)
-    asyncio.run(_run_server(args.host, args.ws_control_port, control_mode))
+    try:
+        asyncio.run(_run_server(args.host, args.ws_control_port, control_mode))
+    except KeyboardInterrupt:
+        logger.info("Keyboard interrupt, Box runtime stopped")

--- a/src/langbot_plugin/box/server.py
+++ b/src/langbot_plugin/box/server.py
@@ -69,9 +69,7 @@ class AiohttpWSConnection(Connection):
 
     async def send(self, message: str) -> None:
         if len(message.encode("utf-8")) > MAX_MESSAGE_BYTES:
-            raise ValueError(
-                f"Runtime message exceeds {MAX_MESSAGE_BYTES} byte limit"
-            )
+            raise ValueError(f"Runtime message exceeds {MAX_MESSAGE_BYTES} byte limit")
         async with self._send_lock:
             try:
                 await self._ws.send_str(message)

--- a/src/langbot_plugin/runtime/app.py
+++ b/src/langbot_plugin/runtime/app.py
@@ -44,6 +44,7 @@ class RuntimeApplication:
         self.context = context.RuntimeContext()
         self._server_tasks: set[asyncio.Task] = set()
         self._control_tasks: set[asyncio.Task] = set()
+        self._control_handler_lock = asyncio.Lock()
         self._closing = False
         self._shutdown_complete = False
 
@@ -79,33 +80,39 @@ class RuntimeApplication:
         self, handler: control_handler_cls.ControlConnectionHandler
     ):
         async def run_current_generation() -> None:
-            previous = getattr(self.context, "control_handler", None)
-            if previous is not None and previous is not handler:
-                close = getattr(previous, "close", None)
-                if close is not None:
-                    await close()
+            async with self._control_handler_lock:
+                previous = getattr(self.context, "control_handler", None)
+                if previous is not None and previous is not handler:
+                    close = getattr(previous, "close", None)
+                    if close is not None:
+                        await close()
 
-            if self._closing:
-                close = getattr(handler, "close", None)
-                if close is not None:
-                    await close()
-                return
+                if self._closing:
+                    close = getattr(handler, "close", None)
+                    if close is not None:
+                        await close()
+                    return
 
-            self.context.control_handler = handler
-            logger.info("Got control connection.")
-            mark_ready = getattr(
-                self.context.plugin_mgr, "mark_control_connection_ready", None
-            )
-            if mark_ready is not None:
-                mark_ready()
-            waiter = self.context.plugin_mgr.wait_for_control_connection
-            if waiter is not None:
-                if not waiter.done():
-                    waiter.set_result(None)
-                # Installed plugins are launched only once. Later control
-                # generations reuse the existing supervised plugin processes.
-                self.context.plugin_mgr.wait_for_control_connection = None
-            await handler.run()
+                self.context.control_handler = handler
+                logger.info("Got control connection.")
+                mark_ready = getattr(
+                    self.context.plugin_mgr, "mark_control_connection_ready", None
+                )
+                if mark_ready is not None:
+                    mark_ready()
+                waiter = self.context.plugin_mgr.wait_for_control_connection
+                if waiter is not None:
+                    if not waiter.done():
+                        waiter.set_result(None)
+                    # Installed plugins are launched only once. Later control
+                    # generations reuse the existing supervised plugin processes.
+                    self.context.plugin_mgr.wait_for_control_connection = None
+            try:
+                await handler.run()
+            finally:
+                async with self._control_handler_lock:
+                    if getattr(self.context, "control_handler", None) is handler:
+                        del self.context.control_handler
 
         task = asyncio.create_task(run_current_generation())
         self._control_tasks.add(task)
@@ -162,6 +169,11 @@ class RuntimeApplication:
             task = asyncio.create_task(coroutine)
             self._server_tasks.add(task)
         await asyncio.sleep(0)
+        for task in list(self._server_tasks):
+            if task.done() and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    raise exc
 
         # ==== check and install dependencies for all plugins ====
         if not self.args.skip_deps_check:
@@ -181,12 +193,13 @@ class RuntimeApplication:
             return
         self._closing = True
 
-        control_handler = getattr(self.context, "control_handler", None)
-        if control_handler is not None:
-            close = getattr(control_handler, "close", None)
-            if close is not None:
-                with contextlib.suppress(Exception):
-                    await close()
+        async with self._control_handler_lock:
+            control_handler = getattr(self.context, "control_handler", None)
+            if control_handler is not None:
+                close = getattr(control_handler, "close", None)
+                if close is not None:
+                    with contextlib.suppress(Exception):
+                        await close()
 
         await self.context.plugin_mgr.shutdown_all_plugins()
 

--- a/src/langbot_plugin/runtime/app.py
+++ b/src/langbot_plugin/runtime/app.py
@@ -6,6 +6,7 @@ import logging
 import os
 
 import asyncio
+import contextlib
 
 from langbot_plugin.runtime.io.controllers.stdio import (
     server as stdio_controller_server,
@@ -41,6 +42,10 @@ class RuntimeApplication:
         if getattr(args, "pypi_trusted_host", ""):
             os.environ["LANGBOT_PLUGIN_PYPI_TRUSTED_HOST"] = args.pypi_trusted_host
         self.context = context.RuntimeContext()
+        self._server_tasks: set[asyncio.Task] = set()
+        self._control_tasks: set[asyncio.Task] = set()
+        self._closing = False
+        self._shutdown_complete = False
 
         logger.info(f"settings.cloud_service_url: {settings.cloud_service_url}")
 
@@ -73,18 +78,53 @@ class RuntimeApplication:
     def set_control_handler(
         self, handler: control_handler_cls.ControlConnectionHandler
     ):
-        self.context.control_handler = handler
-        task = asyncio.create_task(handler.run())
-        logger.info("Got control connection.")
-        if self.context.plugin_mgr.wait_for_control_connection is not None:
-            self.context.plugin_mgr.wait_for_control_connection.set_result(None)
-            # mark as done, indicates all installed plugins are already launched
-            # so next time then langbot reconnects, all plugins will not be launched again
-            self.context.plugin_mgr.wait_for_control_connection = None
+        async def run_current_generation() -> None:
+            previous = getattr(self.context, "control_handler", None)
+            if previous is not None and previous is not handler:
+                close = getattr(previous, "close", None)
+                if close is not None:
+                    await close()
+
+            if self._closing:
+                close = getattr(handler, "close", None)
+                if close is not None:
+                    await close()
+                return
+
+            self.context.control_handler = handler
+            logger.info("Got control connection.")
+            mark_ready = getattr(
+                self.context.plugin_mgr, "mark_control_connection_ready", None
+            )
+            if mark_ready is not None:
+                mark_ready()
+            waiter = self.context.plugin_mgr.wait_for_control_connection
+            if waiter is not None:
+                if not waiter.done():
+                    waiter.set_result(None)
+                # Installed plugins are launched only once. Later control
+                # generations reuse the existing supervised plugin processes.
+                self.context.plugin_mgr.wait_for_control_connection = None
+            await handler.run()
+
+        task = asyncio.create_task(run_current_generation())
+        self._control_tasks.add(task)
+        task.add_done_callback(self._control_task_done)
         return task
 
+    def _control_task_done(self, task: asyncio.Task) -> None:
+        self._control_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "Control connection task failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
     async def run(self):
-        tasks = []
+        server_coroutines = []
 
         # ==== control server ====
         async def new_control_connection_callback(connection: Connection):
@@ -94,10 +134,12 @@ class RuntimeApplication:
             await self.set_control_handler(handler)
 
         if self.context.stdio_server:
-            tasks.append(self.context.stdio_server.run(new_control_connection_callback))
+            server_coroutines.append(
+                self.context.stdio_server.run(new_control_connection_callback)
+            )
 
         if self.context.ws_control_server:
-            tasks.append(
+            server_coroutines.append(
                 self.context.ws_control_server.run(new_control_connection_callback)
             )
 
@@ -110,9 +152,16 @@ class RuntimeApplication:
             await self.context.plugin_mgr.add_plugin_handler(plugin_handler)
 
         if self.context.ws_debug_server:
-            tasks.append(
+            server_coroutines.append(
                 self.context.ws_debug_server.run(new_plugin_debug_connection_callback)
             )
+
+        # Schedule listeners before dependency reconciliation. A slow package
+        # index must not make the control ports look dead.
+        for coroutine in server_coroutines:
+            task = asyncio.create_task(coroutine)
+            self._server_tasks.add(task)
+        await asyncio.sleep(0)
 
         # ==== check and install dependencies for all plugins ====
         if not self.args.skip_deps_check:
@@ -121,12 +170,34 @@ class RuntimeApplication:
 
         # ==== launch plugin processes ====
         if not self.args.debug_only:
-            tasks.append(self.context.plugin_mgr.launch_all_plugins())
+            task = asyncio.create_task(self.context.plugin_mgr.launch_all_plugins())
+            self._server_tasks.add(task)
 
-        await asyncio.gather(*tasks)
+        if self._server_tasks:
+            await asyncio.gather(*list(self._server_tasks))
 
     async def shutdown(self):
+        if self._shutdown_complete:
+            return
+        self._closing = True
+
+        control_handler = getattr(self.context, "control_handler", None)
+        if control_handler is not None:
+            close = getattr(control_handler, "close", None)
+            if close is not None:
+                with contextlib.suppress(Exception):
+                    await close()
+
         await self.context.plugin_mgr.shutdown_all_plugins()
+
+        tasks = [*self._control_tasks, *self._server_tasks]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._control_tasks.clear()
+        self._server_tasks.clear()
+        self._shutdown_complete = True
 
 
 def main(args: argparse.Namespace):
@@ -134,8 +205,14 @@ def main(args: argparse.Namespace):
 
     app = RuntimeApplication(args)
 
+    async def run_with_shutdown() -> None:
+        try:
+            await app.run()
+        finally:
+            await app.shutdown()
+
     try:
-        asyncio.run(app.run())
+        asyncio.run(run_with_shutdown())
     except asyncio.CancelledError:
         logger.info("Runtime application cancelled")
         return

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -20,6 +20,24 @@ PLUGIN_VENV_DIR = ".venv"
 DEFAULT_INSTALL_TIMEOUT_SEC = 300.0
 
 
+async def _terminate_subprocess(proc: asyncio.subprocess.Process) -> None:
+    """Terminate and reap a subprocess without leaving cancellation orphans."""
+    if proc.returncode is not None:
+        return
+    try:
+        proc.terminate()
+    except ProcessLookupError:
+        pass
+    try:
+        await asyncio.wait_for(proc.communicate(), timeout=2)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        await proc.communicate()
+
+
 def get_pip_index_args() -> list[str]:
     """Build pip index args from environment. Defaults to official PyPI."""
     index_url = os.getenv(PYPI_INDEX_URL_ENV, DEFAULT_PYPI_INDEX_URL).strip()
@@ -143,6 +161,9 @@ async def install_single_async(
                 + stderr_bytes.decode("utf-8", errors="ignore")
             ),
         )
+    except asyncio.CancelledError:
+        await _terminate_subprocess(proc)
+        raise
     output = (
         stdout_bytes.decode("utf-8", errors="ignore")
         + "\n"
@@ -381,7 +402,9 @@ def get_plugin_python(plugin_path: str) -> str:
     candidate = root / (
         "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
     )
-    return str(candidate) if candidate.is_file() else sys.executable
+    if candidate.is_file():
+        return str(candidate.resolve())
+    return str(pathlib.Path(sys.executable).resolve())
 
 
 async def ensure_plugin_environment(plugin_path: str) -> str:
@@ -432,6 +455,9 @@ async def install_requirements_isolated(
         return 124, (
             stdout + stderr + f"\nTimed out after {timeout_sec:.0f}s".encode()
         ).decode("utf-8", errors="replace")
+    except asyncio.CancelledError:
+        await _terminate_subprocess(proc)
+        raise
     return proc.returncode or 0, (stdout + stderr).decode("utf-8", errors="replace")
 
 
@@ -481,6 +507,9 @@ print(json.dumps([missing, version_mismatch]))
         proc.kill()
         await proc.communicate()
         return list(deps), []
+    except asyncio.CancelledError:
+        await _terminate_subprocess(proc)
+        raise
     if proc.returncode != 0:
         raise RuntimeError(
             "Dependency verification subprocess failed: "

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -1,10 +1,13 @@
 import asyncio
 import importlib.metadata
 import importlib.util
+import json
 import os
 import re
 import subprocess
 import sys
+import pathlib
+import venv
 
 from packaging.requirements import Requirement
 from pip._internal import main as pipmain
@@ -13,6 +16,8 @@ from pip._internal import main as pipmain
 PYPI_INDEX_URL_ENV = "LANGBOT_PLUGIN_PYPI_INDEX_URL"
 PYPI_TRUSTED_HOST_ENV = "LANGBOT_PLUGIN_PYPI_TRUSTED_HOST"
 DEFAULT_PYPI_INDEX_URL = "https://pypi.org/simple"
+PLUGIN_VENV_DIR = ".venv"
+DEFAULT_INSTALL_TIMEOUT_SEC = 300.0
 
 
 def get_pip_index_args() -> list[str]:
@@ -95,14 +100,18 @@ def install_single(
 
 
 async def install_single_async(
-    package: str, extra_params: list | None = None
+    package: str,
+    extra_params: list | None = None,
+    *,
+    python_executable: str | None = None,
+    timeout_sec: float = DEFAULT_INSTALL_TIMEOUT_SEC,
 ) -> tuple[int, int, str]:
     """Install a package via async subprocess without blocking the event loop."""
     if extra_params is None:
         extra_params = []
 
     cmd = [
-        sys.executable,
+        python_executable or sys.executable,
         "-m",
         "pip",
         "install",
@@ -115,7 +124,21 @@ async def install_single_async(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout_bytes, stderr_bytes = await proc.communicate()
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_sec
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stderr_bytes += (
+            f"\nDependency installation timed out after {timeout_sec:.0f}s".encode()
+        )
+        return 124, 0, (
+            stdout_bytes.decode("utf-8", errors="ignore")
+            + "\n"
+            + stderr_bytes.decode("utf-8", errors="ignore")
+        )
     output = (
         stdout_bytes.decode("utf-8", errors="ignore")
         + "\n"
@@ -311,6 +334,8 @@ async def install_with_retry(
     max_retries: int = 3,
     retry_delay: float = 1.0,
     extra_params: list | None = None,
+    python_executable: str | None = None,
+    timeout_sec: float = DEFAULT_INSTALL_TIMEOUT_SEC,
 ) -> tuple[int, int, str]:
     """Install a package with retry on failure.
 
@@ -326,7 +351,10 @@ async def install_with_retry(
     last_error = ""
     for attempt in range(max_retries):
         returncode, downloaded_bytes, output = await install_single_async(
-            package, extra_params
+            package,
+            extra_params,
+            python_executable=python_executable,
+            timeout_sec=timeout_sec,
         )
         if returncode == 0:
             return returncode, downloaded_bytes, ""
@@ -341,6 +369,119 @@ async def install_with_retry(
             await asyncio.sleep(retry_delay)
 
     return returncode, 0, last_error
+
+
+def get_plugin_python(plugin_path: str) -> str:
+    """Return the isolated interpreter for a plugin when it exists."""
+    root = pathlib.Path(plugin_path) / PLUGIN_VENV_DIR
+    candidate = root / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    return str(candidate) if candidate.is_file() else sys.executable
+
+
+async def ensure_plugin_environment(plugin_path: str) -> str:
+    """Create a plugin-local environment that can still import the SDK.
+
+    System site packages expose the runtime's SDK without reinstalling it, while
+    dependencies installed into the venv shadow only this plugin's imports.
+    """
+    root = pathlib.Path(plugin_path) / PLUGIN_VENV_DIR
+    python_path = get_plugin_python(plugin_path)
+    if python_path != sys.executable:
+        return python_path
+
+    await asyncio.to_thread(
+        venv.EnvBuilder(with_pip=True, system_site_packages=True).create,
+        root,
+    )
+    return get_plugin_python(plugin_path)
+
+
+async def install_requirements_isolated(
+    plugin_path: str,
+    *,
+    timeout_sec: float = DEFAULT_INSTALL_TIMEOUT_SEC,
+) -> tuple[int, str]:
+    """Install a plugin's requirements without blocking the runtime loop."""
+    requirements_file = pathlib.Path(plugin_path) / "requirements.txt"
+    if not requirements_file.is_file():
+        return 0, ""
+
+    python_path = await ensure_plugin_environment(plugin_path)
+    proc = await asyncio.create_subprocess_exec(
+        python_path,
+        "-m",
+        "pip",
+        "install",
+        "-r",
+        str(requirements_file),
+        *get_pip_index_args(),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout_sec)
+    except asyncio.TimeoutError:
+        proc.kill()
+        stdout, stderr = await proc.communicate()
+        return 124, (
+            stdout + stderr + f"\nTimed out after {timeout_sec:.0f}s".encode()
+        ).decode("utf-8", errors="replace")
+    return proc.returncode or 0, (stdout + stderr).decode("utf-8", errors="replace")
+
+
+async def classify_requirements_in_environment(
+    python_executable: str,
+    deps: list[str],
+    *,
+    timeout_sec: float = 30.0,
+) -> tuple[list[str], list[str]]:
+    """Verify requirements against the interpreter that will run the plugin."""
+    verifier = r"""
+import importlib.metadata
+import json
+import sys
+from packaging.requirements import Requirement
+
+missing = []
+version_mismatch = []
+for spec in json.loads(sys.argv[1]):
+    try:
+        req = Requirement(spec)
+    except Exception:
+        missing.append(spec)
+        continue
+    if req.marker and not req.marker.evaluate():
+        continue
+    try:
+        version = importlib.metadata.version(req.name)
+    except importlib.metadata.PackageNotFoundError:
+        missing.append(spec)
+        continue
+    if req.specifier and version not in req.specifier:
+        version_mismatch.append(spec)
+print(json.dumps([missing, version_mismatch]))
+"""
+    proc = await asyncio.create_subprocess_exec(
+        python_executable,
+        "-c",
+        verifier,
+        json.dumps(deps),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout_sec)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        return list(deps), []
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Dependency verification subprocess failed: "
+            + stderr.decode("utf-8", errors="replace").strip()
+        )
+    result = json.loads(stdout.decode("utf-8"))
+    return list(result[0]), list(result[1])
 
 
 async def precheck_dependencies(requirements_file: str) -> dict:

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -134,10 +134,14 @@ async def install_single_async(
         stderr_bytes += (
             f"\nDependency installation timed out after {timeout_sec:.0f}s".encode()
         )
-        return 124, 0, (
-            stdout_bytes.decode("utf-8", errors="ignore")
-            + "\n"
-            + stderr_bytes.decode("utf-8", errors="ignore")
+        return (
+            124,
+            0,
+            (
+                stdout_bytes.decode("utf-8", errors="ignore")
+                + "\n"
+                + stderr_bytes.decode("utf-8", errors="ignore")
+            ),
         )
     output = (
         stdout_bytes.decode("utf-8", errors="ignore")
@@ -374,7 +378,9 @@ async def install_with_retry(
 def get_plugin_python(plugin_path: str) -> str:
     """Return the isolated interpreter for a plugin when it exists."""
     root = pathlib.Path(plugin_path) / PLUGIN_VENV_DIR
-    candidate = root / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    candidate = root / (
+        "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
+    )
     return str(candidate) if candidate.is_file() else sys.executable
 
 

--- a/src/langbot_plugin/runtime/io/connection.py
+++ b/src/langbot_plugin/runtime/io/connection.py
@@ -3,6 +3,31 @@ from __future__ import annotations
 import abc
 
 
+MAX_MESSAGE_BYTES = 16 * 1024 * 1024
+
+
+def split_utf8_chunks(message: str, max_bytes: int) -> list[str]:
+    """Split text without breaking UTF-8 code points."""
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    chunks: list[str] = []
+    current: list[str] = []
+    current_size = 0
+    for char in message:
+        char_size = len(char.encode("utf-8"))
+        if char_size > max_bytes:
+            raise ValueError("max_bytes is smaller than one UTF-8 code point")
+        if current and current_size + char_size > max_bytes:
+            chunks.append("".join(current))
+            current = []
+            current_size = 0
+        current.append(char)
+        current_size += char_size
+    if current:
+        chunks.append("".join(current))
+    return chunks
+
+
 class Connection(abc.ABC):
     """The abstract base class for all connections."""
 

--- a/src/langbot_plugin/runtime/io/connections/stdio.py
+++ b/src/langbot_plugin/runtime/io/connections/stdio.py
@@ -161,7 +161,10 @@ class StdioConnection(connection.Connection):
                                         chunk_data = json.loads(chunk_line)
                                         if chunk_data.get("type") == "chunk_data":
                                             chunk_text = chunk_data.get("data", "")
-                                            if chunk_data.get("offset") != received_size:
+                                            if (
+                                                chunk_data.get("offset")
+                                                != received_size
+                                            ):
                                                 raise ConnectionClosedError(
                                                     "Invalid runtime chunk offset"
                                                 )

--- a/src/langbot_plugin/runtime/io/connections/stdio.py
+++ b/src/langbot_plugin/runtime/io/connections/stdio.py
@@ -5,6 +5,7 @@ import json
 import logging
 
 from langbot_plugin.runtime.io import connection
+from langbot_plugin.runtime.io.connection import MAX_MESSAGE_BYTES, split_utf8_chunks
 from langbot_plugin.entities.io.errors import ConnectionClosedError
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,10 @@ class StdioConnection(connection.Connection):
         async with self._send_lock:  # 确保同一时间只有一个send操作
             message_bytes = message.encode("utf-8")
             message_size = len(message_bytes)
+            if message_size > MAX_MESSAGE_BYTES:
+                raise ValueError(
+                    f"Runtime message exceeds {MAX_MESSAGE_BYTES} byte limit"
+                )
 
             # For small messages, send directly
             if message_size <= self.chunk_size:
@@ -55,17 +60,19 @@ class StdioConnection(connection.Connection):
                 await self.stdin.drain()
 
                 # Send message in chunks
-                for i in range(0, message_size, self.chunk_size):
-                    chunk_data = message_bytes[i : i + self.chunk_size]
+                offset = 0
+                for chunk_text in split_utf8_chunks(message, self.chunk_size):
+                    chunk_size = len(chunk_text.encode("utf-8"))
                     chunk_msg = json.dumps(
                         {
                             "type": "chunk_data",
-                            "data": chunk_data.decode("utf-8", errors="replace"),
-                            "offset": i,
+                            "data": chunk_text,
+                            "offset": offset,
                         }
                     )
                     self.stdin.write(chunk_msg.encode("utf-8") + b"\n")
                     await self.stdin.drain()
+                    offset += chunk_size
                     # Small delay to prevent overwhelming the connection
                     await asyncio.sleep(0.001)
 
@@ -137,7 +144,12 @@ class StdioConnection(connection.Connection):
                                 if msg_data["type"] == "chunk_start":
                                     # Start receiving chunked message
                                     chunks = []
-                                    # total_size = msg_data.get("total_size", 0)  # Reserved for future use
+                                    total_size = int(msg_data.get("total_size", -1))
+                                    if not 0 <= total_size <= MAX_MESSAGE_BYTES:
+                                        raise ConnectionClosedError(
+                                            "Invalid runtime chunked message size"
+                                        )
+                                    received_size = 0
 
                                     while True:
                                         chunk_line = await self._read_single_line()
@@ -148,8 +160,24 @@ class StdioConnection(connection.Connection):
 
                                         chunk_data = json.loads(chunk_line)
                                         if chunk_data.get("type") == "chunk_data":
-                                            chunks.append(chunk_data.get("data", ""))
+                                            chunk_text = chunk_data.get("data", "")
+                                            if chunk_data.get("offset") != received_size:
+                                                raise ConnectionClosedError(
+                                                    "Invalid runtime chunk offset"
+                                                )
+                                            received_size += len(
+                                                chunk_text.encode("utf-8")
+                                            )
+                                            if received_size > total_size:
+                                                raise ConnectionClosedError(
+                                                    "Runtime chunked message exceeds declared size"
+                                                )
+                                            chunks.append(chunk_text)
                                         elif chunk_data.get("type") == "chunk_end":
+                                            if received_size != total_size:
+                                                raise ConnectionClosedError(
+                                                    "Incomplete runtime chunked message"
+                                                )
                                             # Reconstruct original message
                                             return "".join(chunks)
 

--- a/src/langbot_plugin/runtime/io/connections/ws.py
+++ b/src/langbot_plugin/runtime/io/connections/ws.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import websockets
 import asyncio
-import json
 
 from langbot_plugin.runtime.io import connection as io_connection
+from langbot_plugin.runtime.io.connection import MAX_MESSAGE_BYTES, split_utf8_chunks
 from langbot_plugin.entities.io.errors import ConnectionClosedError
 
 
@@ -25,6 +25,10 @@ class WebSocketConnection(io_connection.Connection):
         async with self._send_lock:  # 确保同一时间只有一个send操作
             message_bytes = message.encode("utf-8")
             message_size = len(message_bytes)
+            if message_size > MAX_MESSAGE_BYTES:
+                raise ValueError(
+                    f"Runtime message exceeds {MAX_MESSAGE_BYTES} byte limit"
+                )
 
             # For small messages, send directly
             if message_size <= self.chunk_size:
@@ -36,43 +40,35 @@ class WebSocketConnection(io_connection.Connection):
 
             # For large messages, use chunking with streaming
             try:
-                # Send message in chunks to avoid timeout
-                for i in range(0, message_size, self.chunk_size):
-                    chunk = message_bytes[i : i + self.chunk_size].decode("utf-8")
-                    await self.websocket.send(chunk, text=True)
-                    # Small delay to prevent overwhelming the connection
-                    await asyncio.sleep(0.001)
+                # Send one fragmented WebSocket message. Sending each chunk as
+                # an independent message forces the receiver to guess message
+                # boundaries and permits unbounded cross-message accumulation.
+                chunks = split_utf8_chunks(message, self.chunk_size)
+                await self.websocket.send(chunks)
             except websockets.exceptions.ConnectionClosed:
                 raise ConnectionClosedError("Connection closed during send")
-
-    def _is_valid_json(self, message: str) -> bool:
-        try:
-            json.loads(message)
-            return True
-        except json.JSONDecodeError:
-            return False
 
     async def receive(self) -> str:
         """Receive message with streaming support and timeout protection."""
         try:
-            # Use recv_streaming for better handling of large messages
-            whole_message = ""
             message_chunks = []
+            received_bytes = 0
 
-            while True:
-                async for data in self.websocket.recv_streaming(decode=True):
-                    message_chunks.append(data)
-                    # Yield control periodically to prevent blocking
-                    if len(message_chunks) % 100 == 0:
-                        await asyncio.sleep(0)
+            async for data in self.websocket.recv_streaming(decode=True):
+                message_chunks.append(data)
+                received_bytes += len(data.encode("utf-8"))
+                if received_bytes > MAX_MESSAGE_BYTES:
+                    await self.close()
+                    raise ConnectionClosedError(
+                        f"Runtime message exceeds {MAX_MESSAGE_BYTES} byte limit"
+                    )
+                if len(message_chunks) % 100 == 0:
+                    await asyncio.sleep(0)
 
-                # Join all chunks efficiently
-                whole_message = "".join(message_chunks)
-
-                if self._is_valid_json(whole_message):
-                    return whole_message
-                else:
-                    await asyncio.sleep(0.001)
+            # recv_streaming yields exactly one WebSocket message. JSON
+            # validation belongs to Handler; never concatenate separate peer
+            # messages while waiting for one that happens to parse.
+            return "".join(message_chunks)
 
         except websockets.exceptions.ConnectionClosed:
             raise ConnectionClosedError("Connection closed")

--- a/src/langbot_plugin/runtime/io/controllers/stdio/client.py
+++ b/src/langbot_plugin/runtime/io/controllers/stdio/client.py
@@ -21,11 +21,14 @@ class StdioClientController(Controller):
         args: list[str],
         env: dict[str, str],
         working_dir: str = ".",
+        *,
+        capture_stderr: bool = False,
     ):
         self.command = command
         self.args = args
         self.env = env
         self.working_dir = working_dir
+        self.capture_stderr = capture_stderr
 
     async def run(
         self,
@@ -36,9 +39,7 @@ class StdioClientController(Controller):
             *self.args,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            # Capture stderr (where the plugin's Python `logging` output goes)
-            # so the runtime can buffer per-plugin logs for the detail page.
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE if self.capture_stderr else None,
             env=self.env,
             cwd=self.working_dir,
         )
@@ -62,7 +63,10 @@ class StdioClientController(Controller):
             self.connection = None
 
         process = self.process
-        if process is None or process.returncode is not None:
+        if process is None:
+            return
+        self.process = None
+        if process.returncode is not None:
             return
 
         with contextlib.suppress(ProcessLookupError):

--- a/src/langbot_plugin/runtime/io/controllers/stdio/client.py
+++ b/src/langbot_plugin/runtime/io/controllers/stdio/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Coroutine, Any
 import asyncio
+import contextlib
 
 from langbot_plugin.runtime.io.connections import stdio as stdio_connection
 from langbot_plugin.runtime.io.connection import Connection
@@ -12,6 +13,7 @@ class StdioClientController(Controller):
     """The controller for stdio client."""
 
     process: asyncio.subprocess.Process | None = None
+    connection: stdio_connection.StdioConnection | None = None
 
     def __init__(
         self,
@@ -44,7 +46,30 @@ class StdioClientController(Controller):
         if self.process.stdout is None or self.process.stdin is None:
             raise RuntimeError("Failed to create subprocess pipes")
 
-        connection = stdio_connection.StdioConnection(
+        self.connection = stdio_connection.StdioConnection(
             self.process.stdout, self.process.stdin, process=self.process
         )
-        await new_connection_callback(connection)
+        try:
+            await new_connection_callback(self.connection)
+        finally:
+            await self.close()
+
+    async def close(self) -> None:
+        """Close pipes and reap the owned subprocess."""
+        if self.connection is not None:
+            with contextlib.suppress(Exception):
+                await self.connection.close()
+            self.connection = None
+
+        process = self.process
+        if process is None or process.returncode is not None:
+            return
+
+        with contextlib.suppress(ProcessLookupError):
+            process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2)
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()

--- a/src/langbot_plugin/runtime/io/controllers/ws/client.py
+++ b/src/langbot_plugin/runtime/io/controllers/ws/client.py
@@ -7,6 +7,7 @@ import websockets
 from langbot_plugin.runtime.io.connection import Connection
 from langbot_plugin.runtime.io.connections import ws as ws_connection
 from langbot_plugin.runtime.io.controller import Controller
+from langbot_plugin.runtime.io.connection import MAX_MESSAGE_BYTES
 
 
 class WebSocketClientController(Controller):
@@ -37,7 +38,10 @@ class WebSocketClientController(Controller):
             # Docker deployments on hosts that inject a proxy into containers
             # (e.g. Docker Desktop with a configured proxy).
             async with websockets.connect(
-                self.ws_url, open_timeout=10, proxy=None
+                self.ws_url,
+                open_timeout=10,
+                proxy=None,
+                max_size=MAX_MESSAGE_BYTES,
             ) as websocket:
                 connection = ws_connection.WebSocketConnection(websocket)
                 await new_connection_callback(connection)

--- a/src/langbot_plugin/runtime/io/controllers/ws/server.py
+++ b/src/langbot_plugin/runtime/io/controllers/ws/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from http import HTTPStatus
 import websockets
 from typing import Callable, Coroutine, Any
 import logging
@@ -7,8 +8,18 @@ import logging
 from langbot_plugin.runtime.io.connections import ws as ws_connection
 from langbot_plugin.runtime.io.connection import Connection
 from langbot_plugin.runtime.io.controller import Controller
+from langbot_plugin.runtime.io.connection import MAX_MESSAGE_BYTES
 
 logger = logging.getLogger(__name__)
+protocol_logger = logging.getLogger(f"{__name__}.protocol")
+protocol_logger.setLevel(logging.WARNING)
+
+
+def process_http_request(connection, request):
+    """Serve a quiet HTTP health endpoint alongside the WebSocket endpoint."""
+    if request.path == "/healthz":
+        return connection.respond(HTTPStatus.OK, "ok\n")
+    return None
 
 
 class WebSocketServerController(Controller):
@@ -25,9 +36,20 @@ class WebSocketServerController(Controller):
     ):
         self._new_connection_callback = new_connection_callback
 
-        server = await websockets.serve(self.handle_connection, "0.0.0.0", self.port)
+        server = await websockets.serve(
+            self.handle_connection,
+            "0.0.0.0",
+            self.port,
+            max_size=MAX_MESSAGE_BYTES,
+            process_request=process_http_request,
+            logger=protocol_logger,
+        )
         logger.info(f"WebSocket server started on port {self.port}")
-        await server.wait_closed()
+        try:
+            await server.wait_closed()
+        finally:
+            server.close()
+            await server.wait_closed()
 
     async def handle_connection(self, websocket: websockets.ServerConnection):
         logger.info(f"New connection from {websocket.remote_address}")

--- a/src/langbot_plugin/runtime/io/handler.py
+++ b/src/langbot_plugin/runtime/io/handler.py
@@ -17,6 +17,7 @@ import os
 import hashlib
 import base64
 import uuid
+import contextlib
 import aiofiles
 import aiofiles.os
 import logging
@@ -34,6 +35,8 @@ logger = logging.getLogger(__name__)
 
 FILE_STORAGE_DIR = "data/temp/lbp"
 FILE_CHUNK_LENGTH = 1024 * 16  # 16KB
+MAX_INFLIGHT_ACTIONS = 128
+MAX_STREAM_QUEUE_SIZE = 128
 
 
 class Handler(abc.ABC):
@@ -46,7 +49,9 @@ class Handler(abc.ABC):
     actions: dict[str, Callable[[dict[str, Any]], Coroutine[Any, Any, ActionResponse]]]
 
     resp_waiters: dict[int, asyncio.Future[ActionResponse]] = {}
-    resp_queues: dict[int, asyncio.Queue[ActionResponse]] = {}
+    resp_queues: dict[
+        int, asyncio.Queue[ActionResponse | BaseException]
+    ] = {}
 
     seq_id_index: int = 0
 
@@ -63,6 +68,9 @@ class Handler(abc.ABC):
         self.seq_id_index = random.randint(0, 100000)
         self.resp_waiters = {}
         self.resp_queues = {}
+        self._action_tasks: set[asyncio.Task[None]] = set()
+        self._closed = False
+        self._close_error: ConnectionClosedError | None = None
 
         self._disconnect_callback = disconnect_callback
 
@@ -92,74 +100,174 @@ class Handler(abc.ABC):
         self._disconnect_callback = disconnect_callback
 
     async def run(self) -> None:
-        while True:
-            message = None
+        disconnect_error = ConnectionClosedError("Connection closed")
+        try:
+            while True:
+                try:
+                    message = await self.conn.receive()
+                except ConnectionClosedError as exc:
+                    disconnect_error = exc
+                    # Requests sent on the old transport cannot be completed by
+                    # a replacement connection, even when the handler itself is
+                    # reused by a reconnect callback.
+                    self._fail_pending(exc)
+                    if self._disconnect_callback is not None:
+                        reconnected = await self._disconnect_callback(self)
+                        if reconnected:
+                            continue
+                    break
+                if message is None:
+                    continue
+
+                try:
+                    req_data = json.loads(message)
+                except (json.JSONDecodeError, TypeError) as exc:
+                    logger.warning("Ignored malformed runtime message: %s", exc)
+                    continue
+                if not isinstance(req_data, dict):
+                    logger.warning("Ignored non-object runtime message")
+                    continue
+
+                seq_id = req_data.get("seq_id", -1)
+                if "code" in req_data:
+                    await self._route_response(seq_id, req_data)
+                    continue
+
+                if "action" not in req_data:
+                    logger.warning("Ignored runtime message without action or code")
+                    continue
+
+                if len(self._action_tasks) >= MAX_INFLIGHT_ACTIONS:
+                    await self._send_overloaded_response(seq_id)
+                    continue
+
+                task = asyncio.create_task(self._handle_action(req_data))
+                self._action_tasks.add(task)
+                task.add_done_callback(self._action_task_done)
+        finally:
+            self._closed = True
+            self._close_error = disconnect_error
+            self._fail_pending(disconnect_error)
+            await self._cancel_action_tasks()
+
+    async def close(self) -> None:
+        """Close the transport and deterministically release connection-owned work."""
+        if self._closed:
+            return
+        self._closed = True
+        error = ConnectionClosedError("Connection closed by local runtime")
+        self._close_error = error
+        self._fail_pending(error)
+        try:
+            await self.conn.close()
+        finally:
+            await self._cancel_action_tasks()
+
+    async def _route_response(self, seq_id: int, req_data: dict[str, Any]) -> None:
+        try:
+            response = ActionResponse.model_validate(req_data)
+        except Exception as exc:
+            logger.warning("Ignored malformed runtime response: %s", exc)
+            return
+        waiter = self.resp_waiters.get(seq_id)
+        if waiter is not None and not waiter.done():
+            waiter.set_result(response)
+
+        queue = self.resp_queues.get(seq_id)
+        if queue is not None:
             try:
-                message = await self.conn.receive()
-            except ConnectionClosedError:
-                if self._disconnect_callback is not None:
-                    reconnected = await self._disconnect_callback(self)
-                    if reconnected:
-                        continue
-                break
-            if message is None:
-                continue
+                queue.put_nowait(response)
+            except asyncio.QueueFull:
+                # A stalled stream consumer must not block response routing for
+                # every other action sharing this connection.
+                self.resp_queues.pop(seq_id, None)
+                while not queue.empty():
+                    with contextlib.suppress(asyncio.QueueEmpty):
+                        queue.get_nowait()
+                queue.put_nowait(
+                    ActionCallError(
+                        "Streaming action consumer is too slow; response buffer full"
+                    )
+                )
 
-            async def handle_message(message: str):
-                # sh*t, i dont really know how to use generic type here
-                # so just use dict[str, Any] for now
-                # 2025/07/02: i know now, learned from dify-plugin-sdk, but maybe i will implement it later
-                req_data = json.loads(message)
-                seq_id = req_data["seq_id"] if "seq_id" in req_data else -1
+    async def _handle_action(self, req_data: dict[str, Any]) -> None:
+        seq_id = req_data.get("seq_id", -1)
+        action_name = str(req_data["action"])
+        try:
+            if action_name not in self.actions:
+                raise ValueError(f"Action {action_name} not found")
 
-                if "action" in req_data:  # action request from peer
-                    try:
-                        if req_data["action"] not in self.actions:
-                            raise ValueError(f"Action {req_data['action']} not found")
+            response = self.actions[action_name](req_data["data"])
+            if not isinstance(response, AsyncGenerator):
+                if isinstance(response, Coroutine):
+                    response = await response
+                response.seq_id = seq_id
+                await self.conn.send(json.dumps(response.model_dump()))
+            else:
+                async for chunk in response:
+                    assert isinstance(chunk, ActionResponse)
+                    chunk.seq_id = seq_id
+                    chunk.chunk_status = ChunkStatus.CONTINUE
+                    await self.conn.send(json.dumps(chunk.model_dump()))
 
-                        response = self.actions[req_data["action"]](req_data["data"])
+                end_response = ActionResponse.success({})
+                end_response.seq_id = seq_id
+                end_response.chunk_status = ChunkStatus.END
+                await self.conn.send(json.dumps(end_response.model_dump()))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            traceback.print_exc()
+            error_response = ActionResponse.error(
+                f"{exc.__class__.__name__}: {str(exc)}"
+            )
+            error_response.seq_id = seq_id
+            with contextlib.suppress(ConnectionClosedError):
+                await self.conn.send(json.dumps(error_response.model_dump()))
+        finally:
+            if not action_name.startswith("__"):
+                logger.info("[Action] %s", action_name)
 
-                        if not isinstance(response, AsyncGenerator):
-                            if isinstance(response, Coroutine):
-                                response = await response
+    async def _send_overloaded_response(self, seq_id: int) -> None:
+        response = ActionResponse.error(
+            f"Runtime connection is busy (max {MAX_INFLIGHT_ACTIONS} concurrent actions)"
+        )
+        response.seq_id = seq_id
+        # The receive loop will observe a closed connection and run the normal
+        # disconnect/reconnect path; don't bypass it if this best-effort reply
+        # races with transport loss.
+        with contextlib.suppress(ConnectionClosedError):
+            await self.conn.send(json.dumps(response.model_dump()))
 
-                            response.seq_id = seq_id
-                            await self.conn.send(json.dumps(response.model_dump()))
-                        elif isinstance(response, AsyncGenerator):
-                            response_generator = response
-                            async for chunk in response_generator:
-                                assert isinstance(chunk, ActionResponse)
-                                chunk.seq_id = seq_id
-                                chunk.chunk_status = ChunkStatus.CONTINUE
-                                await self.conn.send(json.dumps(chunk.model_dump()))
+    def _action_task_done(self, task: asyncio.Task[None]) -> None:
+        self._action_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "Runtime action task failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
-                            end_response = ActionResponse.success({})
-                            end_response.seq_id = seq_id
-                            end_response.chunk_status = ChunkStatus.END
-                            await self.conn.send(json.dumps(end_response.model_dump()))
-                    except Exception as e:
-                        traceback.print_exc()
-                        error_response = ActionResponse.error(
-                            f"{e.__class__.__name__}: {str(e)}"
-                        )
-                        error_response.seq_id = seq_id
-                        await self.conn.send(json.dumps(error_response.model_dump()))
-                    finally:
-                        if not req_data["action"].startswith("__"):
-                            logger.info(f"[Action] {req_data['action']}")
+    def _fail_pending(self, error: ConnectionClosedError) -> None:
+        for waiter in list(self.resp_waiters.values()):
+            if not waiter.done():
+                waiter.set_exception(error)
 
-                elif "code" in req_data:  # action response from peer
-                    response = ActionResponse.model_validate(req_data)
+        for queue in list(self.resp_queues.values()):
+            while queue.full():
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+            queue.put_nowait(error)
 
-                    # Handle single response (for call_action)
-                    if seq_id in self.resp_waiters:
-                        self.resp_waiters[seq_id].set_result(response)
-
-                    # Handle streaming response (for call_action_generator)
-                    if seq_id in self.resp_queues:
-                        await self.resp_queues[seq_id].put(response)
-
-            asyncio.create_task(handle_message(message))
+    async def _cancel_action_tasks(self) -> None:
+        tasks = list(self._action_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._action_tasks.clear()
 
     async def call_action(
         self, action: ActionType, data: dict[str, Any], timeout: float = 15.0
@@ -169,10 +277,12 @@ class Handler(abc.ABC):
         this_seq_id = self.seq_id_index
         request = ActionRequest.make_request(this_seq_id, action.value, data)
         # wait for response
-        future = asyncio.Future[ActionResponse]()
+        if self._closed:
+            raise self._close_error or ConnectionClosedError("Connection closed")
+        future = asyncio.get_running_loop().create_future()
         self.resp_waiters[this_seq_id] = future
-        await self.conn.send(json.dumps(request.model_dump()))
         try:
+            await self.conn.send(json.dumps(request.model_dump()))
             response = await asyncio.wait_for(future, timeout)
             if response.code != 0:
                 raise ActionCallError(f"{response.message}")
@@ -180,6 +290,8 @@ class Handler(abc.ABC):
         except asyncio.TimeoutError:
             raise ActionCallTimeoutError(f"Action {action.value} call timed out")
         except ActionCallError:
+            raise
+        except ConnectionClosedError:
             raise
         except Exception as e:
             raise ActionCallError(f"{e.__class__.__name__}: {str(e)}")
@@ -197,15 +309,20 @@ class Handler(abc.ABC):
         request = ActionRequest.make_request(this_seq_id, action.value, data)
 
         # Create a queue for streaming responses
-        queue = asyncio.Queue[ActionResponse]()
+        if self._closed:
+            raise self._close_error or ConnectionClosedError("Connection closed")
+        queue = asyncio.Queue[ActionResponse | BaseException](
+            maxsize=MAX_STREAM_QUEUE_SIZE
+        )
         self.resp_queues[this_seq_id] = queue
 
-        await self.conn.send(json.dumps(request.model_dump()))
-
         try:
+            await self.conn.send(json.dumps(request.model_dump()))
             while True:
                 try:
                     response = await asyncio.wait_for(queue.get(), timeout)
+                    if isinstance(response, BaseException):
+                        raise response
                     if response.code != 0:
                         raise ActionCallError(f"{response.message}")
 
@@ -214,12 +331,14 @@ class Handler(abc.ABC):
                     elif response.chunk_status == ChunkStatus.END:
                         break
                 except asyncio.CancelledError:
-                    break
+                    raise
                 except asyncio.TimeoutError:
                     raise ActionCallTimeoutError(
                         f"Action {action.value} call timed out"
                     )
                 except ActionCallError:
+                    raise
+                except ConnectionClosedError:
                     raise
                 except Exception as e:
                     raise ActionCallError(f"{e.__class__.__name__}: {str(e)}")

--- a/src/langbot_plugin/runtime/io/handler.py
+++ b/src/langbot_plugin/runtime/io/handler.py
@@ -49,9 +49,7 @@ class Handler(abc.ABC):
     actions: dict[str, Callable[[dict[str, Any]], Coroutine[Any, Any, ActionResponse]]]
 
     resp_waiters: dict[int, asyncio.Future[ActionResponse]] = {}
-    resp_queues: dict[
-        int, asyncio.Queue[ActionResponse | BaseException]
-    ] = {}
+    resp_queues: dict[int, asyncio.Queue[ActionResponse | BaseException]] = {}
 
     seq_id_index: int = 0
 

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -86,6 +86,7 @@ class PluginManager:
         self._desired_plugin_paths: set[str] = set()
         self._shutting_down = False
         self._dependency_errors: dict[str, str] = {}
+        self._plugin_operation_locks: dict[str, asyncio.Lock] = {}
 
     def get_plugin_path(self, plugin_author: str, plugin_name: str) -> str:
         return f"data/plugins/{plugin_author}__{plugin_name}"
@@ -172,9 +173,16 @@ class PluginManager:
 
         async def reconcile(plugin_path: str) -> None:
             async with semaphore:
-                returncode, output = await pkgmgr_helper.install_requirements_isolated(
-                    plugin_path
-                )
+                try:
+                    (
+                        returncode,
+                        output,
+                    ) = await pkgmgr_helper.install_requirements_isolated(plugin_path)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    output = f"{type(exc).__name__}: {exc}"
+                    returncode = 1
                 if returncode == 0:
                     self._dependency_errors.pop(plugin_path, None)
                     logger.info(
@@ -338,6 +346,7 @@ class PluginManager:
                 args=args,
                 env={},
                 working_dir=plugin_path,
+                capture_stderr=True,
             )
 
             async def new_plugin_connection_callback(connection: Connection):
@@ -380,19 +389,7 @@ class PluginManager:
         plugin_author = manifest["metadata"]["author"]
         plugin_version = manifest["metadata"]["version"]
 
-        for plugin in self.plugins:
-            if (
-                plugin.manifest.metadata.author == plugin_author
-                and plugin.manifest.metadata.name == plugin_name
-            ):
-                if plugin.manifest.metadata.version == plugin_version:
-                    raise ValueError(
-                        f"Plugin {plugin_author}/{plugin_name}:{plugin_version} already exists"
-                    )
-                elif plugin.debug:
-                    raise ValueError(
-                        f"Plugin {plugin_author}/{plugin_name}:{plugin_version} already exists, and it is a debugging plugin"
-                    )
+        self._validate_install_target(plugin_author, plugin_name, plugin_version)
 
         staging_path = os.path.join(
             "data",
@@ -412,6 +409,34 @@ class PluginManager:
         await asyncio.to_thread(extract)
         return staging_path, plugin_author, plugin_name, plugin_version
 
+    def _validate_install_target(
+        self, plugin_author: str, plugin_name: str, plugin_version: str
+    ) -> None:
+        """Reject a conflicting installed generation for the same plugin."""
+        for plugin in self.plugins:
+            if (
+                plugin.manifest.metadata.author == plugin_author
+                and plugin.manifest.metadata.name == plugin_name
+            ):
+                if plugin.manifest.metadata.version == plugin_version:
+                    raise ValueError(
+                        f"Plugin {plugin_author}/{plugin_name}:{plugin_version} already exists"
+                    )
+                elif plugin.debug:
+                    raise ValueError(
+                        f"Plugin {plugin_author}/{plugin_name}:{plugin_version} already exists, and it is a debugging plugin"
+                    )
+
+    def _get_plugin_operation_lock(
+        self, plugin_author: str, plugin_name: str
+    ) -> asyncio.Lock:
+        key = f"{plugin_author}/{plugin_name}"
+        lock = self._plugin_operation_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._plugin_operation_locks[key] = lock
+        return lock
+
     async def install_plugin_from_marketplace(
         self, plugin_author: str, plugin_name: str, plugin_version: str
     ) -> tuple[str, str, str, str]:
@@ -426,28 +451,29 @@ class PluginManager:
     ) -> str | None:
         """Atomically replace plugin files after stopping the old generation."""
         target_path = self.get_plugin_path(plugin_author, plugin_name)
+        self._desired_plugin_paths.discard(target_path)
+        await self.stop_plugin_supervisor(target_path)
         old_plugin = self.find_plugin(plugin_author, plugin_name)
         if old_plugin is not None:
-            self._desired_plugin_paths.discard(target_path)
             await self.shutdown_plugin(old_plugin)
-            await self.stop_plugin_supervisor(target_path)
 
         backup_path: str | None = None
-        if os.path.isdir(target_path):
-            backup_path = os.path.join(
-                "data",
-                ".plugin-backups",
-                f"{plugin_author}__{plugin_name}-{uuid.uuid4().hex}",
-            )
-            os.makedirs(os.path.dirname(backup_path), exist_ok=True)
-            os.replace(target_path, backup_path)
-
         try:
+            if os.path.isdir(target_path):
+                backup_path = os.path.join(
+                    "data",
+                    ".plugin-backups",
+                    f"{plugin_author}__{plugin_name}-{uuid.uuid4().hex}",
+                )
+                os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+                os.replace(target_path, backup_path)
             os.makedirs(os.path.dirname(target_path), exist_ok=True)
             os.replace(staging_path, target_path)
         except Exception:
             if backup_path is not None and os.path.isdir(backup_path):
                 os.replace(backup_path, target_path)
+            if os.path.isdir(target_path) and not self._shutting_down:
+                self.start_plugin_supervisor(target_path)
             raise
         return backup_path
 
@@ -538,9 +564,14 @@ class PluginManager:
         else:
             raise ValueError(f"Invalid source: {source}")
 
+        operation_lock = self._get_plugin_operation_lock(plugin_author, plugin_name)
+        lock_acquired = False
         backup_path: str | None = None
         activated = False
         try:
+            await operation_lock.acquire()
+            lock_acquired = True
+            self._validate_install_target(plugin_author, plugin_name, plugin_version)
             logger.info("installing isolated plugin dependencies")
             yield {"current_action": "installing dependencies"}
             requirements_file = os.path.join(plugin_path, "requirements.txt")
@@ -639,7 +670,7 @@ class PluginManager:
             )
             if backup_path is not None:
                 shutil.rmtree(backup_path, ignore_errors=True)
-        except Exception:
+        except BaseException:
             if activated:
                 await self._rollback_plugin_activation(
                     plugin_author, plugin_name, backup_path
@@ -647,6 +678,9 @@ class PluginManager:
             else:
                 shutil.rmtree(plugin_path, ignore_errors=True)
             raise
+        finally:
+            if lock_acquired:
+                operation_lock.release()
 
     async def register_plugin(
         self,
@@ -726,6 +760,18 @@ class PluginManager:
         plugin_author: str,
         plugin_name: str,
     ):
+        operation_lock = self._get_plugin_operation_lock(plugin_author, plugin_name)
+        async with operation_lock:
+            async for progress in self._restart_plugin_unlocked(
+                plugin_author, plugin_name
+            ):
+                yield progress
+
+    async def _restart_plugin_unlocked(
+        self,
+        plugin_author: str,
+        plugin_name: str,
+    ):
         for plugin in self.plugins:
             if (
                 plugin.manifest.metadata.author == plugin_author
@@ -764,6 +810,18 @@ class PluginManager:
             raise ValueError(f"Plugin {plugin_author}/{plugin_name} not found")
 
     async def delete_plugin(
+        self,
+        plugin_author: str,
+        plugin_name: str,
+    ):
+        operation_lock = self._get_plugin_operation_lock(plugin_author, plugin_name)
+        async with operation_lock:
+            async for progress in self._delete_plugin_unlocked(
+                plugin_author, plugin_name
+            ):
+                yield progress
+
+    async def _delete_plugin_unlocked(
         self,
         plugin_author: str,
         plugin_name: str,

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -8,11 +8,12 @@ from typing import AsyncGenerator
 import asyncio
 import io
 import enum
-import sys
 import time
 import zipfile
 import yaml
 import logging
+import contextlib
+import uuid
 from langbot_plugin.utils.platform import get_platform
 from langbot_plugin.runtime.io.connection import Connection
 from langbot_plugin.runtime.io.controllers.stdio import (
@@ -45,6 +46,11 @@ from langbot_plugin.entities.io.errors import (
 
 logger = logging.getLogger(__name__)
 
+_PLUGIN_RESTART_INITIAL_DELAY_SEC = 1.0
+_PLUGIN_RESTART_MAX_DELAY_SEC = 60.0
+_PLUGIN_STABLE_WINDOW_SEC = 60.0
+_PLUGIN_READY_TIMEOUT_SEC = 30.0
+
 
 class PluginInstallSource(enum.Enum):
     """The source of plugin installation."""
@@ -75,6 +81,11 @@ class PluginManager:
         self.plugins = []
         self.plugin_run_tasks = []
         self.wait_for_control_connection = None
+        self._control_connection_ready = asyncio.Event()
+        self._plugin_supervisors: dict[str, asyncio.Task[None]] = {}
+        self._desired_plugin_paths: set[str] = set()
+        self._shutting_down = False
+        self._dependency_errors: dict[str, str] = {}
 
     def get_plugin_path(self, plugin_author: str, plugin_name: str) -> str:
         return f"data/plugins/{plugin_author}__{plugin_name}"
@@ -157,29 +168,119 @@ class PluginManager:
             logger.warning(f"Failed to notify plugin diagnostic for {plugin_id}: {e}")
 
     async def ensure_all_plugins_dependencies_installed(self):
-        for plugin_path in glob.glob("data/plugins/*"):
-            if not os.path.isdir(plugin_path):
-                continue
+        semaphore = asyncio.Semaphore(2)
 
-            # install dependencies
-            requirements_file = os.path.join(plugin_path, "requirements.txt")
-            if os.path.exists(requirements_file):
-                pkgmgr_helper.install_requirements(requirements_file)
-                logger.info(f"Installed dependencies for plugin at {plugin_path}")
+        async def reconcile(plugin_path: str) -> None:
+            async with semaphore:
+                returncode, output = await pkgmgr_helper.install_requirements_isolated(
+                    plugin_path
+                )
+                if returncode == 0:
+                    self._dependency_errors.pop(plugin_path, None)
+                    logger.info(
+                        "Installed isolated dependencies for plugin at %s",
+                        plugin_path,
+                    )
+                    return
+                tail = output.strip()[-2000:]
+                self._dependency_errors[plugin_path] = tail
+                logger.error(
+                    "Failed to install dependencies for plugin at %s: %s",
+                    plugin_path,
+                    tail,
+                )
+
+        plugin_paths = [
+            path for path in glob.glob("data/plugins/*") if os.path.isdir(path)
+        ]
+        await asyncio.gather(*(reconcile(path) for path in plugin_paths))
 
     async def launch_all_plugins(self):
-        self.wait_for_control_connection = asyncio.Future()
-        await self.wait_for_control_connection
+        await self._control_connection_ready.wait()
         for plugin_path in glob.glob("data/plugins/*"):
             if not os.path.isdir(plugin_path):
                 continue
 
-            # launch plugin process
-            task = self.launch_plugin(plugin_path)
-            self.plugin_run_tasks.append(task)
+            self.start_plugin_supervisor(plugin_path)
 
         logger.info(f"launch all plugins: {len(self.plugin_run_tasks)}")
-        await asyncio.gather(*self.plugin_run_tasks)
+        if self.plugin_run_tasks:
+            await asyncio.gather(*list(self.plugin_run_tasks))
+
+    def start_plugin_supervisor(self, plugin_path: str) -> asyncio.Task[None]:
+        """Ensure one crash-restarting supervisor owns a production plugin."""
+        existing = self._plugin_supervisors.get(plugin_path)
+        if existing is not None and not existing.done():
+            return existing
+
+        self._desired_plugin_paths.add(plugin_path)
+        task = asyncio.create_task(self._supervise_plugin(plugin_path))
+        self._plugin_supervisors[plugin_path] = task
+        self.plugin_run_tasks.append(task)
+        task.add_done_callback(
+            lambda completed, path=plugin_path: self._supervisor_done(path, completed)
+        )
+        return task
+
+    def _supervisor_done(self, plugin_path: str, task: asyncio.Task[None]) -> None:
+        if self._plugin_supervisors.get(plugin_path) is task:
+            self._plugin_supervisors.pop(plugin_path, None)
+        with contextlib.suppress(ValueError):
+            self.plugin_run_tasks.remove(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "Plugin supervisor failed for %s",
+                plugin_path,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+    async def _supervise_plugin(self, plugin_path: str) -> None:
+        delay = _PLUGIN_RESTART_INITIAL_DELAY_SEC
+        while (
+            not self._shutting_down
+            and plugin_path in self._desired_plugin_paths
+            and os.path.isdir(plugin_path)
+        ):
+            started_at = asyncio.get_running_loop().time()
+            try:
+                await self.launch_plugin(plugin_path)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Plugin process failed: %s", plugin_path)
+
+            if (
+                self._shutting_down
+                or plugin_path not in self._desired_plugin_paths
+                or not os.path.isdir(plugin_path)
+            ):
+                return
+
+            uptime = asyncio.get_running_loop().time() - started_at
+            if uptime >= _PLUGIN_STABLE_WINDOW_SEC:
+                delay = _PLUGIN_RESTART_INITIAL_DELAY_SEC
+            logger.warning(
+                "Plugin process exited unexpectedly; restarting %s in %.1fs",
+                plugin_path,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, _PLUGIN_RESTART_MAX_DELAY_SEC)
+
+    async def stop_plugin_supervisor(self, plugin_path: str) -> None:
+        self._desired_plugin_paths.discard(plugin_path)
+        task = self._plugin_supervisors.get(plugin_path)
+        if task is None or task is asyncio.current_task():
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    def mark_control_connection_ready(self) -> None:
+        self._control_connection_ready.set()
 
     async def launch_plugin(self, plugin_path: str):
         from langbot_plugin.runtime.settings import settings as runtime_settings
@@ -188,7 +289,7 @@ class PluginManager:
             # Due to Windows's lack of supports for both stdio and subprocess:
             # See also: https://docs.python.org/zh-cn/3.13/library/asyncio-platforms.html
             # We have to launch plugin via cmd but communicate via ws.
-            python_path = sys.executable
+            python_path = pkgmgr_helper.get_plugin_python(plugin_path)
 
             # Build command with debug key if set
             cmd_args = [
@@ -212,14 +313,20 @@ class PluginManager:
                 cwd=plugin_path,
             )
 
-            # hold the process
-            task = asyncio.create_task(process.wait())
-
-            # the plugin will connect to the runtime via ws automatically
-
-            await task
+            try:
+                # The plugin connects to the runtime via websocket automatically.
+                await process.wait()
+            except asyncio.CancelledError:
+                if process.returncode is None:
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=2)
+                    except asyncio.TimeoutError:
+                        process.kill()
+                        await process.wait()
+                raise
         else:
-            python_path = sys.executable
+            python_path = pkgmgr_helper.get_plugin_python(plugin_path)
 
             # Build args with debug key if set
             args = ["-m", "langbot_plugin.cli.__init__", "run", "-s", "--prod"]
@@ -243,7 +350,7 @@ class PluginManager:
                 await ctrl.run(new_plugin_connection_callback)
             except asyncio.CancelledError:
                 logger.info(f"plugin process cancelled: {plugin_path}")
-                return
+                raise
 
     async def add_plugin_handler(
         self,
@@ -265,21 +372,14 @@ class PluginManager:
     async def install_plugin_from_file(
         self, plugin_file: bytes
     ) -> tuple[str, str, str, str]:
-        # read manifest.yaml file
-        file_reader = io.BytesIO(plugin_file)
-        manifest_file = zipfile.ZipFile(file_reader, "r")
-        manifest_file_content = manifest_file.read("manifest.yaml")
-        manifest = yaml.safe_load(manifest_file_content)
+        """Validate and extract a package into an isolated staging directory."""
+        with zipfile.ZipFile(io.BytesIO(plugin_file), "r") as manifest_file:
+            manifest = yaml.safe_load(manifest_file.read("manifest.yaml"))
 
-        # extract plugin name and author from manifest
         plugin_name = manifest["metadata"]["name"]
         plugin_author = manifest["metadata"]["author"]
         plugin_version = manifest["metadata"]["version"]
 
-        # unzip to data/plugins/{plugin_author}__{plugin_name}
-        plugin_path = self.get_plugin_path(plugin_author, plugin_name)
-
-        # check if plugin already exists
         for plugin in self.plugins:
             if (
                 plugin.manifest.metadata.author == plugin_author
@@ -293,27 +393,97 @@ class PluginManager:
                     raise ValueError(
                         f"Plugin {plugin_author}/{plugin_name}:{plugin_version} already exists, and it is a debugging plugin"
                     )
-                else:
-                    # shutdown old version
-                    await self.shutdown_plugin(plugin)
-                    # await self.remove_plugin_container(plugin)
-                    # delete old version
-                    shutil.rmtree(plugin_path)
-                    break
 
-        os.makedirs(plugin_path, exist_ok=True)
-        manifest_file.extractall(plugin_path)
+        staging_path = os.path.join(
+            "data",
+            ".plugin-staging",
+            f"{plugin_author}__{plugin_name}-{uuid.uuid4().hex}",
+        )
 
-        return plugin_path, plugin_author, plugin_name, plugin_version
+        def extract() -> None:
+            os.makedirs(staging_path, exist_ok=False)
+            try:
+                with zipfile.ZipFile(io.BytesIO(plugin_file), "r") as archive:
+                    archive.extractall(staging_path)
+            except Exception:
+                shutil.rmtree(staging_path, ignore_errors=True)
+                raise
+
+        await asyncio.to_thread(extract)
+        return staging_path, plugin_author, plugin_name, plugin_version
 
     async def install_plugin_from_marketplace(
         self, plugin_author: str, plugin_name: str, plugin_version: str
-    ) -> tuple[str, str, str]:
+    ) -> tuple[str, str, str, str]:
         # download plugin zip file from marketplace
         plugin_zip_file = await marketplace_helper.download_plugin(
             plugin_author, plugin_name, plugin_version
         )
         return await self.install_plugin_from_file(plugin_zip_file)
+
+    async def _activate_staged_plugin(
+        self, staging_path: str, plugin_author: str, plugin_name: str
+    ) -> str | None:
+        """Atomically replace plugin files after stopping the old generation."""
+        target_path = self.get_plugin_path(plugin_author, plugin_name)
+        old_plugin = self.find_plugin(plugin_author, plugin_name)
+        if old_plugin is not None:
+            self._desired_plugin_paths.discard(target_path)
+            await self.shutdown_plugin(old_plugin)
+            await self.stop_plugin_supervisor(target_path)
+
+        backup_path: str | None = None
+        if os.path.isdir(target_path):
+            backup_path = os.path.join(
+                "data",
+                ".plugin-backups",
+                f"{plugin_author}__{plugin_name}-{uuid.uuid4().hex}",
+            )
+            os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+            os.replace(target_path, backup_path)
+
+        try:
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+            os.replace(staging_path, target_path)
+        except Exception:
+            if backup_path is not None and os.path.isdir(backup_path):
+                os.replace(backup_path, target_path)
+            raise
+        return backup_path
+
+    async def _wait_for_plugin_ready(
+        self, plugin_author: str, plugin_name: str, timeout: float
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            plugin = self.find_plugin(plugin_author, plugin_name)
+            if (
+                plugin is not None
+                and plugin.status
+                == runtime_plugin_container.RuntimeContainerStatus.INITIALIZED
+            ):
+                return
+            await asyncio.sleep(0.1)
+        raise RuntimeError(
+            f"Plugin {plugin_author}/{plugin_name} did not become ready within {timeout:.0f}s"
+        )
+
+    async def _rollback_plugin_activation(
+        self,
+        plugin_author: str,
+        plugin_name: str,
+        backup_path: str | None,
+    ) -> None:
+        target_path = self.get_plugin_path(plugin_author, plugin_name)
+        self._desired_plugin_paths.discard(target_path)
+        current = self.find_plugin(plugin_author, plugin_name)
+        if current is not None:
+            await self.shutdown_plugin(current)
+        await self.stop_plugin_supervisor(target_path)
+        shutil.rmtree(target_path, ignore_errors=True)
+        if backup_path is not None and os.path.isdir(backup_path):
+            os.replace(backup_path, target_path)
+            self.start_plugin_supervisor(target_path)
 
     async def install_plugin(
         self, source: PluginInstallSource, install_info: dict[str, typing.Any]
@@ -368,139 +538,116 @@ class PluginManager:
         else:
             raise ValueError(f"Invalid source: {source}")
 
-        # install deps
-        logger.info("installing dependencies")
-        yield {"current_action": "installing dependencies"}
-        requirements_file = os.path.join(plugin_path, "requirements.txt")
-        if os.path.exists(requirements_file):
-            precheck_result = await pkgmgr_helper.precheck_dependencies(
-                requirements_file
-            )
-            deps = precheck_result["deps"]
-            to_install = precheck_result["to_install"]
-            already_installed = precheck_result["already_installed"]
+        backup_path: str | None = None
+        activated = False
+        try:
+            logger.info("installing isolated plugin dependencies")
+            yield {"current_action": "installing dependencies"}
+            requirements_file = os.path.join(plugin_path, "requirements.txt")
+            if os.path.exists(requirements_file):
+                deps = pkgmgr_helper.parse_requirements(requirements_file)
+                python_path = await pkgmgr_helper.ensure_plugin_environment(
+                    plugin_path
+                )
+                total_downloaded = 0
+                started_at = time.time()
+                failures: dict[str, str] = {}
+                for index, dep in enumerate(deps):
+                    elapsed = time.time() - started_at
+                    yield {
+                        "current_action": "installing dependencies",
+                        "metadata": {
+                            "deps_total": len(deps),
+                            "deps_installed": index,
+                            "deps_remaining": len(deps) - index,
+                            "current_dep": dep,
+                            "deps_downloaded_size": total_downloaded,
+                            "deps_speed": total_downloaded / elapsed
+                            if elapsed > 0
+                            else 0,
+                            "already_installed": 0,
+                            "to_install": len(deps),
+                        },
+                    }
+                    returncode, downloaded, error = (
+                        await pkgmgr_helper.install_with_retry(
+                            dep,
+                            max_retries=3,
+                            python_executable=python_path,
+                        )
+                    )
+                    total_downloaded += downloaded
+                    if returncode != 0:
+                        failures[dep] = error
 
-            logger.info(
-                f"Dependency precheck: {len(already_installed)} already installed, "
-                f"{len(to_install)} to install"
-            )
-
-            total_deps = len(deps)
-            total_downloaded = 0
-            start_time = time.time()
-            # Requirement specs pip could not install even after retries,
-            # mapped to the tail of pip's stderr for diagnostics.
-            install_failures: dict[str, str] = {}
-            already_installed_count = len(already_installed)
-            to_install_count = len(to_install)
-
-            for i, dep in enumerate(to_install):
-                elapsed = time.time() - start_time
+                elapsed = time.time() - started_at
                 yield {
                     "current_action": "installing dependencies",
                     "metadata": {
-                        "deps_total": total_deps,
-                        "deps_installed": already_installed_count + i,
-                        "deps_remaining": to_install_count - i,
-                        "current_dep": dep,
+                        "deps_total": len(deps),
+                        "deps_installed": len(deps) - len(failures),
+                        "deps_remaining": 0,
+                        "deps_failed": len(failures),
+                        "failed_deps": list(failures),
+                        "current_dep": "",
                         "deps_downloaded_size": total_downloaded,
-                        "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
-                        "already_installed": already_installed_count,
-                        "to_install": to_install_count,
+                        "deps_speed": total_downloaded / elapsed
+                        if elapsed > 0
+                        else 0,
                     },
                 }
-
-                (
-                    returncode,
-                    downloaded_bytes,
-                    error_msg,
-                ) = await pkgmgr_helper.install_with_retry(dep, max_retries=3)
-                total_downloaded += downloaded_bytes
-
-                if returncode != 0:
-                    logger.error(
-                        f"Failed to install dependency after retries: {dep}, "
-                        f"error: {error_msg}"
+                if failures:
+                    raise DependencyInstallError(
+                        failed=list(failures),
+                        plugin=f"{plugin_author}/{plugin_name}",
+                        details=failures,
                     )
-                    install_failures[dep] = error_msg
 
-            # Verification: pip may report success while the distribution is
-            # still unimportable or the installed version violates the
-            # specifier. Only verify deps that pip did not already flag as a
-            # hard install failure, so the two error classes stay distinct.
-            verified_targets = [d for d in deps if d not in install_failures]
-            missing_deps, version_mismatch = (
-                pkgmgr_helper.classify_unsatisfied_dependencies(verified_targets)
-            )
+                missing, version_mismatch = (
+                    await pkgmgr_helper.classify_requirements_in_environment(
+                        python_path, deps
+                    )
+                )
+                if missing or version_mismatch:
+                    raise DependencyVerificationError(
+                        missing=missing,
+                        version_mismatch=version_mismatch,
+                        plugin=f"{plugin_author}/{plugin_name}",
+                    )
 
-            failed_deps = (
-                list(install_failures.keys()) + missing_deps + version_mismatch
-            )
-
-            elapsed = time.time() - start_time
-            yield {
-                "current_action": "installing dependencies",
-                "metadata": {
-                    "deps_total": total_deps,
-                    "deps_installed": total_deps - len(failed_deps),
-                    "deps_remaining": 0,
-                    "deps_failed": len(failed_deps),
-                    "failed_deps": failed_deps,
-                    "current_dep": "",
-                    "deps_downloaded_size": total_downloaded,
-                    "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
+            yield {"current_action": "initializing plugin settings"}
+            await self.context.control_handler.call_action(
+                RuntimeToLangBotAction.INITIALIZE_PLUGIN_SETTINGS,
+                {
+                    "plugin_author": plugin_author,
+                    "plugin_name": plugin_name,
+                    "install_source": source.value,
+                    "install_info": install_info
+                    if source != PluginInstallSource.LOCAL
+                    else {},
                 },
-            }
+            )
 
-            plugin_ref = f"{plugin_author}/{plugin_name}"
-
-            # pip-level install failures take priority — they are the root
-            # cause and carry the actual pip stderr for debugging.
-            if install_failures:
-                logger.error(
-                    f"Plugin {plugin_ref} failed to install "
-                    f"{len(install_failures)} dependencies: "
-                    f"{list(install_failures.keys())}"
+            yield {"current_action": "launching plugin"}
+            backup_path = await self._activate_staged_plugin(
+                plugin_path, plugin_author, plugin_name
+            )
+            activated = True
+            target_path = self.get_plugin_path(plugin_author, plugin_name)
+            self.start_plugin_supervisor(target_path)
+            await self._wait_for_plugin_ready(
+                plugin_author, plugin_name, _PLUGIN_READY_TIMEOUT_SEC
+            )
+            if backup_path is not None:
+                shutil.rmtree(backup_path, ignore_errors=True)
+        except Exception:
+            if activated:
+                await self._rollback_plugin_activation(
+                    plugin_author, plugin_name, backup_path
                 )
-                raise DependencyInstallError(
-                    failed=list(install_failures.keys()),
-                    plugin=plugin_ref,
-                    details=install_failures,
-                )
-
-            # pip succeeded but the result cannot be verified — surface which
-            # deps are missing vs. version-mismatched so callers can react.
-            if missing_deps or version_mismatch:
-                logger.error(
-                    f"Plugin {plugin_ref} dependency verification failed — "
-                    f"missing: {missing_deps}, version mismatch: {version_mismatch}"
-                )
-                raise DependencyVerificationError(
-                    missing=missing_deps,
-                    version_mismatch=version_mismatch,
-                    plugin=plugin_ref,
-                )
-
-        # initialize plugin settings
-        yield {"current_action": "initializing plugin settings"}
-        await self.context.control_handler.call_action(
-            RuntimeToLangBotAction.INITIALIZE_PLUGIN_SETTINGS,
-            {
-                "plugin_author": plugin_author,
-                "plugin_name": plugin_name,
-                "install_source": source.value,
-                "install_info": install_info
-                if source != PluginInstallSource.LOCAL
-                else {},
-            },
-        )
-
-        # launch plugin
-        yield {"current_action": "launching plugin"}
-        task = self.launch_plugin(plugin_path)
-
-        asyncio_task = asyncio.create_task(task)
-        self.plugin_run_tasks.append(asyncio_task)
+            else:
+                shutil.rmtree(plugin_path, ignore_errors=True)
+            raise
 
     async def register_plugin(
         self,
@@ -549,17 +696,21 @@ class PluginManager:
         plugin_container.install_info = plugin_settings["install_info"]
         self.plugins.append(plugin_container)
 
-        # initialize plugin
-        await handler.initialize_plugin(plugin_settings)
+        try:
+            # initialize plugin
+            await handler.initialize_plugin(plugin_settings)
 
-        # refresh plugin container from plugin (components may have changed)
-        plugin_container_data = await handler.get_plugin_container()
-        refreshed = runtime_plugin_container.PluginContainer.from_dict(
-            plugin_container_data
-        )
-        plugin_container.components = refreshed.components
-        plugin_container.manifest = refreshed.manifest
-        plugin_container.status = refreshed.status
+            # refresh plugin container from plugin (components may have changed)
+            plugin_container_data = await handler.get_plugin_container()
+            refreshed = runtime_plugin_container.PluginContainer.from_dict(
+                plugin_container_data
+            )
+            plugin_container.components = refreshed.components
+            plugin_container.manifest = refreshed.manifest
+            plugin_container.status = refreshed.status
+        except Exception:
+            await self.remove_plugin_container(plugin_container)
+            raise
 
     async def remove_plugin_container(
         self,
@@ -582,18 +733,19 @@ class PluginManager:
                 and plugin.manifest.metadata.name == plugin_name
             ):
                 is_debugging = plugin.debug
+                plugin_path = self.get_plugin_path(plugin_author, plugin_name)
 
                 yield {"current_action": "shutting down plugin"}
+                if not is_debugging:
+                    self._desired_plugin_paths.discard(plugin_path)
                 await self.shutdown_plugin(plugin)
+                if not is_debugging:
+                    await self.stop_plugin_supervisor(plugin_path)
                 yield {"current_action": "removing plugin container"}
                 await self.remove_plugin_container(plugin)
                 if not is_debugging:
                     yield {"current_action": "launching plugin"}
-                    task = self.launch_plugin(
-                        self.get_plugin_path(plugin_author, plugin_name)
-                    )
-                    asyncio_task = asyncio.create_task(task)
-                    self.plugin_run_tasks.append(asyncio_task)
+                    self.start_plugin_supervisor(plugin_path)
 
                     # Poll until the plugin appears in self.plugins (with timeout)
                     plugin_key = f"{plugin_author}/{plugin_name}"
@@ -603,7 +755,7 @@ class PluginManager:
                             break
                         await asyncio.sleep(1)
                     else:
-                        logger.warning(
+                        raise RuntimeError(
                             f"Plugin {plugin_key} restart timed out waiting for registration"
                         )
 
@@ -627,8 +779,11 @@ class PluginManager:
                         f"Plugin {plugin_author}/{plugin_name} is a debugging plugin"
                     )
                 else:
+                    plugin_path = self.get_plugin_path(plugin_author, plugin_name)
+                    self._desired_plugin_paths.discard(plugin_path)
                     yield {"current_action": "shutting down plugin"}
                     await self.shutdown_plugin(plugin)
+                    await self.stop_plugin_supervisor(plugin_path)
                     yield {"current_action": "removing plugin container"}
                     await self.remove_plugin_container(plugin)
                     yield {"current_action": "deleting plugin files"}
@@ -682,8 +837,20 @@ class PluginManager:
             raise ValueError(f"Plugin {plugin_author}/{plugin_name} not found")
 
     async def shutdown_all_plugins(self):
-        for plugin in self.plugins:
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        self._desired_plugin_paths.clear()
+        for plugin in list(self.plugins):
             await self.shutdown_plugin(plugin)
+
+        tasks = list(self._plugin_supervisors.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._plugin_supervisors.clear()
+        self.plugin_run_tasks.clear()
 
     async def shutdown_plugin(
         self,
@@ -691,24 +858,35 @@ class PluginManager:
     ):
         # Send shutdown notification to plugin before closing connection
         # For debug plugins, this will trigger reconnection; for production plugins, it's just a notification
+        handler = plugin_container._runtime_plugin_handler
+        if handler is None:
+            await self.remove_plugin_container(plugin_container)
+            return
         try:
-            await plugin_container._runtime_plugin_handler.shutdown_plugin()
+            await handler.shutdown_plugin()
         except Exception as e:
             logger.warning(f"Failed to send shutdown notification: {e}")
 
-        await plugin_container._runtime_plugin_handler.conn.close()
+        close = getattr(handler, "close", None)
+        if close is not None:
+            await close()
+        else:
+            await handler.conn.close()
         await self.remove_plugin_container(plugin_container)
-        if plugin_container._runtime_plugin_handler.stdio_process is not None:
-            plugin_container._runtime_plugin_handler.stdio_process.kill()
-
-            if (
-                plugin_container._runtime_plugin_handler.stdio_process.returncode
-                is None
-            ):
-                await asyncio.wait_for(
-                    plugin_container._runtime_plugin_handler.stdio_process.wait(),
-                    timeout=2,
-                )
+        if handler.stdio_process is not None:
+            process = handler.stdio_process
+            if process.returncode is None:
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    with contextlib.suppress(ProcessLookupError):
+                        process.terminate()
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=2)
+                    except asyncio.TimeoutError:
+                        with contextlib.suppress(ProcessLookupError):
+                            process.kill()
+                        await process.wait()
             logger.info(
                 f"plugin process terminated: {plugin_container.manifest.metadata.author}/{plugin_container.manifest.metadata.name}:{plugin_container.manifest.metadata.version}"
             )

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -546,9 +546,7 @@ class PluginManager:
             requirements_file = os.path.join(plugin_path, "requirements.txt")
             if os.path.exists(requirements_file):
                 deps = pkgmgr_helper.parse_requirements(requirements_file)
-                python_path = await pkgmgr_helper.ensure_plugin_environment(
-                    plugin_path
-                )
+                python_path = await pkgmgr_helper.ensure_plugin_environment(plugin_path)
                 total_downloaded = 0
                 started_at = time.time()
                 failures: dict[str, str] = {}
@@ -569,12 +567,14 @@ class PluginManager:
                             "to_install": len(deps),
                         },
                     }
-                    returncode, downloaded, error = (
-                        await pkgmgr_helper.install_with_retry(
-                            dep,
-                            max_retries=3,
-                            python_executable=python_path,
-                        )
+                    (
+                        returncode,
+                        downloaded,
+                        error,
+                    ) = await pkgmgr_helper.install_with_retry(
+                        dep,
+                        max_retries=3,
+                        python_executable=python_path,
                     )
                     total_downloaded += downloaded
                     if returncode != 0:
@@ -591,9 +591,7 @@ class PluginManager:
                         "failed_deps": list(failures),
                         "current_dep": "",
                         "deps_downloaded_size": total_downloaded,
-                        "deps_speed": total_downloaded / elapsed
-                        if elapsed > 0
-                        else 0,
+                        "deps_speed": total_downloaded / elapsed if elapsed > 0 else 0,
                     },
                 }
                 if failures:
@@ -603,10 +601,11 @@ class PluginManager:
                         details=failures,
                     )
 
-                missing, version_mismatch = (
-                    await pkgmgr_helper.classify_requirements_in_environment(
-                        python_path, deps
-                    )
+                (
+                    missing,
+                    version_mismatch,
+                ) = await pkgmgr_helper.classify_requirements_in_environment(
+                    python_path, deps
                 )
                 if missing or version_mismatch:
                     raise DependencyVerificationError(

--- a/tests/box/test_e2b_backend.py
+++ b/tests/box/test_e2b_backend.py
@@ -187,6 +187,20 @@ async def test_start_session_basic(backend, mock_e2b_module):
 
 
 @pytest.mark.anyio
+async def test_is_session_alive_probes_remote_sandbox(backend, mock_e2b_module):
+    backend._api_key = "test-api-key"
+    info = await backend.start_session(BoxSpec(session_id="alive", cmd="true"))
+
+    assert await backend.is_session_alive(info) is True
+    mock_e2b_module.connect.assert_awaited_once_with(
+        sandbox_id="sandbox-test-123", api_key="test-api-key"
+    )
+
+    mock_e2b_module.connect.side_effect = RuntimeError("sandbox gone")
+    assert await backend.is_session_alive(info) is False
+
+
+@pytest.mark.anyio
 async def test_start_session_with_template(backend, mock_e2b_module):
     """start_session passes template parameter when image is specified."""
     backend._api_key = "test-api-key"

--- a/tests/box/test_runtime.py
+++ b/tests/box/test_runtime.py
@@ -1157,9 +1157,7 @@ def test_relative_allowed_mount_root_is_resolved_from_working_directory(
         runtime._ensure_default_workspace()
 
     assert (tmp_path / "data/box/default").is_dir()
-    assert runtime._allowed_mount_roots()[0] == str(
-        (tmp_path / "data/box").resolve()
-    )
+    assert runtime._allowed_mount_roots()[0] == str((tmp_path / "data/box").resolve())
 
 
 @pytest.mark.anyio
@@ -1248,7 +1246,9 @@ async def test_delete_waits_for_inflight_session_creation(logger):
     backend.start_session = mock.AsyncMock(side_effect=blocked_start)
     with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
-        creating = asyncio.create_task(runtime.create_session(_make_spec("create-race")))
+        creating = asyncio.create_task(
+            runtime.create_session(_make_spec("create-race"))
+        )
         await entered.wait()
         deleting = asyncio.create_task(runtime.delete_session("create-race"))
         await asyncio.sleep(0)
@@ -1281,9 +1281,7 @@ async def test_managed_process_capacity_and_completed_retention(logger):
             )
 
         backend.last_process.finish(0)
-        await _wait_until(
-            lambda: not runtime._sessions["p1"].managed_processes
-        )
+        await _wait_until(lambda: not runtime._sessions["p1"].managed_processes)
         await runtime.start_managed_process(
             "p2", BoxManagedProcessSpec(command="daemon")
         )
@@ -1307,10 +1305,7 @@ async def test_completed_process_diagnostics_are_globally_bounded(logger):
         first = backend.last_process
         first.finish(0)
         await _wait_until(
-            lambda: runtime._sessions["bounded"]
-            .managed_processes["one"]
-            .exit_code
-            == 0
+            lambda: runtime._sessions["bounded"].managed_processes["one"].exit_code == 0
         )
 
         await runtime.start_managed_process(

--- a/tests/box/test_runtime.py
+++ b/tests/box/test_runtime.py
@@ -19,6 +19,7 @@ import pytest
 from langbot_plugin.box.backend import BaseSandboxBackend, DockerBackend
 from langbot_plugin.box.errors import (
     BoxBackendUnavailableError,
+    BoxCapacityExceededError,
     BoxManagedProcessNotFoundError,
     BoxSessionConflictError,
     BoxSessionNotFoundError,
@@ -771,7 +772,7 @@ async def test_delete_session_stops_backend(logger):
 
 
 @pytest.mark.anyio
-async def test_shutdown_drops_non_persistent_keeps_persistent(logger):
+async def test_shutdown_drops_all_sessions_including_persistent(logger):
     backend = FakeBackend(logger)
     with mock.patch("os.getenv", return_value=""):
         runtime = BoxRuntime(logger, backends=[backend])
@@ -780,8 +781,8 @@ async def test_shutdown_drops_non_persistent_keeps_persistent(logger):
         await runtime.shutdown()
 
     assert "ephemeral" not in runtime._sessions
-    assert "persist" in runtime._sessions
-    assert backend.stopped_sessions == 1
+    assert "persist" not in runtime._sessions
+    assert backend.stopped_sessions == 2
 
 
 @pytest.mark.anyio
@@ -1127,3 +1128,199 @@ async def test_reap_skips_session_with_running_managed_process(logger):
 
         assert "mp7" in runtime._sessions  # protected by running process
         await runtime.stop_managed_process("mp7", "default")
+
+
+@pytest.mark.anyio
+async def test_session_memory_change_is_a_conflict(logger):
+    backend = FakeBackend(logger)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend])
+        await runtime.create_session(_make_spec("memory", memory_mb=256))
+        with pytest.raises(BoxSessionConflictError, match="memory_mb=256"):
+            await runtime.create_session(_make_spec("memory", memory_mb=512))
+        await runtime.shutdown()
+
+
+def test_relative_allowed_mount_root_is_resolved_from_working_directory(
+    logger, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config = {
+        "local": {
+            "host_root": "./data/box",
+            "default_workspace": "",
+            "allowed_mount_roots": ["./data/box", "/tmp"],
+        }
+    }
+    with mock.patch("os.getenv", return_value=json.dumps(config)):
+        runtime = BoxRuntime(logger, backends=[FakeBackend(logger)])
+        runtime._ensure_default_workspace()
+
+    assert (tmp_path / "data/box/default").is_dir()
+    assert runtime._allowed_mount_roots()[0] == str(
+        (tmp_path / "data/box").resolve()
+    )
+
+
+@pytest.mark.anyio
+async def test_session_capacity_is_enforced(logger):
+    backend = FakeBackend(logger)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend], max_sessions=1)
+        await runtime.create_session(_make_spec("one"))
+        with pytest.raises(BoxCapacityExceededError, match="capacity"):
+            await runtime.create_session(_make_spec("two"))
+        await runtime.shutdown()
+
+
+@pytest.mark.anyio
+async def test_different_sessions_start_without_global_io_lock(logger):
+    backend = FakeBackend(logger)
+    original_start = backend.start_session
+    both_entered = asyncio.Event()
+    release = asyncio.Event()
+    entered = 0
+
+    async def blocked_start(spec):
+        nonlocal entered
+        entered += 1
+        if entered == 2:
+            both_entered.set()
+        await release.wait()
+        return await original_start(spec)
+
+    backend.start_session = mock.AsyncMock(side_effect=blocked_start)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend])
+        first = asyncio.create_task(runtime.create_session(_make_spec("first")))
+        second = asyncio.create_task(runtime.create_session(_make_spec("second")))
+        await asyncio.wait_for(both_entered.wait(), timeout=1)
+        release.set()
+        await asyncio.gather(first, second)
+        await runtime.shutdown()
+
+
+@pytest.mark.anyio
+async def test_delete_during_managed_process_start_leaves_no_orphan(logger):
+    backend = FakeBackend(logger)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    process = FakeProcess()
+
+    async def blocked_start(session, spec):
+        entered.set()
+        await release.wait()
+        return process
+
+    backend.start_managed_process = mock.AsyncMock(side_effect=blocked_start)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend])
+        await runtime.create_session(_make_spec("race"))
+        starting = asyncio.create_task(
+            runtime.start_managed_process(
+                "race", BoxManagedProcessSpec(command="daemon")
+            )
+        )
+        await entered.wait()
+        deleting = asyncio.create_task(runtime.delete_session("race"))
+        await asyncio.sleep(0)
+        release.set()
+        await starting
+        await deleting
+
+    assert "race" not in runtime._sessions
+    process.terminate.assert_called_once()
+    backend.stop_session.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_delete_waits_for_inflight_session_creation(logger):
+    backend = FakeBackend(logger)
+    original_start = backend.start_session
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_start(spec):
+        entered.set()
+        await release.wait()
+        return await original_start(spec)
+
+    backend.start_session = mock.AsyncMock(side_effect=blocked_start)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend])
+        creating = asyncio.create_task(runtime.create_session(_make_spec("create-race")))
+        await entered.wait()
+        deleting = asyncio.create_task(runtime.delete_session("create-race"))
+        await asyncio.sleep(0)
+        release.set()
+        await creating
+        await deleting
+
+    assert "create-race" not in runtime._sessions
+    backend.stop_session.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_managed_process_capacity_and_completed_retention(logger):
+    backend = FakeBackend(logger)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(
+            logger,
+            backends=[backend],
+            max_managed_processes=1,
+            completed_process_retention_sec=0,
+        )
+        await runtime.create_session(_make_spec("p1"))
+        await runtime.create_session(_make_spec("p2"))
+        await runtime.start_managed_process(
+            "p1", BoxManagedProcessSpec(command="daemon")
+        )
+        with pytest.raises(BoxCapacityExceededError, match="capacity"):
+            await runtime.start_managed_process(
+                "p2", BoxManagedProcessSpec(command="daemon")
+            )
+
+        backend.last_process.finish(0)
+        await _wait_until(
+            lambda: not runtime._sessions["p1"].managed_processes
+        )
+        await runtime.start_managed_process(
+            "p2", BoxManagedProcessSpec(command="daemon")
+        )
+        await runtime.shutdown()
+
+
+@pytest.mark.anyio
+async def test_completed_process_diagnostics_are_globally_bounded(logger):
+    backend = FakeBackend(logger)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(
+            logger,
+            backends=[backend],
+            max_completed_processes=1,
+            completed_process_retention_sec=300,
+        )
+        await runtime.create_session(_make_spec("bounded"))
+        await runtime.start_managed_process(
+            "bounded", BoxManagedProcessSpec(process_id="one", command="true")
+        )
+        first = backend.last_process
+        first.finish(0)
+        await _wait_until(
+            lambda: runtime._sessions["bounded"]
+            .managed_processes["one"]
+            .exit_code
+            == 0
+        )
+
+        await runtime.start_managed_process(
+            "bounded", BoxManagedProcessSpec(process_id="two", command="true")
+        )
+        second = backend.last_process
+        second.finish(0)
+        await _wait_until(
+            lambda: "one" not in runtime._sessions["bounded"].managed_processes
+        )
+
+        assert set(runtime._sessions["bounded"].managed_processes) == {"two"}
+        await runtime.shutdown()

--- a/tests/box/test_runtime.py
+++ b/tests/box/test_runtime.py
@@ -1172,6 +1172,33 @@ async def test_session_capacity_is_enforced(logger):
 
 
 @pytest.mark.anyio
+async def test_closing_session_still_counts_toward_capacity(logger):
+    backend = FakeBackend(logger)
+    stop_started = asyncio.Event()
+    release_stop = asyncio.Event()
+
+    async def slow_stop_session(session: BoxSessionInfo):
+        stop_started.set()
+        await release_stop.wait()
+
+    backend.stop_session = mock.AsyncMock(side_effect=slow_stop_session)
+    with mock.patch("os.getenv", return_value=""):
+        runtime = BoxRuntime(logger, backends=[backend], max_sessions=1)
+        await runtime.create_session(_make_spec("one"))
+        delete_task = asyncio.create_task(runtime.delete_session("one"))
+        await stop_started.wait()
+
+        with pytest.raises(BoxCapacityExceededError, match="capacity"):
+            await runtime.create_session(_make_spec("two"))
+
+        release_stop.set()
+        await delete_task
+        created = await runtime.create_session(_make_spec("two"))
+        assert created["session_id"] == "two"
+        await runtime.shutdown()
+
+
+@pytest.mark.anyio
 async def test_different_sessions_start_without_global_io_lock(logger):
     backend = FakeBackend(logger)
     original_start = backend.start_session

--- a/tests/box/test_server.py
+++ b/tests/box/test_server.py
@@ -719,6 +719,7 @@ def test_create_app_registers_routes_and_runtime(mock_runtime):
     assert app["runtime"] is mock_runtime
 
     routes = {(route.method, route.resource.canonical) for route in app.router.routes()}
+    assert ("GET", "/healthz") in routes
     assert ("GET", "/rpc/ws") in routes
     assert (
         "GET",

--- a/tests/runtime/helper/test_pkgmgr.py
+++ b/tests/runtime/helper/test_pkgmgr.py
@@ -309,7 +309,13 @@ def _patch_install_sequence(monkeypatch, results):
     seq = list(results)
     calls = {"n": 0}
 
-    async def fake_install(package, extra_params=None):
+    async def fake_install(
+        package,
+        extra_params=None,
+        *,
+        python_executable=None,
+        timeout_sec=pkgmgr.DEFAULT_INSTALL_TIMEOUT_SEC,
+    ):
         calls["n"] += 1
         return seq.pop(0)
 

--- a/tests/runtime/helper/test_pkgmgr.py
+++ b/tests/runtime/helper/test_pkgmgr.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import pathlib
+
+import pytest
 
 from langbot_plugin.runtime.helper import pkgmgr
 
@@ -115,6 +118,93 @@ def test_install_single_async_builds_pip_command_and_parses_output(monkeypatch):
     assert downloaded == 2048
     assert "Downloading async.whl" in output
     assert calls[0][0][-2:] == ("install", "demo")
+
+
+class _BlockingProcess:
+    def __init__(self):
+        self.returncode = None
+        self.communicate_started = asyncio.Event()
+        self.terminated = False
+        self.killed = False
+
+    async def communicate(self):
+        self.communicate_started.set()
+        if self.returncode is not None:
+            return b"", b""
+        await asyncio.Future()
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self):
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_install_single_async_reaps_subprocess_when_cancelled(monkeypatch):
+    process = _BlockingProcess()
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    task = asyncio.create_task(pkgmgr.install_single_async("demo"))
+    await process.communicate_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.terminated
+    assert not process.killed
+
+
+def test_get_plugin_python_returns_absolute_venv_interpreter(tmp_path):
+    executable = (
+        tmp_path
+        / ".venv"
+        / ("Scripts/python.exe" if pkgmgr.sys.platform == "win32" else "bin/python")
+    )
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+
+    result = pkgmgr.get_plugin_python(str(tmp_path))
+
+    assert pathlib.Path(result).is_absolute()
+    assert pathlib.Path(result) == executable.resolve()
+
+
+@pytest.mark.asyncio
+async def test_install_requirements_reaps_subprocess_when_cancelled(
+    monkeypatch, tmp_path
+):
+    (tmp_path / "requirements.txt").write_text("demo\n", encoding="utf-8")
+    process = _BlockingProcess()
+
+    async def fake_ensure_plugin_environment(plugin_path):
+        return pkgmgr.sys.executable
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return process
+
+    monkeypatch.setattr(
+        pkgmgr, "ensure_plugin_environment", fake_ensure_plugin_environment
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    task = asyncio.create_task(pkgmgr.install_requirements_isolated(str(tmp_path)))
+    await process.communicate_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.terminated
+    assert not process.killed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/io/test_connections.py
+++ b/tests/runtime/io/test_connections.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+from langbot_plugin.runtime.io.connection import split_utf8_chunks
 from langbot_plugin.runtime.io.connections.stdio import StdioConnection
 from langbot_plugin.runtime.io.connections.ws import WebSocketConnection
 
@@ -48,7 +51,7 @@ class FakeWebSocket:
         self.receive_batches = receive_batches or []
         self.closed = False
 
-    async def send(self, data: str, text: bool = False):
+    async def send(self, data, text: bool = False):
         self.sent.append((data, text))
 
     def recv_streaming(self, decode: bool = False):
@@ -129,13 +132,21 @@ async def test_websocket_connection_sends_large_message_in_chunks():
 
     await connection.send("abcdefghi")
 
-    assert websocket.sent == [("abcd", True), ("efgh", True), ("i", True)]
+    assert websocket.sent == [(["abcd", "efgh", "i"], False)]
 
 
 async def test_websocket_connection_receives_streamed_json_message():
     websocket = FakeWebSocket(receive_batches=[['{"ok": ', "true}"]])
     connection = WebSocketConnection(websocket)
 
+    assert await connection.receive() == '{"ok": true}'
+
+
+async def test_websocket_connection_returns_one_malformed_message_at_a_time():
+    websocket = FakeWebSocket(receive_batches=[["not-json"], ['{"ok": true}']])
+    connection = WebSocketConnection(websocket)
+
+    assert await connection.receive() == "not-json"
     assert await connection.receive() == '{"ok": true}'
 
 
@@ -146,3 +157,15 @@ async def test_websocket_connection_close_closes_socket():
     await connection.close()
 
     assert websocket.closed is True
+
+
+def test_split_utf8_chunks_respects_byte_limit():
+    chunks = split_utf8_chunks("a你b好", 4)
+
+    assert "".join(chunks) == "a你b好"
+    assert all(len(chunk.encode("utf-8")) <= 4 for chunk in chunks)
+
+
+def test_split_utf8_chunks_rejects_impossible_limit():
+    with pytest.raises(ValueError, match="UTF-8 code point"):
+        split_utf8_chunks("你", 2)

--- a/tests/runtime/io/test_controllers.py
+++ b/tests/runtime/io/test_controllers.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 from langbot_plugin.runtime.io.connections.stdio import StdioConnection
@@ -14,6 +18,7 @@ class FakeProcess:
     def __init__(self, stdin=object(), stdout=object()):
         self.stdin = stdin
         self.stdout = stdout
+        self.returncode = 0
 
 
 class FakeWebSocket:
@@ -34,9 +39,13 @@ class FakeWebSocketConnectContext:
 class FakeServer:
     def __init__(self):
         self.waited = False
+        self.closed = False
 
     async def wait_closed(self):
         self.waited = True
+
+    def close(self):
+        self.closed = True
 
 
 async def test_stdio_client_controller_creates_process_connection(monkeypatch):
@@ -111,10 +120,11 @@ async def test_websocket_client_controller_invokes_connection_callback(monkeypat
     captured = {}
     websocket = FakeWebSocket()
 
-    def fake_connect(url, open_timeout, proxy="__unset__"):
+    def fake_connect(url, open_timeout, proxy="__unset__", **kwargs):
         captured["url"] = url
         captured["open_timeout"] = open_timeout
         captured["proxy"] = proxy
+        captured.update(kwargs)
         return FakeWebSocketConnectContext(websocket)
 
     async def callback(connection):
@@ -140,7 +150,7 @@ async def test_websocket_client_controller_reports_connection_failure(monkeypatc
     captured = {}
     error = OSError("network down")
 
-    def fake_connect(url, open_timeout, proxy=None):
+    def fake_connect(url, open_timeout, proxy=None, **kwargs):
         raise error
 
     async def callback(connection):
@@ -162,10 +172,11 @@ async def test_websocket_server_controller_run_waits_for_server(monkeypatch):
     fake_server = FakeServer()
     captured = {}
 
-    async def fake_serve(handler, host, port):
+    async def fake_serve(handler, host, port, **kwargs):
         captured["handler"] = handler
         captured["host"] = host
         captured["port"] = port
+        captured.update(kwargs)
         return fake_server
 
     async def callback(connection):
@@ -179,7 +190,34 @@ async def test_websocket_server_controller_run_waits_for_server(monkeypatch):
     assert captured["handler"] == controller.handle_connection
     assert captured["host"] == "0.0.0.0"
     assert captured["port"] == 9000
+    assert captured["process_request"] is ws_server.process_http_request
+    assert captured["logger"] is ws_server.protocol_logger
     assert fake_server.waited is True
+    assert fake_server.closed is True
+
+
+def test_websocket_server_health_endpoint():
+    connection = MagicMock()
+    response = object()
+    connection.respond.return_value = response
+
+    result = ws_server.process_http_request(
+        connection, SimpleNamespace(path="/healthz")
+    )
+
+    assert result is response
+    connection.respond.assert_called_once_with(HTTPStatus.OK, "ok\n")
+
+
+def test_websocket_server_non_health_request_continues_handshake():
+    connection = MagicMock()
+
+    result = ws_server.process_http_request(
+        connection, SimpleNamespace(path="/control/ws")
+    )
+
+    assert result is None
+    connection.respond.assert_not_called()
 
 
 async def test_websocket_server_controller_wraps_new_connections():

--- a/tests/runtime/io/test_controllers.py
+++ b/tests/runtime/io/test_controllers.py
@@ -77,8 +77,39 @@ async def test_stdio_client_controller_creates_process_connection(monkeypatch):
     assert captured["args"][:2] == ("python", "plugin.py")
     assert captured["kwargs"]["env"] == {"TOKEN": "secret"}
     assert captured["kwargs"]["cwd"] == "/tmp/plugin"
+    assert captured["kwargs"]["stderr"] is None
     assert isinstance(captured["connection"], StdioConnection)
     assert captured["connection"].process is process
+
+
+async def test_stdio_client_controller_captures_stderr_only_when_requested(
+    monkeypatch,
+):
+    process = FakeProcess()
+    captured = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured.update(kwargs)
+        return process
+
+    async def callback(connection):
+        return None
+
+    monkeypatch.setattr(
+        stdio_client.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    controller = stdio_client.StdioClientController(
+        "python",
+        [],
+        {},
+        capture_stderr=True,
+    )
+
+    await controller.run(callback)
+
+    assert captured["stderr"] is stdio_client.asyncio.subprocess.PIPE
 
 
 async def test_stdio_client_controller_rejects_missing_pipes(monkeypatch):

--- a/tests/runtime/io/test_handler.py
+++ b/tests/runtime/io/test_handler.py
@@ -107,9 +107,7 @@ async def test_disconnect_fails_pending_unary_and_stream_calls():
     conn = ProtocolConnection()
     handler = Handler(conn)
     run_task = asyncio.create_task(handler.run())
-    unary = asyncio.create_task(
-        handler.call_action(SampleAction.ECHO, {}, timeout=10)
-    )
+    unary = asyncio.create_task(handler.call_action(SampleAction.ECHO, {}, timeout=10))
 
     async def consume_stream():
         async for _ in handler.call_action_generator(

--- a/tests/runtime/io/test_handler.py
+++ b/tests/runtime/io/test_handler.py
@@ -46,6 +46,11 @@ class QueueConnection(Connection):
         self.closed = True
 
 
+class FailingSendConnection(QueueConnection):
+    async def send(self, message: str) -> None:
+        raise ConnectionClosedError("send failed")
+
+
 async def _wait_for_sent(conn: QueueConnection, count: int = 1) -> list[dict]:
     for _ in range(50):
         if len(conn.sent) >= count:
@@ -85,6 +90,133 @@ async def test_call_action_timeout_cleans_waiter():
         await handler.call_action(SampleAction.ECHO, {}, timeout=0.01)
 
     assert handler.resp_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_call_action_send_failure_cleans_waiter_immediately():
+    handler = Handler(FailingSendConnection())
+
+    with pytest.raises(ConnectionClosedError, match="send failed"):
+        await handler.call_action(SampleAction.ECHO, {}, timeout=10)
+
+    assert handler.resp_waiters == {}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_fails_pending_unary_and_stream_calls():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+    run_task = asyncio.create_task(handler.run())
+    unary = asyncio.create_task(
+        handler.call_action(SampleAction.ECHO, {}, timeout=10)
+    )
+
+    async def consume_stream():
+        async for _ in handler.call_action_generator(
+            SampleAction.STREAM, {}, timeout=10
+        ):
+            pass
+
+    stream = asyncio.create_task(consume_stream())
+    await conn.sent_messages(2)
+    await conn.close_peer()
+
+    with pytest.raises(ConnectionClosedError):
+        await asyncio.wait_for(unary, timeout=0.5)
+    with pytest.raises(ConnectionClosedError):
+        await asyncio.wait_for(stream, timeout=0.5)
+    await run_task
+    assert handler.resp_waiters == {}
+    assert handler.resp_queues == {}
+
+
+@pytest.mark.asyncio
+async def test_reconnect_still_fails_requests_from_old_transport():
+    first = QueueConnection()
+    second = QueueConnection()
+    reconnects = 0
+
+    async def reconnect(current_handler):
+        nonlocal reconnects
+        reconnects += 1
+        if reconnects == 1:
+            current_handler.conn = second
+            return True
+        return False
+
+    handler = Handler(first, reconnect)
+    run_task = asyncio.create_task(handler.run())
+    old_call = asyncio.create_task(
+        handler.call_action(SampleAction.ECHO, {}, timeout=10)
+    )
+    await _wait_for_sent(first)
+    await first.incoming.put(ConnectionClosedError("old transport closed"))
+
+    with pytest.raises(ConnectionClosedError, match="old transport closed"):
+        await asyncio.wait_for(old_call, timeout=0.5)
+
+    new_call = asyncio.create_task(
+        handler.call_action(SampleAction.ECHO, {}, timeout=1)
+    )
+    [request] = await _wait_for_sent(second)
+    await second.incoming.put(
+        json.dumps(
+            ActionResponse.success({"generation": 2})
+            .model_copy(update={"seq_id": request["seq_id"]})
+            .model_dump()
+        )
+    )
+    assert await new_call == {"generation": 2}
+
+    await second.incoming.put(ConnectionClosedError("done"))
+    await run_task
+
+
+@pytest.mark.asyncio
+async def test_run_ignores_non_object_json_message():
+    conn = QueueConnection()
+    handler = Handler(conn)
+
+    @handler.action(SampleAction.ECHO)
+    async def echo(data):
+        return ActionResponse.success(data)
+
+    run_task = asyncio.create_task(handler.run())
+    await conn.incoming.put("[]")
+    await conn.incoming.put(
+        json.dumps({"seq_id": 4, "action": "echo", "data": {"ok": True}})
+    )
+    [response] = await _wait_for_sent(conn)
+    await conn.incoming.put(ConnectionClosedError("done"))
+    await run_task
+
+    assert response["data"] == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_slow_inbound_action_does_not_block_outbound_response_routing():
+    conn = ProtocolConnection()
+    handler = Handler(conn)
+    release = asyncio.Event()
+
+    @handler.action(SampleAction.STREAM)
+    async def slow_action(_data):
+        await release.wait()
+        return ActionResponse.success({})
+
+    run_task = asyncio.create_task(handler.run())
+    await conn.send_peer_request("stream", {}, seq_id=77)
+    call_task = asyncio.create_task(
+        handler.call_action(SampleAction.ECHO, {}, timeout=1)
+    )
+    [request] = await conn.sent_messages(1)
+    await conn.send_peer_response(request["seq_id"], data={"ok": True})
+
+    assert await asyncio.wait_for(call_task, timeout=0.5) == {"ok": True}
+    release.set()
+    await conn.sent_messages(2)
+    await conn.close_peer()
+    await run_task
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import os
 import zipfile
 from types import SimpleNamespace
 from typing import Any
@@ -422,6 +423,89 @@ async def test_install_plugin_from_file_rejects_same_version_duplicate(
 
     with pytest.raises(ValueError, match="already exists"):
         await manager.install_plugin_from_file(_plugin_zip(version="1.0.0"))
+
+
+@pytest.mark.asyncio
+async def test_dependency_reconciliation_isolates_plugin_failures(monkeypatch):
+    manager = _manager()
+
+    async def fake_install(plugin_path):
+        if plugin_path.endswith("bad"):
+            raise OSError("venv unavailable")
+        return 0, ""
+
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr.glob.glob",
+        lambda pattern: ["data/plugins/bad", "data/plugins/good"],
+    )
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr.os.path.isdir",
+        lambda path: True,
+    )
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.install_requirements_isolated",
+        fake_install,
+    )
+
+    await manager.ensure_all_plugins_dependencies_installed()
+
+    assert manager._dependency_errors == {
+        "data/plugins/bad": "OSError: venv unavailable"
+    }
+
+
+@pytest.mark.asyncio
+async def test_activation_stops_supervisor_without_registered_container(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    manager = _manager()
+    target_path = tmp_path / "data/plugins/tester__demo"
+    target_path.mkdir(parents=True)
+    (target_path / "old.py").write_text("old", encoding="utf-8")
+    staging_path = tmp_path / "data/.plugin-staging/tester__demo-new"
+    staging_path.mkdir(parents=True)
+    (staging_path / "new.py").write_text("new", encoding="utf-8")
+    manager.stop_plugin_supervisor = AsyncMock()
+
+    await manager._activate_staged_plugin(str(staging_path), "tester", "demo")
+
+    manager.stop_plugin_supervisor.assert_awaited_once_with("data/plugins/tester__demo")
+    assert (target_path / "new.py").is_file()
+
+
+@pytest.mark.asyncio
+async def test_activation_failure_restores_and_restarts_previous_generation(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    manager = _manager()
+    target_path = tmp_path / "data/plugins/tester__demo"
+    target_path.mkdir(parents=True)
+    (target_path / "old.py").write_text("old", encoding="utf-8")
+    staging_path = tmp_path / "data/.plugin-staging/tester__demo-new"
+    staging_path.mkdir(parents=True)
+    (staging_path / "new.py").write_text("new", encoding="utf-8")
+    manager.stop_plugin_supervisor = AsyncMock()
+    restarted = []
+    manager.start_plugin_supervisor = lambda path: restarted.append(path)
+    real_replace = os.replace
+
+    def fail_new_generation(source, destination):
+        if str(source) == str(staging_path):
+            raise OSError("swap failed")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr.os.replace",
+        fail_new_generation,
+    )
+
+    with pytest.raises(OSError, match="swap failed"):
+        await manager._activate_staged_plugin(str(staging_path), "tester", "demo")
+
+    assert (target_path / "old.py").read_text(encoding="utf-8") == "old"
+    assert restarted == ["data/plugins/tester__demo"]
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -5,6 +5,7 @@ import io
 import zipfile
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -386,7 +387,7 @@ async def test_notify_plugin_diagnostic_skips_synthetic_log_with_active_reader()
 
 
 @pytest.mark.asyncio
-async def test_install_plugin_from_file_extracts_manifest_and_replaces_old_version(
+async def test_install_plugin_from_file_extracts_manifest_to_staging(
     tmp_path,
     monkeypatch,
 ):
@@ -403,10 +404,12 @@ async def test_install_plugin_from_file_extracts_manifest_and_replaces_old_versi
         _plugin_zip(version="2.0.0")
     )
 
-    assert (tmp_path / "data/plugins/tester__demo/manifest.yaml").exists()
-    assert new_path == "data/plugins/tester__demo"
+    staged = tmp_path / new_path
+    assert (staged / "manifest.yaml").exists()
+    assert new_path.startswith("data/.plugin-staging/tester__demo-")
     assert (author, name, version) == ("tester", "demo", "2.0.0")
-    assert manager.plugins == []
+    assert manager.plugins == [old_plugin]
+    assert (old_path / "old.py").exists()
 
 
 @pytest.mark.asyncio
@@ -436,7 +439,9 @@ async def test_install_plugin_raises_when_dependency_install_fails(
 
     call_count = {"n": 0}
 
-    async def fake_install_single_async(dep, extra_params=None):
+    async def fake_install_single_async(
+        dep, extra_params=None, *, python_executable=None, timeout_sec=300
+    ):
         call_count["n"] += 1
         return 1, 0, "pip could not find package"
 
@@ -444,9 +449,16 @@ async def test_install_plugin_raises_when_dependency_install_fails(
     async def fake_sleep(delay):
         return None
 
+    async def fake_ensure_plugin_environment(plugin_path):
+        return "plugin-python"
+
     monkeypatch.setattr(manager, "install_plugin_from_file", fake_install_from_file)
     monkeypatch.setattr(
-        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.install_single_async",
+        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.ensure_plugin_environment",
+        fake_ensure_plugin_environment,
+    )
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.helper.pkgmgr.install_single_async",
         fake_install_single_async,
     )
     monkeypatch.setattr(
@@ -493,13 +505,25 @@ async def test_install_plugin_raises_verification_error_when_pip_lies(
         return "data/plugins/tester__demo", "tester", "demo", "1.0.0"
 
     # pip exits 0 (success) but nothing actually got installed.
-    async def fake_install_single_async(dep, extra_params=None):
+    async def fake_install_single_async(
+        dep, extra_params=None, *, python_executable=None, timeout_sec=300
+    ):
         return 0, 0, "Successfully installed langbot-absent-after-install"
 
     monkeypatch.setattr(manager, "install_plugin_from_file", fake_install_from_file)
     monkeypatch.setattr(
-        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.install_single_async",
+        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.ensure_plugin_environment",
+        lambda plugin_path: asyncio.sleep(0, result="plugin-python"),
+    )
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.helper.pkgmgr.install_single_async",
         fake_install_single_async,
+    )
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr.pkgmgr_helper.classify_requirements_in_environment",
+        lambda python, deps: asyncio.sleep(
+            0, result=(["langbot-absent-after-install"], [])
+        ),
     )
 
     with pytest.raises(DependencyVerificationError) as exc_info:
@@ -654,6 +678,69 @@ async def test_shutdown_plugin_closes_connection_and_removes_container():
     assert manager.plugin_handlers == []
     assert handler.shutdown_calls == 1
     assert handler.conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_all_plugins_uses_snapshot_and_closes_every_plugin():
+    manager = _manager()
+    plugins = [_plugin(name="one"), _plugin(name="two")]
+    handlers = [FakeHandler(plugin) for plugin in plugins]
+    for plugin, handler in zip(plugins, handlers, strict=True):
+        plugin._runtime_plugin_handler = handler
+    manager.plugins = list(plugins)
+    manager.plugin_handlers = list(handlers)
+
+    await manager.shutdown_all_plugins()
+
+    assert manager.plugins == []
+    assert manager.plugin_handlers == []
+    assert [handler.shutdown_calls for handler in handlers] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_plugin_supervisor_restarts_after_crash(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    plugin_path = tmp_path / "data/plugins/tester__demo"
+    plugin_path.mkdir(parents=True)
+    manager = _manager()
+    second_generation_started = asyncio.Event()
+    calls = 0
+
+    async def fake_launch(path):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("crash")
+        second_generation_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(manager, "launch_plugin", fake_launch)
+    monkeypatch.setattr(
+        "langbot_plugin.runtime.plugin.mgr._PLUGIN_RESTART_INITIAL_DELAY_SEC",
+        0,
+    )
+
+    manager.start_plugin_supervisor(str(plugin_path))
+    await asyncio.wait_for(second_generation_started.wait(), timeout=1)
+    assert calls == 2
+
+    await manager.stop_plugin_supervisor(str(plugin_path))
+    assert str(plugin_path) not in manager._desired_plugin_paths
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_rolls_back_container_when_initialize_fails():
+    manager = _manager()
+    manager.context = SimpleNamespace(control_handler=FakeControlHandler())
+    plugin = _plugin(status=RuntimeContainerStatus.MOUNTED)
+    handler = FakeHandler(plugin)
+    handler.initialize_plugin = AsyncMock(side_effect=RuntimeError("init failed"))
+
+    with pytest.raises(RuntimeError, match="init failed"):
+        await manager.register_plugin(handler, plugin.model_dump())
+
+    assert manager.plugins == []
+    assert manager.plugin_handlers == []
 
 
 @pytest.mark.asyncio
@@ -1027,12 +1114,15 @@ async def test_install_plugin_marketplace_streams_progress_and_launches(monkeypa
 
     async def fake_install_plugin_from_file(plugin_file):
         assert plugin_file == b"zip"
-        return "data/plugins/tester__demo", "tester", "demo", "1.0.0"
+        return "data/.plugin-staging/tester__demo-stage", "tester", "demo", "1.0.0"
 
     launched = []
 
-    async def fake_launch_plugin(plugin_path):
+    def fake_start_plugin_supervisor(plugin_path):
         launched.append(plugin_path)
+
+    async def fake_wait_for_plugin_ready(author, name, timeout):
+        return None
 
     monkeypatch.setattr(
         marketplace_helper,
@@ -1042,7 +1132,13 @@ async def test_install_plugin_marketplace_streams_progress_and_launches(monkeypa
     monkeypatch.setattr(
         manager, "install_plugin_from_file", fake_install_plugin_from_file
     )
-    monkeypatch.setattr(manager, "launch_plugin", fake_launch_plugin)
+    monkeypatch.setattr(manager, "start_plugin_supervisor", fake_start_plugin_supervisor)
+    monkeypatch.setattr(manager, "_wait_for_plugin_ready", fake_wait_for_plugin_ready)
+    monkeypatch.setattr(
+        manager,
+        "_activate_staged_plugin",
+        lambda path, author, name: asyncio.sleep(0, result=None),
+    )
 
     progress = [
         item
@@ -1055,8 +1151,6 @@ async def test_install_plugin_marketplace_streams_progress_and_launches(monkeypa
             },
         )
     ]
-    await asyncio.gather(*manager.plugin_run_tasks)
-
     assert [item["current_action"] for item in progress] == [
         "downloading plugin package",
         "downloading plugin package",

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -1132,7 +1132,9 @@ async def test_install_plugin_marketplace_streams_progress_and_launches(monkeypa
     monkeypatch.setattr(
         manager, "install_plugin_from_file", fake_install_plugin_from_file
     )
-    monkeypatch.setattr(manager, "start_plugin_supervisor", fake_start_plugin_supervisor)
+    monkeypatch.setattr(
+        manager, "start_plugin_supervisor", fake_start_plugin_supervisor
+    )
     monkeypatch.setattr(manager, "_wait_for_plugin_ready", fake_wait_for_plugin_ready)
     monkeypatch.setattr(
         manager,

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -280,9 +280,7 @@ async def test_runtime_application_surfaces_listener_failure(monkeypatch):
         "WebSocketServerController",
         FakeServerController,
     )
-    app = runtime_app.RuntimeApplication(
-        _args(skip_deps_check=True, debug_only=True)
-    )
+    app = runtime_app.RuntimeApplication(_args(skip_deps_check=True, debug_only=True))
 
     with pytest.raises(RuntimeError, match="listener bind failed"):
         await app.run()
@@ -400,6 +398,7 @@ def test_runtime_main_handles_cancelled_error(monkeypatch):
         lambda: calls.append(("configure_logging",)),
     )
     monkeypatch.setattr(runtime_app, "RuntimeApplication", FakeApplication)
+
     def cancel_run(coroutine):
         coroutine.close()
         raise asyncio.CancelledError
@@ -427,6 +426,7 @@ def test_runtime_main_handles_keyboard_interrupt(monkeypatch):
         lambda: calls.append(("configure_logging",)),
     )
     monkeypatch.setattr(runtime_app, "RuntimeApplication", FakeApplication)
+
     def interrupt_run(coroutine):
         coroutine.close()
         raise KeyboardInterrupt

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -174,9 +174,57 @@ async def test_set_control_handler_runs_handler_and_resolves_waiter(monkeypatch)
     task = app.set_control_handler(handler)
     await task
 
-    assert app.context.control_handler is handler
+    assert not hasattr(app.context, "control_handler")
     assert handler.calls == ["run"]
     assert app.context.plugin_mgr.wait_for_control_connection is None
+
+
+async def test_set_control_handler_serializes_replacements(monkeypatch):
+    monkeypatch.setattr(
+        runtime_app.plugin_mgr_cls,
+        "PluginManager",
+        FakePluginManager,
+    )
+    monkeypatch.setattr(
+        runtime_app.stdio_controller_server,
+        "StdioServerController",
+        FakeServerController,
+    )
+    monkeypatch.setattr(
+        runtime_app.ws_controller_server,
+        "WebSocketServerController",
+        FakeServerController,
+    )
+    app = runtime_app.RuntimeApplication(_args())
+
+    class BlockingHandler:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.close_calls = 0
+
+        async def run(self):
+            self.started.set()
+            await self.release.wait()
+
+        async def close(self):
+            self.close_calls += 1
+            self.release.set()
+
+    first = BlockingHandler()
+    second = BlockingHandler()
+    first_task = app.set_control_handler(first)
+    await first.started.wait()
+    second_task = app.set_control_handler(second)
+    await second.started.wait()
+
+    assert first_task.done()
+    assert first.close_calls == 1
+    assert app.context.control_handler is second
+
+    second.release.set()
+    await second_task
+    assert not hasattr(app.context, "control_handler")
 
 
 async def test_runtime_application_run_coordinates_servers_and_plugin_manager(

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 
+import pytest
+
 from langbot_plugin.runtime import app as runtime_app
 
 
@@ -29,6 +31,9 @@ class FakePluginManager:
     async def shutdown_all_plugins(self):
         self.calls.append("shutdown_all")
 
+    def mark_control_connection_ready(self):
+        self.calls.append("control_ready")
+
 
 class FakeServerController:
     instances = []
@@ -41,6 +46,11 @@ class FakeServerController:
     async def run(self, callback):
         self.callbacks.append(callback)
         await callback(object())
+
+
+class FailingServerController(FakeServerController):
+    async def run(self, callback):
+        raise RuntimeError("listener bind failed")
 
 
 class FakeControlHandler:
@@ -205,11 +215,14 @@ async def test_runtime_application_run_coordinates_servers_and_plugin_manager(
     await app.run()
 
     manager = FakePluginManager.instances[-1]
-    assert manager.calls == [
-        "ensure_deps",
+    assert manager.calls[0] == "add_plugin_handler"
+    assert set(manager.calls) == {
         "add_plugin_handler",
+        "control_ready",
+        "ensure_deps",
         "launch_all",
-    ]
+    }
+    assert manager.calls.index("ensure_deps") < manager.calls.index("launch_all")
     assert FakeControlHandler.instances[-1].calls == ["run"]
     assert FakePluginHandler.instances[-1].debug_plugin is True
 
@@ -245,7 +258,34 @@ async def test_runtime_application_run_can_skip_deps_and_plugin_launch(monkeypat
 
     await app.run()
 
-    assert FakePluginManager.instances[-1].calls == ["add_plugin_handler"]
+    assert FakePluginManager.instances[-1].calls == [
+        "add_plugin_handler",
+        "control_ready",
+    ]
+
+
+async def test_runtime_application_surfaces_listener_failure(monkeypatch):
+    monkeypatch.setattr(
+        runtime_app.plugin_mgr_cls,
+        "PluginManager",
+        FakePluginManager,
+    )
+    monkeypatch.setattr(
+        runtime_app.stdio_controller_server,
+        "StdioServerController",
+        FailingServerController,
+    )
+    monkeypatch.setattr(
+        runtime_app.ws_controller_server,
+        "WebSocketServerController",
+        FakeServerController,
+    )
+    app = runtime_app.RuntimeApplication(
+        _args(skip_deps_check=True, debug_only=True)
+    )
+
+    with pytest.raises(RuntimeError, match="listener bind failed"):
+        await app.run()
 
 
 async def test_runtime_application_run_uses_websocket_control_server(monkeypatch):
@@ -284,7 +324,10 @@ async def test_runtime_application_run_uses_websocket_control_server(monkeypatch
 
     assert app.context.ws_control_server.callbacks
     assert FakeControlHandler.instances[-1].calls == ["run"]
-    assert FakePluginManager.instances[-1].calls == ["add_plugin_handler"]
+    assert FakePluginManager.instances[-1].calls == [
+        "add_plugin_handler",
+        "control_ready",
+    ]
 
 
 async def test_runtime_application_shutdown_delegates_to_plugin_manager(monkeypatch):
@@ -321,6 +364,9 @@ def test_runtime_main_configures_logging_and_runs_application(monkeypatch):
         async def run(self):
             calls.append(("run",))
 
+        async def shutdown(self):
+            calls.append(("shutdown",))
+
     monkeypatch.setattr(
         runtime_app,
         "configure_process_logging",
@@ -330,7 +376,12 @@ def test_runtime_main_configures_logging_and_runs_application(monkeypatch):
 
     runtime_app.main(_args())
 
-    assert calls == [("configure_logging",), ("init", _args()), ("run",)]
+    assert calls == [
+        ("configure_logging",),
+        ("init", _args()),
+        ("run",),
+        ("shutdown",),
+    ]
 
 
 def test_runtime_main_handles_cancelled_error(monkeypatch):
@@ -349,11 +400,11 @@ def test_runtime_main_handles_cancelled_error(monkeypatch):
         lambda: calls.append(("configure_logging",)),
     )
     monkeypatch.setattr(runtime_app, "RuntimeApplication", FakeApplication)
-    monkeypatch.setattr(
-        runtime_app.asyncio,
-        "run",
-        lambda coroutine: (_ for _ in ()).throw(asyncio.CancelledError()),
-    )
+    def cancel_run(coroutine):
+        coroutine.close()
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(runtime_app.asyncio, "run", cancel_run)
 
     runtime_app.main(_args())
 
@@ -376,11 +427,11 @@ def test_runtime_main_handles_keyboard_interrupt(monkeypatch):
         lambda: calls.append(("configure_logging",)),
     )
     monkeypatch.setattr(runtime_app, "RuntimeApplication", FakeApplication)
-    monkeypatch.setattr(
-        runtime_app.asyncio,
-        "run",
-        lambda coroutine: (_ for _ in ()).throw(KeyboardInterrupt()),
-    )
+    def interrupt_run(coroutine):
+        coroutine.close()
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(runtime_app.asyncio, "run", interrupt_run)
 
     runtime_app.main(_args())
 


### PR DESCRIPTION
## Summary

- make RPC disconnects fail pending unary and streaming calls immediately, bound inbound work and message sizes, and deterministically close transports and owned tasks
- supervise production plugin processes with bounded exponential restart backoff, isolate plugin dependencies in per-plugin virtual environments, and make install/upgrade activation atomic with rollback
- serialize control-connection replacement and same-plugin lifecycle operations so overlapping generations cannot remain active
- prevent stdio deadlocks by capturing stderr only for plugin processes with an active log consumer; LangBot-managed runtimes inherit stderr
- terminate and reap dependency installers on cancellation, isolate per-plugin reconciliation failures, and resolve plugin virtual-environment interpreters to absolute paths
- remove Box global I/O lock contention and lifecycle races, add liveness checks and admission limits, count closing sessions against capacity, and deterministically clean up sessions/processes
- expose quiet HTTP health endpoints for Plugin Runtime and Box Runtime orchestration
- bump the package version to `0.4.15`

This change intentionally focuses on runtime stability and resource ownership; it is not a security audit.

## Verification

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest -q` — 829 passed
- `uv run python scripts/check_action_consistency.py`
- built sdist and wheel, installed the wheel into a fresh Python 3.12 environment, and smoke-tested `lbp` / `lbp box`
- started the installed wheel and verified `/healthz` on Plugin Runtime control/debug ports and Box Runtime
- real stdio crash/restart tests for Plugin Runtime and Box Runtime
- real standalone WebSocket reconnect tests after killing and restarting both runtimes
- real Docker-backed Box command execution and managed-process WebSocket attach/relay

## Deployment note

The companion LangBot draft PR depends on the `0.4.15` release from this change. After this PR is merged and the release workflow publishes the artifact, the LangBot dependency pin and lockfile will be updated before that PR is marked ready.
