### PR TITLE
feat: optional control auth and Workspace debug keys

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -273,12 +273,14 @@ the same manifest identity after initialization. On Windows the child receives
 an explicit environment allowlist, so Runtime and Box control secrets are not
 inherited.
 
-WebSocket control requires the high-entropy
+WebSocket control may use the high-entropy
 `LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN` in the
-`X-LangBot-Plugin-Runtime-Token` handshake header. The debug server never
-accepts an empty key: it validates an explicitly configured `PLUGIN_DEBUG_KEY`
-or generates one at process start, and `lbp run` sends that value in the
-`X-LangBot-Plugin-Debug-Key` handshake header for explicit development
+`X-LangBot-Plugin-Runtime-Token` handshake header. OSS defaults to no control
+token when both LangBot and Runtime leave it unset; if either side configures
+one, both sides must use the same value. The debug server instead accepts only
+Workspace-scoped random credentials issued through the authenticated control
+channel. Each Workspace gets a different token, valid for two hours, and
+`lbp run` sends it in the `X-LangBot-Plugin-Debug-Key` handshake header
 sessions. Windows production children use their one-use registration
 capability in `X-LangBot-Plugin-Registration-Capability` instead. The
 instance-scoped `SET_RUNTIME_CONFIG` handshake and per-action installation

--- a/src/langbot_plugin/assets/templates/.env.example.example
+++ b/src/langbot_plugin/assets/templates/.env.example.example
@@ -1,7 +1,7 @@
 # This is a .env file example, please copy it to .env file.
 # Please refer to https://docs.langbot.app/en/plugin/dev/tutor.html for more details.
-DEBUG_RUNTIME_WS_URL=ws://127.0.0.1:5401/debug/ws
+DEBUG_RUNTIME_WS_URL=ws://127.0.0.1:5401/plugin/debug/ws
 
 # Plugin debug key for runtime authentication
-# Leave empty to disable authentication
+# Copy the current Workspace's two-hour rotating key from LangBot Extensions > Debug Info.
 PLUGIN_DEBUG_KEY=

--- a/src/langbot_plugin/runtime/app.py
+++ b/src/langbot_plugin/runtime/app.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import argparse
 from enum import Enum
-import hmac
 import logging
 import os
-import secrets
 import signal
 from collections.abc import Mapping
 
@@ -25,7 +23,7 @@ from langbot_plugin.runtime.bounded_executor import (
     configure_bounded_default_executor_from_env,
 )
 from langbot_plugin.runtime.event_loop_monitor import EventLoopLagMonitor
