### PR TITLE
fix: bind runtime control to all interfaces

### DIFF
--- a/src/langbot_plugin/runtime/app.py
+++ b/src/langbot_plugin/runtime/app.py
@@ -89,17 +89,7 @@ class RuntimeApplication:
                         name=PLUGIN_RUNTIME_CONTROL_TOKEN_ENV,
                     )
                 )
-            allow_network_without_token = str(
-                os.environ.get(
-                    "LANGBOT_PLUGIN_RUNTIME_ALLOW_UNAUTHENTICATED_NETWORK_CONTROL",
-                    "",
-                )
-            ).strip().lower() in {"1", "true", "yes"}
-            control_host = (
-                "0.0.0.0"
-                if configured_control_token or allow_network_without_token
-                else "127.0.0.1"
-            )
+            control_host = "0.0.0.0"
             self.context.ws_control_server = (
                 ws_controller_server.WebSocketServerController(
                     self.args.ws_control_port,

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -216,7 +216,9 @@ def test_runtime_application_initializes_websocket_control_mode(monkeypatch):
     assert app.context.ws_debug_server.port == 5501
 
 
-def test_runtime_application_binds_unauthenticated_control_to_loopback(monkeypatch):
+def test_runtime_application_binds_unauthenticated_control_to_all_interfaces(
+    monkeypatch,
+):
     monkeypatch.setattr(runtime_app.plugin_mgr_cls, "PluginManager", FakePluginManager)
     monkeypatch.delenv(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV)
 
@@ -224,20 +226,6 @@ def test_runtime_application_binds_unauthenticated_control_to_loopback(monkeypat
 
     assert app.context.ws_control_server is not None
     assert app.context.ws_control_server.expected_headers == {}
-    assert app.context.ws_control_server.host == "127.0.0.1"
-
-
-def test_runtime_application_allows_explicit_trusted_network_control_without_secret(
-    monkeypatch,
-):
-    monkeypatch.setattr(runtime_app.plugin_mgr_cls, "PluginManager", FakePluginManager)
-    monkeypatch.delenv(PLUGIN_RUNTIME_CONTROL_TOKEN_ENV)
-    monkeypatch.setenv(
-        "LANGBOT_PLUGIN_RUNTIME_ALLOW_UNAUTHENTICATED_NETWORK_CONTROL", "true"
-    )
-
-    app = runtime_app.RuntimeApplication(_args(stdio_control=False))
-
     assert app.context.ws_control_server.host == "0.0.0.0"
 
 


### PR DESCRIPTION
## Summary
- always bind Runtime WebSocket control to `0.0.0.0`
- remove `LANGBOT_PLUGIN_RUNTIME_ALLOW_UNAUTHENTICATED_NETWORK_CONTROL`
- preserve optional control-token header validation

## Verification
- ruff format/check
- runtime app tests: 18 passed
- full suite: 1123 passed
- git diff --check