### PR TITLE
fix(box): close websockets during shutdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.15"
+version = "0.4.16"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/box/server.py
+++ b/src/langbot_plugin/box/server.py
@@ -28,7 +28,7 @@ import sys
 from typing import Any
 
 import pydantic
-from aiohttp import web
+from aiohttp import WSCloseCode, web
 
 from langbot_plugin.entities.io.actions.enums import CommonAction
 from langbot_plugin.entities.io.errors import ConnectionClosedError
@@ -47,6 +47,8 @@ from .models import BoxExecutionResult, BoxManagedProcessSpec, BoxSpec
 from .runtime import BoxRuntime
 
 logger = logging.getLogger("langbot.box.server")
+
+_ACTIVE_WEBSOCKETS_KEY = web.AppKey("active_websockets", set)
 
 
 def _result_to_dict(result: BoxExecutionResult) -> dict:
@@ -353,54 +355,63 @@ async def handle_managed_process_ws(request: web.Request) -> web.StreamResponse:
         heartbeat=_MANAGED_PROCESS_WS_HEARTBEAT_SEC,
     )
     await ws.prepare(request)
+    active_websockets = request.app.setdefault(_ACTIVE_WEBSOCKETS_KEY, set())
+    active_websockets.add(ws)
 
-    async with managed_process.attach_lock:
-        process = managed_process.process
-        stdout = process.stdout
-        stdin = process.stdin
-        if stdout is None or stdin is None:
-            await ws.close(message=b"managed process stdio unavailable")
-            return ws
+    try:
+        async with managed_process.attach_lock:
+            process = managed_process.process
+            stdout = process.stdout
+            stdin = process.stdin
+            if stdout is None or stdin is None:
+                await ws.close(message=b"managed process stdio unavailable")
+                return ws
 
-        async def _stdout_to_ws() -> None:
-            while True:
-                line = await stdout.readline()
-                if not line:
-                    break
-                await ws.send_str(line.decode("utf-8", errors="replace").rstrip("\n"))
-                runtime_session.info.last_used_at = dt.datetime.now(dt.timezone.utc)
-
-        async def _ws_to_stdin() -> None:
-            async for msg in ws:
-                if msg.type == web.WSMsgType.TEXT:
-                    stdin.write((msg.data + "\n").encode("utf-8"))
-                    await stdin.drain()
+            async def _stdout_to_ws() -> None:
+                while True:
+                    line = await stdout.readline()
+                    if not line:
+                        break
+                    await ws.send_str(
+                        line.decode("utf-8", errors="replace").rstrip("\n")
+                    )
                     runtime_session.info.last_used_at = dt.datetime.now(dt.timezone.utc)
-                elif msg.type in (
-                    web.WSMsgType.CLOSE,
-                    web.WSMsgType.CLOSING,
-                    web.WSMsgType.CLOSED,
-                    web.WSMsgType.ERROR,
-                ):
-                    break
 