-from langbot_plugin.runtime.settings import settings
+
 from langbot_plugin.runtime.security import (
     PLUGIN_DEBUG_KEY_HEADER,
     PLUGIN_REGISTRATION_CAPABILITY_HEADER,
@@ -65,8 +63,6 @@ class RuntimeApplication:
         self._closing = False
         self._shutdown_complete = False
 
-        logger.info(f"settings.cloud_service_url: {settings.cloud_service_url}")
-
         # Set the debug port in context so PluginManager can use it
         self.context.ws_debug_port = self.args.ws_debug_port
 
@@ -77,33 +73,26 @@ class RuntimeApplication:
         else:
             self._control_connection_mode = ControlConnectionMode.WS
 
-        configured_debug_key = str(settings.plugin_debug_key or "").strip()
-        if configured_debug_key:
-            settings.plugin_debug_key = validate_runtime_secret(
-                configured_debug_key,
-                name="PLUGIN_DEBUG_KEY",
-            )
-        else:
-            # Debug access is enabled by default for development, but never
-            # with the historical empty-key bypass. The authenticated control
-            # channel is the only place where this generated key is exposed.
-            settings.plugin_debug_key = secrets.token_urlsafe(48)
-
         # build controllers layer
         if self._control_connection_mode == ControlConnectionMode.STDIO:
             self.context.stdio_server = stdio_controller_server.StdioServerController()
 
         elif self._control_connection_mode == ControlConnectionMode.WS:
-            control_token = validate_runtime_secret(
-                os.environ.get(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV, ""),
-                name=PLUGIN_RUNTIME_CONTROL_TOKEN_ENV,
-            )
+            configured_control_token = str(
+                os.environ.get(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV, "")
+            ).strip()
+            expected_headers = {}
+            if configured_control_token:
+                expected_headers[PLUGIN_RUNTIME_CONTROL_TOKEN_HEADER] = (
+                    validate_runtime_secret(
+                        configured_control_token,
+                        name=PLUGIN_RUNTIME_CONTROL_TOKEN_ENV,
+                    )
+                )
             self.context.ws_control_server = (
                 ws_controller_server.WebSocketServerController(
                     self.args.ws_control_port,
-                    expected_headers={
-                        PLUGIN_RUNTIME_CONTROL_TOKEN_HEADER: control_token,
-                    },
+                    expected_headers=expected_headers,
                     health_snapshot_provider=self._health_snapshot,
                 )
             )
@@ -128,10 +117,7 @@ class RuntimeApplication:
         """Admit explicit debug clients or one pending installed plugin."""
 
         supplied_debug_key = str(headers.get(PLUGIN_DEBUG_KEY_HEADER) or "")
-        if supplied_debug_key and hmac.compare_digest(
-            settings.plugin_debug_key,
-            supplied_debug_key,
-        ):
+        if self.context.workspace_debug_tokens.binding_for_token(supplied_debug_key):
             return True
 
         registration_capability = str(
@@ -247,6 +233,12 @@ class RuntimeApplication:
         async def new_plugin_debug_connection_callback(connection: Connection):
             plugin_handler = plugin_handler_cls.PluginConnectionHandler(
                 connection, self.context, debug_plugin=True
+            )
+            request_headers = getattr(connection, "request_headers", {})
+            plugin_handler.debug_workspace_binding = (
+                self.context.workspace_debug_tokens.binding_for_token(
+                    str(request_headers.get(PLUGIN_DEBUG_KEY_HEADER) or "")
+                )
             )
 
             await self.context.plugin_mgr.add_plugin_handler(plugin_handler)

--- a/src/langbot_plugin/runtime/context.py
+++ b/src/langbot_plugin/runtime/context.py
@@ -15,6 +15,7 @@ from langbot_plugin.entities.io.context import (
     PluginWorkerPolicy,
     RuntimeIdentity,
 )
+from langbot_plugin.runtime.security import WorkspaceDebugTokenStore
 
 
 class RuntimeContext:
@@ -57,6 +58,7 @@ class RuntimeContext:
         self._workspace_binding_ready = asyncio.Event()
         self._installation_bindings: dict[str, InstallationBinding] = {}
         self._installation_watermarks: dict[str, InstallationBinding] = {}
+        self.workspace_debug_tokens = WorkspaceDebugTokenStore()
 
     def get_runtime_resource_stats(self) -> dict[str, Any]:
         """Return aggregate O(1) counters safe for public health probes."""

--- a/src/langbot_plugin/runtime/io/connections/ws.py
+++ b/src/langbot_plugin/runtime/io/connections/ws.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import websockets
 import asyncio
+from collections.abc import Mapping
 from websockets.exceptions import ConnectionClosed as WebSocketClosed
 
 from langbot_plugin.runtime.io import connection as io_connection
@@ -23,6 +24,7 @@ class WebSocketConnection(io_connection.Connection):
     ):
         self.websocket = websocket
         self.chunk_size = chunk_size
+        self.request_headers: Mapping[str, str] = {}
         self._send_lock = asyncio.Lock()  # 发送锁，防止并发发送冲突
 
     async def send(self, message: str) -> None:

--- a/src/langbot_plugin/runtime/io/controllers/ws/server.py
+++ b/src/langbot_plugin/runtime/io/controllers/ws/server.py
@@ -116,4 +116,7 @@ class WebSocketServerController(Controller):
     async def handle_connection(self, websocket: websockets.ServerConnection):
         logger.info(f"New connection from {websocket.remote_address}")
         connection = ws_connection.WebSocketConnection(websocket)
+        request = getattr(websocket, "request", None)
+        if request is not None:
+            connection.request_headers = request.headers
         await self._new_connection_callback(connection)

--- a/src/langbot_plugin/runtime/io/handlers/control.py
+++ b/src/langbot_plugin/runtime/io/handlers/control.py
@@ -667,7 +667,8 @@ class ControlConnectionHandler(handler.Handler):
             ):
                 raise ValueError("GET_DEBUG_INFO requires Workspace context")
             if self.context.runtime_identity is None or (
-                action_context.instance_uuid != self.context.runtime_identity.instance_uuid
+                action_context.instance_uuid
+                != self.context.runtime_identity.instance_uuid
             ):
                 raise ValueError("GET_DEBUG_INFO targets another Runtime instance")
             return action_context

