### PR TITLE
fix: fence optional control and rotating debug sessions

### DIFF
--- a/src/langbot_plugin/runtime/app.py
+++ b/src/langbot_plugin/runtime/app.py
@@ -89,9 +89,21 @@ class RuntimeApplication:
                         name=PLUGIN_RUNTIME_CONTROL_TOKEN_ENV,
                     )
                 )
+            allow_network_without_token = str(
+                os.environ.get(
+                    "LANGBOT_PLUGIN_RUNTIME_ALLOW_UNAUTHENTICATED_NETWORK_CONTROL",
+                    "",
+                )
+            ).strip().lower() in {"1", "true", "yes"}
+            control_host = (
+                "0.0.0.0"
+                if configured_control_token or allow_network_without_token
+                else "127.0.0.1"
+            )
             self.context.ws_control_server = (
                 ws_controller_server.WebSocketServerController(
                     self.args.ws_control_port,
+                    host=control_host,
                     expected_headers=expected_headers,
                     health_snapshot_provider=self._health_snapshot,
                 )
@@ -239,6 +251,9 @@ class RuntimeApplication:
                 self.context.workspace_debug_tokens.binding_for_token(
                     str(request_headers.get(PLUGIN_DEBUG_KEY_HEADER) or "")
                 )
+            )
+            plugin_handler.debug_auth_token = str(
+                request_headers.get(PLUGIN_DEBUG_KEY_HEADER) or ""
             )
 
             await self.context.plugin_mgr.add_plugin_handler(plugin_handler)

--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -50,6 +50,7 @@ class PluginConnectionHandler(handler.Handler):
     """If this plugin is a debug plugin."""
 
     debug_workspace_binding: ActionContext | None = None
+    debug_auth_token: str | None = None
 
     stdio_process: asyncio.subprocess.Process | None = None
     """The stdio process of the plugin."""
@@ -91,6 +92,7 @@ class PluginConnectionHandler(handler.Handler):
         self.context = context
         self.name = "FromPlugin"
         self.debug_plugin = debug_plugin
+        self.debug_auth_token = None
         self.stdio_process = stdio_process
         runtime_binding = getattr(self.context, "workspace_binding", None)
         if runtime_binding is not None and (
@@ -732,7 +734,21 @@ class PluginConnectionHandler(handler.Handler):
     ) -> ActionEnvelopeContext | None:
         """Fence production worker actions to the consumed launch capability."""
 
-        if self.debug_plugin:
+        if self.debug_plugin and not (
+            action == PluginToRuntimeAction.REGISTER_PLUGIN.value
+            and not self.debug_auth_token
+        ):
+            if self.debug_auth_token:
+                current_binding = self.context.workspace_debug_tokens.binding_for_token(
+                    self.debug_auth_token
+                )
+                if current_binding is None:
+                    raise ValueError("Workspace debug credential expired")
+                if (
+                    self.debug_workspace_binding is None
+                    or not self.debug_workspace_binding.same_workspace(current_binding)
+                ):
+                    raise ValueError("Workspace debug credential was fenced")
             return super().validate_inbound_action_context(action, action_context)
 
         if action == PluginToRuntimeAction.REGISTER_PLUGIN.value:

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -131,6 +131,7 @@ def _installation_binding(runtime_revision=1):
 
 
 def _handler(debug_plugin=False, action_context=None):
+    valid_tokens = {"key"}
     control_handler = FakeControlHandler()
     manager = FakePluginManager()
     context = SimpleNamespace(
@@ -138,7 +139,9 @@ def _handler(debug_plugin=False, action_context=None):
         plugin_mgr=manager,
         workspace_binding=action_context,
         workspace_debug_tokens=SimpleNamespace(
-            binding_for_token=lambda token: action_context if token == "key" else None
+            binding_for_token=lambda token: action_context
+            if token in valid_tokens
+            else None
         ),
     )
     handler = PluginConnectionHandler(
@@ -147,7 +150,30 @@ def _handler(debug_plugin=False, action_context=None):
         debug_plugin=debug_plugin,
     )
     handler.debug_workspace_binding = action_context
+    handler.debug_auth_token = (
+        "key" if debug_plugin and action_context is not None else None
+    )
     return handler, manager, control_handler
+
+
+async def test_debug_handler_rejects_actions_after_credential_expiry():
+    binding = ActionContext(
+        instance_uuid="i", workspace_uuid="w", placement_generation=1
+    )
+    handler, _manager, _control = _handler(debug_plugin=True, action_context=binding)
+    handler.bind_action_context(binding)
+    handler.context.workspace_debug_tokens.binding_for_token = (
+        lambda supplied_token: None
+    )
+
+    async with ProtocolSession(handler) as session:
+        response = await session.request(
+            PluginToRuntimeAction.GET_BOTS.value,
+            {},
+        )
+
+    assert response["code"] != 0
+    assert "expired" in response["message"].lower()
 
 
 async def test_plugin_handler_registers_plugin_when_debug_key_matches():

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -216,7 +216,7 @@ def test_runtime_application_initializes_websocket_control_mode(monkeypatch):
     assert app.context.ws_debug_server.port == 5501
 
 
-def test_runtime_application_allows_websocket_control_without_secret(monkeypatch):
+def test_runtime_application_binds_unauthenticated_control_to_loopback(monkeypatch):
     monkeypatch.setattr(runtime_app.plugin_mgr_cls, "PluginManager", FakePluginManager)
     monkeypatch.delenv(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV)
 
@@ -224,6 +224,21 @@ def test_runtime_application_allows_websocket_control_without_secret(monkeypatch
 
     assert app.context.ws_control_server is not None
     assert app.context.ws_control_server.expected_headers == {}
+    assert app.context.ws_control_server.host == "127.0.0.1"
+
+
+def test_runtime_application_allows_explicit_trusted_network_control_without_secret(
+    monkeypatch,
+):
+    monkeypatch.setattr(runtime_app.plugin_mgr_cls, "PluginManager", FakePluginManager)
+    monkeypatch.delenv(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV)
+    monkeypatch.setenv(
+        "LANGBOT_PLUGIN_RUNTIME_ALLOW_UNAUTHENTICATED_NETWORK_CONTROL", "true"
+    )
+
+    app = runtime_app.RuntimeApplication(_args(stdio_control=False))
+
+    assert app.context.ws_control_server.host == "0.0.0.0"
 
 
 def test_workspace_debug_tokens_are_distinct_and_rotate(monkeypatch):


### PR DESCRIPTION
Closes the blocker/high findings from the post-merge cross-repository review.\n\n- tokenless WS control binds to loopback by default\n- trusted container networks require an explicit opt-in\n- established debug connections revalidate their Workspace credential on every action, so expiry/rotation/generation fencing takes effect\n\nVerification: ruff; full pytest (1124 passed).