### PR TITLE
fix: bridge RAG file transfers across scoped handlers

### DIFF
--- a/src/langbot_plugin/runtime/io/handlers/plugin.py
+++ b/src/langbot_plugin/runtime/io/handlers/plugin.py
@@ -426,11 +426,14 @@ class PluginConnectionHandler(handler.Handler):
                 data,
                 timeout=60,
             )
-            # LangBot sent the file via FILE_CHUNK; read from local temp
+            # LangBot sent the file to the control connection's transfer
+            # storage. Repackage it into this plugin connection's isolated
+            # transfer storage before returning the new key to the plugin.
             file_key = result.get("file_key", "")
             if file_key:
-                file_bytes = await self.read_local_file(file_key)
-                await self.delete_local_file(file_key)
+                control_handler = self.context.control_handler
+                file_bytes = await control_handler.read_local_file(file_key)
+                await control_handler.delete_local_file(file_key)
                 # Forward to plugin subprocess via chunked transfer
                 plugin_file_key = await self.send_file(file_bytes, "")
                 return handler.ActionResponse.success({"file_key": plugin_file_key})

--- a/tests/runtime/io/handlers/test_plugin_handler.py
+++ b/tests/runtime/io/handlers/test_plugin_handler.py
@@ -678,19 +678,25 @@ async def test_plugin_handler_get_knowledge_file_stream_repackages_file(monkeypa
         "file_key": "host-file"
     }
 
-    async def fake_read_local_file(file_key):
-        file_ops.append(("read", file_key))
+    async def fake_read_control_file(file_key):
+        file_ops.append(("control-read", file_key))
         return b"file-bytes"
 
-    async def fake_delete_local_file(file_key):
-        file_ops.append(("delete", file_key))
+    async def fake_delete_control_file(file_key):
+        file_ops.append(("control-delete", file_key))
+
+    async def reject_plugin_storage_read(file_key):
+        raise AssertionError(
+            f"host file must not be read from plugin storage: {file_key}"
+        )
 
     async def fake_send_file(file_bytes, extension):
         file_ops.append(("send", file_bytes, extension))
         return "plugin-file"
 
-    monkeypatch.setattr(handler, "read_local_file", fake_read_local_file)
-    monkeypatch.setattr(handler, "delete_local_file", fake_delete_local_file)
+    control.read_local_file = fake_read_control_file
+    control.delete_local_file = fake_delete_control_file
+    monkeypatch.setattr(handler, "read_local_file", reject_plugin_storage_read)
     monkeypatch.setattr(handler, "send_file", fake_send_file)
 
     async with ProtocolSession(handler) as session:
@@ -700,8 +706,8 @@ async def test_plugin_handler_get_knowledge_file_stream_repackages_file(monkeypa
         )
 
     assert file_ops == [
-        ("read", "host-file"),
-        ("delete", "host-file"),
+        ("control-read", "host-file"),
+        ("control-delete", "host-file"),
         ("send", b"file-bytes", ""),
     ]
     assert response["data"] == {"file_key": "plugin-file"}


### PR DESCRIPTION
## Summary
- read Host file chunks from the control handler transfer scope
- repackage bytes into the isolated plugin handler transfer scope
- add regression coverage proving the wrong scope is never read

## Root cause
In shared Runtime, Host -> Runtime FILE_CHUNK data belongs to the control connection, while Runtime -> plugin data belongs to the per-installation plugin connection. The proxy incorrectly read the Host key from the plugin connection scope, causing deterministic FileNotFoundError during every knowledge ingestion.

## Verification
- 1123 passed
- ruff check src tests
- ruff format --check src tests
- git diff --check