--- a/src/langbot_plugin/runtime/io/handlers/control.py
+++ b/src/langbot_plugin/runtime/io/handlers/control.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncGenerator
 
 from langbot_plugin.runtime.io import connection, handler
 from langbot_plugin.entities.io.context import (
+    ActionContext,
     ActionEnvelopeContext,
     ApplyPluginInstallationRequest,
     InstallationBinding,
@@ -27,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 INSTANCE_SCOPED_CONTROL_ACTIONS = frozenset(
     {
-        LangBotToRuntimeAction.GET_DEBUG_INFO.value,
         LangBotToRuntimeAction.RECONCILE_PLUGIN_INSTALLATIONS.value,
         LangBotToRuntimeAction.SET_RUNTIME_CONFIG.value,
     }
@@ -37,6 +37,7 @@ INSTANCE_SCOPED_CONTROL_ACTIONS = frozenset(
 # added LangBot-to-Runtime action to choose a scope before it can ship.
 TENANT_SCOPED_CONTROL_ACTIONS = frozenset(
     {
+        LangBotToRuntimeAction.GET_DEBUG_INFO.value,
         LangBotToRuntimeAction.LIST_PLUGINS.value,
         LangBotToRuntimeAction.GET_PLUGIN_INFO.value,
         LangBotToRuntimeAction.GET_PLUGIN_ICON.value,
@@ -461,12 +462,17 @@ class ControlConnectionHandler(handler.Handler):
 
         @self.action(LangBotToRuntimeAction.GET_DEBUG_INFO)
         async def get_debug_info(data: dict[str, Any]) -> handler.ActionResponse:
-            """Get debug information including debug key and WS URL."""
-            from langbot_plugin.runtime.settings import settings as runtime_settings
+            """Get the current Workspace-scoped rotating debug credential."""
+
+            action_context = self.current_action_context
+            if action_context is None:
+                raise ValueError("GET_DEBUG_INFO requires Workspace context")
+            credential = self.context.workspace_debug_tokens.issue(action_context)
 
             return handler.ActionResponse.success(
                 {
-                    "plugin_debug_key": runtime_settings.plugin_debug_key,
+                    "plugin_debug_key": credential.token,
+                    "expires_at": credential.expires_at,
                     "ws_debug_port": self.context.ws_debug_port,
                     "resources": self.context.get_runtime_resource_stats(),
                 }
@@ -654,6 +660,17 @@ class ControlConnectionHandler(handler.Handler):
             if action_context is not None:
                 raise ValueError(f"{action} does not accept tenant context")
             return None
+
+        if action == LangBotToRuntimeAction.GET_DEBUG_INFO.value:
+            if not isinstance(action_context, ActionContext) or isinstance(
+                action_context, InstallationBinding
+            ):
+                raise ValueError("GET_DEBUG_INFO requires Workspace context")
+            if self.context.runtime_identity is None or (
+                action_context.instance_uuid != self.context.runtime_identity.instance_uuid
+            ):
+                raise ValueError("GET_DEBUG_INFO targets another Runtime instance")
+            return action_context
 
         if (
             self.context.runtime_profile == "shared"

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -169,7 +169,10 @@ class PluginConnectionHandler(handler.Handler):
                 debug_binding = self.context.workspace_debug_tokens.binding_for_token(
                     str(plugin_debug_key)
                 )
-                if debug_binding is None or debug_binding != self.debug_workspace_binding:
+                if (
+                    debug_binding is None
+                    or debug_binding != self.debug_workspace_binding
+                ):
                     logger.warning(
                         "Plugin debug key verification failed. Expected key does not match."
                     )

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import Any, AsyncGenerator
-import hmac
 import logging
 
 from langbot_plugin.runtime.io import handler, connection
@@ -14,7 +13,7 @@ from langbot_plugin.entities.io.actions.enums import (
 )
 from langbot_plugin.runtime import context as context_module
 import asyncio
-from langbot_plugin.runtime.settings import settings as runtime_settings
+
 from langbot_plugin.runtime.plugin.logbuffer import PluginLogBuffer
 from langbot_plugin.entities.io.context import (
     ActionContext,
@@ -49,6 +48,8 @@ class PluginConnectionHandler(handler.Handler):
 
     debug_plugin: bool = False
     """If this plugin is a debug plugin."""
+
+    debug_workspace_binding: ActionContext | None = None
 
     stdio_process: asyncio.subprocess.Process | None = None
     """The stdio process of the plugin."""
@@ -165,16 +166,17 @@ class PluginConnectionHandler(handler.Handler):
                 # Get the debug key from plugin data
                 plugin_debug_key = data.get("plugin_debug_key", "")
 
-                if not plugin_debug_key or not hmac.compare_digest(
-                    str(plugin_debug_key),
-                    str(runtime_settings.plugin_debug_key),
-                ):
+                debug_binding = self.context.workspace_debug_tokens.binding_for_token(
+                    str(plugin_debug_key)
+                )
+                if debug_binding is None or debug_binding != self.debug_workspace_binding:
                     logger.warning(
                         "Plugin debug key verification failed. Expected key does not match."
                     )
                     return handler.ActionResponse.error(
                         "Plugin debug key verification failed"
                     )
+                self.bind_action_context(debug_binding)
 
             await self.context.plugin_mgr.register_plugin(
                 self,

--- a/src/langbot_plugin/runtime/security.py
+++ b/src/langbot_plugin/runtime/security.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import re
+import secrets
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
 
 
 PLUGIN_RUNTIME_CONTROL_TOKEN_ENV = "LANGBOT_PLUGIN_RUNTIME_CONTROL_TOKEN"
@@ -11,6 +16,7 @@ PLUGIN_REGISTRATION_CAPABILITY_ENV = "LANGBOT_PLUGIN_REGISTRATION_CAPABILITY"
 PLUGIN_REGISTRATION_CAPABILITY_HEADER = "X-LangBot-Plugin-Registration-Capability"
 PLUGIN_RUNTIME_PROFILE_ENV = "LANGBOT_PLUGIN_RUNTIME_PROFILE"
 RUNTIME_SECRET_MIN_LENGTH = 32
+WORKSPACE_DEBUG_TOKEN_TTL_SECONDS = 2 * 60 * 60
 
 _SECRET_PATTERN = re.compile(r"^[^\s]{32,}$")
 
@@ -25,3 +31,53 @@ def validate_runtime_secret(value: str, *, name: str) -> str:
             f"{RUNTIME_SECRET_MIN_LENGTH} characters"
         )
     return secret
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceDebugCredential:
+    token: str
+    expires_at: str
+
+
+class WorkspaceDebugTokenStore:
+    """Issue one random debug credential per Workspace and rotation window."""
+
+    def __init__(self, *, clock=time.time, ttl_seconds: int = WORKSPACE_DEBUG_TOKEN_TTL_SECONDS):
+        self._clock = clock
+        self._ttl_seconds = ttl_seconds
+        self._credentials: dict[str, tuple[str, float, Any]] = {}
+
+    @staticmethod
+    def _format_time(timestamp: float) -> str:
+        return datetime.fromtimestamp(timestamp, timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def issue(self, binding: Any) -> WorkspaceDebugCredential:
+        workspace_uuid = str(getattr(binding, "workspace_uuid", "") or "").strip()
+        if not workspace_uuid:
+            raise ValueError("Workspace debug credentials require Workspace context")
+        now = float(self._clock())
+        token, expires, existing_binding = self._credentials.get(workspace_uuid, ("", 0.0, None))
+        if existing_binding is not None and (
+            getattr(existing_binding, "instance_uuid", None) != getattr(binding, "instance_uuid", None)
+            or getattr(existing_binding, "placement_generation", None)
+            != getattr(binding, "placement_generation", None)
+        ):
+            token, expires = "", 0.0
+        if not token or now >= expires:
+            token = secrets.token_urlsafe(48)
+            expires = now + self._ttl_seconds
+        self._credentials[workspace_uuid] = (token, expires, binding)
+        return WorkspaceDebugCredential(token=token, expires_at=self._format_time(expires))
+
+    def binding_for_token(self, supplied_token: str) -> Any | None:
+        supplied_token = str(supplied_token or "")
+        if not supplied_token:
+            return None
+        now = float(self._clock())
+        for workspace_uuid, (token, expires, binding) in tuple(self._credentials.items()):
+            if now >= expires:
+                self._credentials.pop(workspace_uuid, None)
+                continue
+            if secrets.compare_digest(token, supplied_token):
+                return binding
+        return None

--- a/src/langbot_plugin/runtime/security.py
+++ b/src/langbot_plugin/runtime/security.py
@@ -42,23 +42,32 @@ class WorkspaceDebugCredential:
 class WorkspaceDebugTokenStore:
     """Issue one random debug credential per Workspace and rotation window."""
 
-    def __init__(self, *, clock=time.time, ttl_seconds: int = WORKSPACE_DEBUG_TOKEN_TTL_SECONDS):
+    def __init__(
+        self, *, clock=time.time, ttl_seconds: int = WORKSPACE_DEBUG_TOKEN_TTL_SECONDS
+    ):
         self._clock = clock
         self._ttl_seconds = ttl_seconds
         self._credentials: dict[str, tuple[str, float, Any]] = {}
 
     @staticmethod
     def _format_time(timestamp: float) -> str:
-        return datetime.fromtimestamp(timestamp, timezone.utc).isoformat().replace("+00:00", "Z")
+        return (
+            datetime.fromtimestamp(timestamp, timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
 
     def issue(self, binding: Any) -> WorkspaceDebugCredential:
         workspace_uuid = str(getattr(binding, "workspace_uuid", "") or "").strip()
         if not workspace_uuid:
             raise ValueError("Workspace debug credentials require Workspace context")
         now = float(self._clock())
-        token, expires, existing_binding = self._credentials.get(workspace_uuid, ("", 0.0, None))
+        token, expires, existing_binding = self._credentials.get(
+            workspace_uuid, ("", 0.0, None)
+        )
         if existing_binding is not None and (
-            getattr(existing_binding, "instance_uuid", None) != getattr(binding, "instance_uuid", None)
+            getattr(existing_binding, "instance_uuid", None)
+            != getattr(binding, "instance_uuid", None)
             or getattr(existing_binding, "placement_generation", None)
             != getattr(binding, "placement_generation", None)
         ):
@@ -67,14 +76,18 @@ class WorkspaceDebugTokenStore:
             token = secrets.token_urlsafe(48)
             expires = now + self._ttl_seconds
         self._credentials[workspace_uuid] = (token, expires, binding)
-        return WorkspaceDebugCredential(token=token, expires_at=self._format_time(expires))
+        return WorkspaceDebugCredential(
+            token=token, expires_at=self._format_time(expires)
+        )
 
     def binding_for_token(self, supplied_token: str) -> Any | None:
         supplied_token = str(supplied_token or "")
         if not supplied_token:
             return None
         now = float(self._clock())
-        for workspace_uuid, (token, expires, binding) in tuple(self._credentials.items()):
+        for workspace_uuid, (token, expires, binding) in tuple(
+            self._credentials.items()
+        ):
             if now >= expires:
                 self._credentials.pop(workspace_uuid, None)
                 continue

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -431,20 +431,25 @@ async def test_control_handler_binds_runtime_once_to_identity_and_policy():
     assert "identity cannot be rebound" in rebound["message"]
 
 
-async def test_control_handler_get_debug_info_returns_runtime_settings(monkeypatch):
+async def test_control_handler_get_debug_info_returns_workspace_token():
     handler, _manager = _handler()
-    monkeypatch.setattr(runtime_settings, "plugin_debug_key", "debug-key")
+    workspace_context = ActionContext(
+        instance_uuid="instance-1",
+        workspace_uuid="workspace-a",
+        placement_generation=4,
+    )
 
     async with ProtocolSession(handler) as session:
         response = await session.request(
             LangBotToRuntimeAction.GET_DEBUG_INFO.value,
-            action_context=None,
+            action_context=workspace_context,
         )
 
-    assert response["data"] == {
-        "plugin_debug_key": "debug-key",
-        "ws_debug_port": 5401,
-        "resources": {
+    assert response["code"] == 0
+    assert len(response["data"]["plugin_debug_key"]) >= 32
+    assert response["data"]["expires_at"].endswith("Z")
+    assert response["data"]["ws_debug_port"] == 5401
+    assert response["data"]["resources"] == {
             "event_loop": {},
             "blocking_executor": {},
             "plugin_handlers": 0,
@@ -452,7 +457,6 @@ async def test_control_handler_get_debug_info_returns_runtime_settings(monkeypat
             "installation_runtimes": 0,
             "pending_registrations": 0,
             "restart_coordinator": {"configured": False},
-        },
     }
 
 

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -450,13 +450,13 @@ async def test_control_handler_get_debug_info_returns_workspace_token():
     assert response["data"]["expires_at"].endswith("Z")
     assert response["data"]["ws_debug_port"] == 5401
     assert response["data"]["resources"] == {
-            "event_loop": {},
-            "blocking_executor": {},
-            "plugin_handlers": 0,
-            "legacy_supervisors": 0,
-            "installation_runtimes": 0,
-            "pending_registrations": 0,
-            "restart_coordinator": {"configured": False},
+        "event_loop": {},
+        "blocking_executor": {},
+        "plugin_handlers": 0,
+        "legacy_supervisors": 0,
+        "installation_runtimes": 0,
+        "pending_registrations": 0,
+        "restart_coordinator": {"configured": False},
     }
 
 

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -137,20 +137,22 @@ def _handler(debug_plugin=False, action_context=None):
         control_handler=control_handler,
         plugin_mgr=manager,
         workspace_binding=action_context,
+        workspace_debug_tokens=SimpleNamespace(
+            binding_for_token=lambda token: action_context if token == "key" else None
+        ),
     )
     handler = PluginConnectionHandler(
         ProtocolConnection(),
         context,
         debug_plugin=debug_plugin,
     )
+    handler.debug_workspace_binding = action_context
     return handler, manager, control_handler
 
 
-async def test_plugin_handler_registers_plugin_when_debug_key_matches(monkeypatch):
-    handler, manager, _control = _handler(debug_plugin=True)
-    monkeypatch.setattr(
-        plugin_handler_module.runtime_settings, "plugin_debug_key", "key"
-    )
+async def test_plugin_handler_registers_plugin_when_debug_key_matches():
+    binding = ActionContext(instance_uuid="i", workspace_uuid="w", placement_generation=1)
+    handler, manager, _control = _handler(debug_plugin=True, action_context=binding)
 
     async with ProtocolSession(handler) as session:
         response = await session.request(
@@ -190,11 +192,9 @@ def test_shared_plugin_handler_rejects_unregistered_and_revoked_worker_actions()
         )
 
 
-async def test_plugin_handler_rejects_plugin_with_invalid_debug_key(monkeypatch):
-    handler, manager, _control = _handler(debug_plugin=True)
-    monkeypatch.setattr(
-        plugin_handler_module.runtime_settings, "plugin_debug_key", "key"
-    )
+async def test_plugin_handler_rejects_plugin_with_invalid_debug_key():
+    binding = ActionContext(instance_uuid="i", workspace_uuid="w", placement_generation=1)
+    handler, manager, _control = _handler(debug_plugin=True, action_context=binding)
 
     async with ProtocolSession(handler) as session:
         response = await session.request(
@@ -207,9 +207,8 @@ async def test_plugin_handler_rejects_plugin_with_invalid_debug_key(monkeypatch)
     assert manager.calls == []
 
 
-async def test_plugin_handler_prod_registration_disables_debug_mode(monkeypatch):
+async def test_plugin_handler_prod_registration_disables_debug_mode():
     handler, manager, _control = _handler(debug_plugin=True)
-    monkeypatch.setattr(plugin_handler_module.runtime_settings, "plugin_debug_key", "")
 
     async with ProtocolSession(handler) as session:
         response = await session.request(
@@ -234,13 +233,8 @@ async def test_plugin_handler_prod_registration_disables_debug_mode(monkeypatch)
     ]
 
 
-async def test_plugin_handler_rejects_prod_registration_without_capability(
-    monkeypatch,
-):
+async def test_plugin_handler_rejects_prod_registration_without_capability():
     handler, manager, _control = _handler(debug_plugin=True)
-    monkeypatch.setattr(
-        plugin_handler_module.runtime_settings, "plugin_debug_key", "key"
-    )
 
     async with ProtocolSession(handler) as session:
         response = await session.request(

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -151,7 +151,9 @@ def _handler(debug_plugin=False, action_context=None):
 
 
 async def test_plugin_handler_registers_plugin_when_debug_key_matches():
-    binding = ActionContext(instance_uuid="i", workspace_uuid="w", placement_generation=1)
+    binding = ActionContext(
+        instance_uuid="i", workspace_uuid="w", placement_generation=1
+    )
     handler, manager, _control = _handler(debug_plugin=True, action_context=binding)
 
     async with ProtocolSession(handler) as session:
@@ -193,7 +195,9 @@ def test_shared_plugin_handler_rejects_unregistered_and_revoked_worker_actions()
 
 
 async def test_plugin_handler_rejects_plugin_with_invalid_debug_key():
-    binding = ActionContext(instance_uuid="i", workspace_uuid="w", placement_generation=1)
+    binding = ActionContext(
+        instance_uuid="i", workspace_uuid="w", placement_generation=1
+    )
     handler, manager, _control = _handler(debug_plugin=True, action_context=binding)
 
     async with ProtocolSession(handler) as session:

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -232,7 +232,9 @@ def test_workspace_debug_tokens_are_distinct_and_rotate(monkeypatch):
     app = runtime_app.RuntimeApplication(_args(stdio_control=True))
     app.context.workspace_debug_tokens._clock = lambda: now[0]
     first = ActionContext(instance_uuid="i", workspace_uuid="a", placement_generation=1)
-    second = ActionContext(instance_uuid="i", workspace_uuid="b", placement_generation=1)
+    second = ActionContext(
+        instance_uuid="i", workspace_uuid="b", placement_generation=1
+    )
 
     first_token = app.context.workspace_debug_tokens.issue(first).token
     assert app.context.workspace_debug_tokens.issue(first).token == first_token
@@ -244,7 +246,6 @@ def test_workspace_debug_tokens_are_distinct_and_rotate(monkeypatch):
     assert rotated != first_token
     assert not app._authenticate_plugin_request({PLUGIN_DEBUG_KEY_HEADER: first_token})
     assert app._authenticate_plugin_request({PLUGIN_DEBUG_KEY_HEADER: rotated})
-
 
 
 async def test_set_control_handler_runs_handler(monkeypatch):

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -14,6 +14,7 @@ from langbot_plugin.runtime.security import (
     PLUGIN_RUNTIME_CONTROL_TOKEN_HEADER,
 )
 from langbot_plugin.entities.io.context import (
+    ActionContext,
     PluginWorkerPolicy,
     RuntimeIdentity,
 )
@@ -138,7 +139,6 @@ def _configure_runtime(app, profile="oss_dev"):
 
 @pytest.fixture(autouse=True)
 def _runtime_secrets(monkeypatch):
-    monkeypatch.setattr(runtime_app.settings, "plugin_debug_key", "")
     monkeypatch.setenv(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV, "c" * 48)
 
 
@@ -171,11 +171,8 @@ def test_runtime_application_initializes_stdio_control_mode(monkeypatch):
     assert isinstance(app.context.stdio_server, FakeServerController)
     assert app.context.ws_control_server is None
     assert app.context.ws_debug_server.port == 5401
-    assert len(runtime_app.settings.plugin_debug_key) >= 32
     authenticator = app.context.ws_debug_server.kwargs["request_authenticator"]
-    assert authenticator(
-        {PLUGIN_DEBUG_KEY_HEADER: runtime_app.settings.plugin_debug_key}
-    )
+    assert not authenticator({PLUGIN_DEBUG_KEY_HEADER: "legacy-static-key"})
     assert authenticator(
         {PLUGIN_REGISTRATION_CAPABILITY_HEADER: ("pending-registration-capability")}
     )
@@ -219,20 +216,35 @@ def test_runtime_application_initializes_websocket_control_mode(monkeypatch):
     assert app.context.ws_debug_server.port == 5501
 
 
-def test_runtime_application_rejects_websocket_control_without_secret(monkeypatch):
+def test_runtime_application_allows_websocket_control_without_secret(monkeypatch):
     monkeypatch.setattr(runtime_app.plugin_mgr_cls, "PluginManager", FakePluginManager)
     monkeypatch.delenv(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV)
 
-    with pytest.raises(ValueError, match=PLUGIN_RUNTIME_CONTROL_TOKEN_ENV):
-        runtime_app.RuntimeApplication(_args(stdio_control=False))
+    app = runtime_app.RuntimeApplication(_args(stdio_control=False))
+
+    assert app.context.ws_control_server is not None
+    assert app.context.ws_control_server.expected_headers == {}
 
 
-def test_runtime_application_rejects_weak_configured_debug_key(monkeypatch):
+def test_workspace_debug_tokens_are_distinct_and_rotate(monkeypatch):
     monkeypatch.setattr(runtime_app.plugin_mgr_cls, "PluginManager", FakePluginManager)
-    monkeypatch.setattr(runtime_app.settings, "plugin_debug_key", "short")
+    now = [1_000.0]
+    app = runtime_app.RuntimeApplication(_args(stdio_control=True))
+    app.context.workspace_debug_tokens._clock = lambda: now[0]
+    first = ActionContext(instance_uuid="i", workspace_uuid="a", placement_generation=1)
+    second = ActionContext(instance_uuid="i", workspace_uuid="b", placement_generation=1)
 
-    with pytest.raises(ValueError, match="PLUGIN_DEBUG_KEY"):
-        runtime_app.RuntimeApplication(_args(stdio_control=True))
+    first_token = app.context.workspace_debug_tokens.issue(first).token
+    assert app.context.workspace_debug_tokens.issue(first).token == first_token
+    assert app.context.workspace_debug_tokens.issue(second).token != first_token
+    assert app._authenticate_plugin_request({PLUGIN_DEBUG_KEY_HEADER: first_token})
+
+    now[0] += 2 * 60 * 60
+    rotated = app.context.workspace_debug_tokens.issue(first).token
+    assert rotated != first_token
+    assert not app._authenticate_plugin_request({PLUGIN_DEBUG_KEY_HEADER: first_token})
+    assert app._authenticate_plugin_request({PLUGIN_DEBUG_KEY_HEADER: rotated})
+
 
 
 async def test_set_control_handler_runs_handler(monkeypatch):


### PR DESCRIPTION
Make the OSS control-channel token optional when both sides omit it. Add random per-Workspace plugin debug credentials that rotate every two hours and bind accepted debug sockets to the authenticated Workspace.

Verification: ruff; full pytest (1122 passed).