### PR TITLE
fix: propagate debug Workspace through registration

### DIFF
--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -50,6 +50,7 @@ from langbot_plugin.entities.io.errors import (
 )
 from langbot_plugin.runtime.security import PLUGIN_REGISTRATION_CAPABILITY_ENV
 from langbot_plugin.entities.io.context import (
+    ActionContext,
     InstallationBinding,
     PluginInstallationDesiredState,
     PluginWorkerPolicy,
@@ -1713,6 +1714,7 @@ class PluginManager:
 
         installation_binding: InstallationBinding | None = None
         installation_runtime: PluginInstallationRuntime | None = None
+        runtime_binding: ActionContext | None = None
         if debug_plugin:
             if registration_capability:
                 raise ValueError(
@@ -1756,8 +1758,9 @@ class PluginManager:
 
             # if it's a debug plugin, we need to initialize the plugin settings first
             if debug_plugin:
-                # Debug plugins preserve the OSS single-Workspace flow.
-                runtime_binding = await self.context.wait_for_workspace_binding()
+                runtime_binding = handler.bound_action_context
+                if not isinstance(runtime_binding, ActionContext):
+                    raise ValueError("Debug plugin is not bound to a Workspace")
                 await self.context.control_handler.call_action(
                     RuntimeToLangBotAction.INITIALIZE_PLUGIN_SETTINGS,
                     {
@@ -1766,23 +1769,25 @@ class PluginManager:
                         "install_source": PluginInstallSource.DEBUG.value,
                         "install_info": {},
                     },
+                    action_context=runtime_binding,
                 )
             elif installation_binding is None:
                 # Temporary OSS compatibility for legacy data/plugins launches.
                 runtime_binding = await self.context.wait_for_workspace_binding()
 
             # get plugin settings from LangBot
+            settings_kwargs: dict[str, typing.Any] = {}
+            if installation_binding is not None or debug_plugin:
+                settings_kwargs["action_context"] = (
+                    installation_binding or runtime_binding
+                )
             plugin_settings = await self.context.control_handler.call_action(
                 RuntimeToLangBotAction.GET_PLUGIN_SETTINGS,
                 {
                     "plugin_author": plugin_author,
                     "plugin_name": plugin_name,
                 },
-                **(
-                    {"action_context": installation_binding}
-                    if installation_binding is not None
-                    else {}
-                ),
+                **settings_kwargs,
             )
         except Exception as e:
             raise ValueError(
@@ -1805,6 +1810,8 @@ class PluginManager:
                 raise ValueError(
                     "LangBot did not provide a trusted plugin installation capability"
                 )
+            if runtime_binding is None:
+                raise ValueError("Plugin Runtime is not bound to a Workspace")
             handler.bind_action_context(
                 runtime_binding.for_installation(installation_uuid.strip())
             )

--- a/tests/runtime/plugin/test_manager.py
+++ b/tests/runtime/plugin/test_manager.py
@@ -171,9 +171,11 @@ spec: {{}}
 class FakeControlHandler:
     def __init__(self):
         self.calls: list[tuple[Any, dict[str, Any]]] = []
+        self.contexts: list[ActionContext | None] = []
 
-    async def call_action(self, action, payload):
+    async def call_action(self, action, payload, *, action_context=None):
         self.calls.append((action, payload))
+        self.contexts.append(action_context)
         return {
             "enabled": True,
             "priority": 7,
@@ -1032,8 +1034,10 @@ async def test_register_plugin_rejects_missing_installation_capability():
     manager = _manager()
     control_handler = FakeControlHandler()
 
-    async def settings_without_installation(action, payload):
-        result = await FakeControlHandler.call_action(control_handler, action, payload)
+    async def settings_without_installation(action, payload, *, action_context=None):
+        result = await FakeControlHandler.call_action(
+            control_handler, action, payload, action_context=action_context
+        )
         result.pop("installation_uuid")
         return result
 
@@ -1060,8 +1064,14 @@ async def test_register_debug_plugin_initializes_settings_first():
     plugin = _plugin(name="debug", status=RuntimeContainerStatus.MOUNTED)
     handler = FakeHandler(plugin)
     handler.debug_plugin = True
+    handler.bound_action_context = manager.context.workspace_binding
 
     await manager.register_plugin(handler, plugin.model_dump(), debug_plugin=True)
+
+    assert control_handler.contexts[:2] == [
+        manager.context.workspace_binding,
+        manager.context.workspace_binding,
+    ]
 
     assert [call[0] for call in control_handler.calls] == [
         RuntimeToLangBotAction.INITIALIZE_PLUGIN_SETTINGS,


### PR DESCRIPTION
Bind debug plugin settings initialization and lookup to the Workspace authenticated by the rotating debug token. Prevents fallback to the Runtime default Workspace.\n\nVerification: ruff; full pytest (1122 passed).