-        stdout_task = asyncio.create_task(_stdout_to_ws())
-        stdin_task = asyncio.create_task(_ws_to_stdin())
-        try:
-            done, pending = await asyncio.wait(
-                [stdout_task, stdin_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            for task in pending:
-                task.cancel()
-            for task in done:
-                task.result()
-        finally:
-            for task in (stdout_task, stdin_task):
-                if not task.done():
+            async def _ws_to_stdin() -> None:
+                async for msg in ws:
+                    if msg.type == web.WSMsgType.TEXT:
+                        stdin.write((msg.data + "\n").encode("utf-8"))
+                        await stdin.drain()
+                        runtime_session.info.last_used_at = dt.datetime.now(
+                            dt.timezone.utc
+                        )
+                    elif msg.type in (
+                        web.WSMsgType.CLOSE,
+                        web.WSMsgType.CLOSING,
+                        web.WSMsgType.CLOSED,
+                        web.WSMsgType.ERROR,
+                    ):
+                        break
+
+            stdout_task = asyncio.create_task(_stdout_to_ws())
+            stdin_task = asyncio.create_task(_ws_to_stdin())
+            try:
+                done, pending = await asyncio.wait(
+                    [stdout_task, stdin_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in pending:
                     task.cancel()
-            await asyncio.gather(stdout_task, stdin_task, return_exceptions=True)
-            await ws.close()
+                for task in done:
+                    task.result()
+            finally:
+                for task in (stdout_task, stdin_task):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(stdout_task, stdin_task, return_exceptions=True)
+                await ws.close()
+    finally:
+        active_websockets.discard(ws)
 
     return ws
 
@@ -414,10 +425,15 @@ async def handle_rpc_ws(request: web.Request) -> web.StreamResponse:
 
     ws = web.WebSocketResponse(max_msg_size=MAX_MESSAGE_BYTES)
     await ws.prepare(request)
+    active_websockets = request.app.setdefault(_ACTIVE_WEBSOCKETS_KEY, set())
+    active_websockets.add(ws)
 
     connection = AiohttpWSConnection(ws)
     handler = BoxServerHandler(connection, runtime)
-    await handler.run()
+    try:
+        await handler.run()
+    finally:
+        active_websockets.discard(ws)
 
     return ws
 
@@ -427,6 +443,22 @@ async def handle_healthz(request: web.Request) -> web.Response:
     return web.Response(text="ok\n")
 
 
+async def _close_active_websockets(app: web.Application) -> None:
+    """Close live clients before aiohttp waits for request handlers to drain."""
+    active_websockets = list(app.get(_ACTIVE_WEBSOCKETS_KEY, ()))
+    if active_websockets:
+        await asyncio.gather(
+            *(
+                ws.close(
+                    code=WSCloseCode.GOING_AWAY,
+                    message=b"Box runtime shutting down",
+                )
+                for ws in active_websockets
+            ),
+            return_exceptions=True,
+        )
+
+
 # ── App factory ──────────────────────────────────────────────────────
 
 
@@ -434,6 +466,8 @@ def create_app(runtime: BoxRuntime) -> web.Application:
     """Create the aiohttp app with all WebSocket routes on a single port."""
     app = web.Application()
     app["runtime"] = runtime
+    app[_ACTIVE_WEBSOCKETS_KEY] = set()
+    app.on_shutdown.append(_close_active_websockets)
     app.router.add_get("/healthz", handle_healthz)
     app.router.add_get("/rpc/ws", handle_rpc_ws)
     app.router.add_get(

--- a/tests/box/test_server.py
+++ b/tests/box/test_server.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
-from aiohttp import web
+from aiohttp import WSCloseCode, web
 
 from langbot_plugin.box import server
 from langbot_plugin.box.actions import LangBotToBoxAction
@@ -717,6 +717,8 @@ def test_create_app_registers_routes_and_runtime(mock_runtime):
     app = create_app(mock_runtime)
     assert isinstance(app, web.Application)
     assert app["runtime"] is mock_runtime
+    assert app[server._ACTIVE_WEBSOCKETS_KEY] == set()
+    assert server._close_active_websockets in app.on_shutdown
 
     routes = {(route.method, route.resource.canonical) for route in app.router.routes()}
     assert ("GET", "/healthz") in routes
@@ -745,7 +747,10 @@ async def test_handle_rpc_ws_prepares_ws_and_runs_handler(mock_runtime):
     fake_ws.prepare = mock.AsyncMock()
 
     request = mock.MagicMock()
-    request.app = {"runtime": mock_runtime}
+    request.app = {
+        "runtime": mock_runtime,
+        server._ACTIVE_WEBSOCKETS_KEY: set(),
+    }
 
     run_mock = mock.AsyncMock()
     with (
@@ -757,6 +762,24 @@ async def test_handle_rpc_ws_prepares_ws_and_runs_handler(mock_runtime):
     assert result is fake_ws
     fake_ws.prepare.assert_awaited_once_with(request)
     run_mock.assert_awaited_once()
+    assert request.app[server._ACTIVE_WEBSOCKETS_KEY] == set()
+
+
+async def test_close_active_websockets_closes_every_client(mock_runtime):
+    app = create_app(mock_runtime)
+    first_ws = mock.MagicMock()
+    first_ws.close = mock.AsyncMock()
+    second_ws = mock.MagicMock()
+    second_ws.close = mock.AsyncMock(side_effect=ConnectionResetError)
+    app[server._ACTIVE_WEBSOCKETS_KEY].update((first_ws, second_ws))
+
+    await server._close_active_websockets(app)
+
+    for ws in (first_ws, second_ws):
+        ws.close.assert_awaited_once_with(
+            code=WSCloseCode.GOING_AWAY,
+            message=b"Box runtime shutting down",
+        )
 
 
 # ── handle_managed_process_ws error/early-return paths ───────────────


### PR DESCRIPTION
## Summary

- track active Box action-RPC and managed-process WebSockets
- close all live clients during aiohttp shutdown so the process exits immediately instead of waiting for the default 60-second drain timeout
- bump the SDK patch version to `0.4.16`

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest -q` — 830 passed
- live Box RPC client: SIGINT closes the client with code 1001 and the Box process exits immediately
- `uv build`