### PR TITLE
fix(runtime): create plugin virtual environments reliably

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot-plugin"
-version = "0.4.16"
+version = "0.4.17"
 description = "This package contains the SDK, CLI for building plugins for LangBot, plus the runtime for hosting LangBot plugins"
 readme = "README.md"
 authors = [

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -398,9 +398,10 @@ async def install_with_retry(
 
 def get_plugin_python(plugin_path: str) -> str:
     """Return the isolated interpreter for a plugin when it exists."""
-    root = pathlib.Path(plugin_path) / PLUGIN_VENV_DIR
-    candidate = root / (
-        "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
+    candidate = (
+        pathlib.Path(plugin_path)
+        / PLUGIN_VENV_DIR
+        / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
     )
     if candidate.is_file():
         return str(candidate.resolve())
@@ -414,15 +415,19 @@ async def ensure_plugin_environment(plugin_path: str) -> str:
     dependencies installed into the venv shadow only this plugin's imports.
     """
     root = pathlib.Path(plugin_path) / PLUGIN_VENV_DIR
-    python_path = get_plugin_python(plugin_path)
-    if python_path != sys.executable:
-        return python_path
+    candidate = root / (
+        "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
+    )
+    if candidate.is_file():
+        return str(candidate.resolve())
 
     await asyncio.to_thread(
         venv.EnvBuilder(with_pip=True, system_site_packages=True).create,
         root,
     )
-    return get_plugin_python(plugin_path)
+    if not candidate.is_file():
+        raise RuntimeError(f"Plugin virtual environment was not created at {root}")
+    return str(candidate.resolve())
 
 
 async def install_requirements_isolated(

--- a/tests/runtime/helper/test_pkgmgr.py
+++ b/tests/runtime/helper/test_pkgmgr.py
@@ -180,6 +180,36 @@ def test_get_plugin_python_returns_absolute_venv_interpreter(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_ensure_plugin_environment_creates_missing_venv_for_symlinked_host_python(
+    monkeypatch, tmp_path
+):
+    executable = (
+        tmp_path
+        / ".venv"
+        / ("Scripts/python.exe" if pkgmgr.sys.platform == "win32" else "bin/python")
+    )
+    created_roots = []
+
+    class FakeEnvBuilder:
+        def __init__(self, *, with_pip, system_site_packages):
+            assert with_pip is True
+            assert system_site_packages is True
+
+        def create(self, root):
+            created_roots.append(pathlib.Path(root))
+            executable.parent.mkdir(parents=True)
+            executable.touch()
+
+    monkeypatch.setattr(pkgmgr.venv, "EnvBuilder", FakeEnvBuilder)
+    monkeypatch.setattr(pkgmgr.sys, "executable", "/host/.venv/bin/python")
+
+    result = await pkgmgr.ensure_plugin_environment(str(tmp_path))
+
+    assert created_roots == [tmp_path / ".venv"]
+    assert pathlib.Path(result) == executable.resolve()
+
+
+@pytest.mark.asyncio
 async def test_install_requirements_reaps_subprocess_when_cancelled(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## What changed

- detect an existing plugin virtual environment by checking its interpreter path directly
- create the plugin-local virtual environment whenever that interpreter is absent
- fail explicitly if virtual-environment creation returns without producing an interpreter
- add a regression test for hosts where `sys.executable` is a symlink-style path
- bump the SDK version to 0.4.17

## Root cause

`get_plugin_python()` returns a resolved path, but `ensure_plugin_environment()` compared that result with the unresolved `sys.executable`. In uv and other symlinked Python environments those paths differ even when no plugin virtual environment exists, so dependency reconciliation incorrectly skipped virtual-environment creation and installed or ran against the shared host environment.

## Impact

Plugin dependencies are again isolated per plugin, preventing cross-plugin dependency conflicts and making startup and reconciliation behavior deterministic across uv, virtualenv, and symlinked interpreter layouts.

## Validation

- `uv run pytest -q` — 831 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build` — wheel and sdist built successfully
