### PR TITLE
fix(runtime): remove aggregate plugin worker admission

### DIFF
--- a/src/langbot_plugin/api/proxies/langbot_api.py
+++ b/src/langbot_plugin/api/proxies/langbot_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 from typing import Any
 
@@ -178,7 +177,7 @@ class LangBotAPIProxy:
 
     async def set_plugin_storage(self, key: str, value: bytes) -> None:
         """Set a plugin storage value"""
-        encoded = (await asyncio.to_thread(base64.b64encode, value)).decode("utf-8")
+        encoded = base64.b64encode(value).decode("utf-8")
         await self.plugin_runtime_handler.call_action(
             PluginToRuntimeAction.SET_PLUGIN_STORAGE,
             {"key": key, "value_base64": encoded},
@@ -192,7 +191,7 @@ class LangBotAPIProxy:
             )
         )["value_base64"]
 
-        return await asyncio.to_thread(base64.b64decode, resp)
+        return base64.b64decode(resp)
 
     async def get_plugin_storage_keys(self) -> list[str]:
         """Get all plugin storage keys"""
@@ -210,7 +209,7 @@ class LangBotAPIProxy:
 
     async def set_workspace_storage(self, key: str, value: bytes) -> None:
         """Set a workspace storage value"""
-        encoded = (await asyncio.to_thread(base64.b64encode, value)).decode("utf-8")
+        encoded = base64.b64encode(value).decode("utf-8")
         await self.plugin_runtime_handler.call_action(
             PluginToRuntimeAction.SET_WORKSPACE_STORAGE,
             {"key": key, "value_base64": encoded},
@@ -224,7 +223,7 @@ class LangBotAPIProxy:
             )
         )["value_base64"]
 
-        return await asyncio.to_thread(base64.b64decode, resp)
+        return base64.b64decode(resp)
 
     async def get_workspace_storage_keys(self) -> list[str]:
         """Get all workspace storage keys"""
@@ -255,7 +254,7 @@ class LangBotAPIProxy:
             )
         )["file_base64"]
 
-        return await asyncio.to_thread(base64.b64decode, resp)
+        return base64.b64decode(resp)
 
     async def list_plugins_manifest(self) -> list[str]:
         """List all plugins"""

--- a/src/langbot_plugin/cli/run/handler.py
+++ b/src/langbot_plugin/cli/run/handler.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 import mimetypes
 import typing
-import aiofiles
 import logging
 from copy import deepcopy
 from pathlib import Path
@@ -43,12 +42,13 @@ MAX_RUNTIME_UI_FILE_BYTES = 4 * 1024 * 1024
 
 
 async def _read_runtime_ui_file_limited(path: str | Path) -> bytes:
-    if await asyncio.to_thread(os.path.getsize, path) > MAX_RUNTIME_UI_FILE_BYTES:
+    file_path = Path(path)
+    if file_path.stat().st_size > MAX_RUNTIME_UI_FILE_BYTES:
         raise ValueError(
             f"Plugin UI file exceeds the {MAX_RUNTIME_UI_FILE_BYTES}-byte limit"
         )
-    async with aiofiles.open(path, "rb") as file:
-        content = await file.read(MAX_RUNTIME_UI_FILE_BYTES + 1)
+    with file_path.open("rb") as file:
+        content = file.read(MAX_RUNTIME_UI_FILE_BYTES + 1)
     if len(content) > MAX_RUNTIME_UI_FILE_BYTES:
         raise ValueError(
             f"Plugin UI file exceeds the {MAX_RUNTIME_UI_FILE_BYTES}-byte limit"

--- a/src/langbot_plugin/entities/io/context.py
+++ b/src/langbot_plugin/entities/io/context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import math
 import re
 from typing import Literal
@@ -39,6 +40,7 @@ class PluginWorkerPolicy(pydantic.BaseModel):
     max_total_cpus: float = 8.0
     max_total_memory_mb: int = 8192
     max_installations: int = 10_000
+    max_pending_registrations: int = 1024
     max_concurrent_restarts: int = 1
     restart_failure_threshold: int = 8
     restart_failure_window_seconds: float = 30.0
@@ -62,6 +64,7 @@ class PluginWorkerPolicy(pydantic.BaseModel):
         "max_workers",
         "max_total_memory_mb",
         "max_installations",
+        "max_pending_registrations",
         "max_concurrent_restarts",
         "restart_failure_threshold",
         mode="before",
@@ -112,6 +115,7 @@ class PluginWorkerPolicy(pydantic.BaseModel):
         "max_workers",
         "max_total_memory_mb",
         "max_installations",
+        "max_pending_registrations",
         "max_concurrent_restarts",
         "restart_failure_threshold",
     )
@@ -129,10 +133,6 @@ class PluginWorkerPolicy(pydantic.BaseModel):
             raise ValueError("max_total_memory_mb cannot be lower than max_memory_mb")
         if self.max_installations < self.max_workers:
             raise ValueError("max_installations cannot be lower than max_workers")
-        if self.max_concurrent_restarts > self.effective_worker_capacity:
-            raise ValueError(
-                "max_concurrent_restarts cannot exceed effective worker capacity"
-            )
         if self.restart_failure_threshold > self.max_installations:
             raise ValueError(
                 "restart_failure_threshold cannot exceed max_installations"
@@ -291,6 +291,31 @@ class RuntimeConfig(pydantic.BaseModel):
     cloud_service_url: str | None = None
 
     model_config = pydantic.ConfigDict(extra="forbid", frozen=True)
+
+    def model_dump(self, **kwargs):
+        include_pending_registration_limit = kwargs.pop(
+            "include_pending_registration_limit",
+            False,
+        )
+        payload = super().model_dump(**kwargs)
+        if not include_pending_registration_limit and isinstance(
+            payload.get("worker_policy"),
+            dict,
+        ):
+            payload["worker_policy"].pop("max_pending_registrations", None)
+        return payload
+
+    def model_dump_json(self, **kwargs) -> str:
+        include_pending_registration_limit = kwargs.pop(
+            "include_pending_registration_limit",
+            False,
+        )
+        return json.dumps(
+            self.model_dump(
+                include_pending_registration_limit=include_pending_registration_limit,
+                **kwargs,
+            )
+        )
 
     @pydantic.field_validator("cloud_service_url")
     @classmethod

--- a/src/langbot_plugin/runtime/context.py
+++ b/src/langbot_plugin/runtime/context.py
@@ -70,6 +70,17 @@ class RuntimeContext:
             getattr(plugin_manager, "handlers", ()),
         )
         event_loop_monitor = self.event_loop_monitor
+        installation_state_counts = {
+            "running": 0,
+            "starting": 0,
+            "failed": 0,
+            "disabled": 0,
+        }
+        for runtime in getattr(plugin_manager, "_installations", {}).values():
+            state = str(getattr(runtime, "state", "disabled"))
+            if state in installation_state_counts:
+                installation_state_counts[state] += 1
+
         return {
             "event_loop": (
                 event_loop_monitor.snapshot() if event_loop_monitor is not None else {}
@@ -84,6 +95,7 @@ class RuntimeContext:
                 getattr(plugin_manager, "_plugin_supervisors", ())
             ),
             "installation_runtimes": len(getattr(plugin_manager, "_installations", ())),
+            "installation_states": installation_state_counts,
             "pending_registrations": len(
                 getattr(plugin_manager, "_pending_registrations", ())
             ),
@@ -286,6 +298,49 @@ class RuntimeContext:
         del self._installation_bindings[binding.installation_uuid]
         self._installation_watermarks[binding.installation_uuid] = binding
         return binding
+
+    def reconcile_installation_watermarks(
+        self,
+        authoritative_bindings: tuple[InstallationBinding, ...],
+    ) -> None:
+        """Drop inactive historical fences absent from an authoritative replay."""
+
+        for binding in self.inactive_installation_watermark_snapshots(
+            authoritative_bindings
+        ):
+            self.drop_installation_watermark_if_current(binding)
+
+    def inactive_installation_watermark_snapshots(
+        self,
+        authoritative_bindings: tuple[InstallationBinding, ...],
+    ) -> tuple[InstallationBinding, ...]:
+        """Return inactive watermark values eligible for authoritative GC."""
+
+        authoritative_uuids = {
+            binding.installation_uuid for binding in authoritative_bindings
+        }
+        snapshots: list[InstallationBinding] = []
+        for installation_uuid, watermark in list(self._installation_watermarks.items()):
+            if installation_uuid in authoritative_uuids:
+                continue
+            if installation_uuid in self._installation_bindings:
+                continue
+            snapshots.append(watermark)
+        return tuple(snapshots)
+
+    def drop_installation_watermark_if_current(
+        self,
+        binding: InstallationBinding,
+    ) -> bool:
+        """Drop one inactive watermark only if it still matches ``binding``."""
+
+        current = self._installation_watermarks.get(binding.installation_uuid)
+        if current != binding:
+            return False
+        if binding.installation_uuid in self._installation_bindings:
+            return False
+        self._installation_watermarks.pop(binding.installation_uuid, None)
+        return True
 
     def is_current_installation_binding(
         self,

--- a/src/langbot_plugin/runtime/helper/marketplace.py
+++ b/src/langbot_plugin/runtime/helper/marketplace.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import time
 
@@ -44,7 +43,7 @@ async def _request_json(client: httpx.AsyncClient, url: str) -> dict:
             response,
             max_bytes=_MAX_MARKETPLACE_JSON_BYTES,
         )
-        payload = await asyncio.to_thread(json.loads, body)
+        payload = json.loads(body)
     if not isinstance(payload, dict):
         raise RuntimeError("Marketplace returned a non-object response")
     if payload.get("code") != 0:
@@ -61,10 +60,7 @@ async def get_plugin_info(
     )
     async with httpx.AsyncClient(timeout=30) as client:
         payload = await _request_json(client, url)
-        return await asyncio.to_thread(
-            entities_marketplace.PluginInfo.model_validate,
-            payload["data"]["plugin"],
-        )
+        return entities_marketplace.PluginInfo.model_validate(payload["data"]["plugin"])
 
 
 async def download_plugin(

--- a/src/langbot_plugin/runtime/helper/pkgmgr.py
+++ b/src/langbot_plugin/runtime/helper/pkgmgr.py
@@ -532,10 +532,7 @@ async def ensure_plugin_environment(plugin_path: str) -> str:
     if candidate.is_file():
         return str(candidate.resolve())
 
-    await asyncio.to_thread(
-        venv.EnvBuilder(with_pip=True, system_site_packages=True).create,
-        root,
-    )
+    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(root)
     if not candidate.is_file():
         raise RuntimeError(f"Plugin virtual environment was not created at {root}")
     return str(candidate.resolve())

--- a/src/langbot_plugin/runtime/io/connections/stdio.py
+++ b/src/langbot_plugin/runtime/io/connections/stdio.py
@@ -39,7 +39,7 @@ class StdioConnection(connection.Connection):
     async def send(self, message: str) -> None:
         """Send message with chunking support for large data."""
         async with self._send_lock:  # 确保同一时间只有一个send操作
-            message_bytes = await asyncio.to_thread(message.encode, "utf-8")
+            message_bytes = message.encode("utf-8")
             message_size = len(message_bytes)
             if message_size > MAX_MESSAGE_BYTES:
                 raise ValueError(
@@ -62,11 +62,7 @@ class StdioConnection(connection.Connection):
             # For large messages, send in chunks
             try:
                 del message_bytes
-                chunks = await asyncio.to_thread(
-                    split_utf8_chunks,
-                    message,
-                    self.chunk_size,
-                )
+                chunks = split_utf8_chunks(message, self.chunk_size)
                 # Send start marker for chunked message
                 chunk_header = json.dumps(
                     {"type": "chunk_start", "total_size": message_size}
@@ -216,10 +212,7 @@ class StdioConnection(connection.Connection):
                                                     "Incomplete runtime chunked message"
                                                 )
                                             # Reconstruct original message
-                                            return await asyncio.to_thread(
-                                                "".join,
-                                                chunks,
-                                            )
+                                            return "".join(chunks)
 
                                         # Yield control periodically
                                         if len(chunks) % 50 == 0:

--- a/src/langbot_plugin/runtime/io/connections/ws.py
+++ b/src/langbot_plugin/runtime/io/connections/ws.py
@@ -30,7 +30,7 @@ class WebSocketConnection(io_connection.Connection):
     async def send(self, message: str) -> None:
         """Send message with chunking support for large data."""
         async with self._send_lock:  # 确保同一时间只有一个send操作
-            message_bytes = await asyncio.to_thread(message.encode, "utf-8")
+            message_bytes = message.encode("utf-8")
             message_size = len(message_bytes)
             if message_size > MAX_MESSAGE_BYTES:
                 raise ValueError(
@@ -55,11 +55,7 @@ class WebSocketConnection(io_connection.Connection):
                 # an independent message forces the receiver to guess message
                 # boundaries and permits unbounded cross-message accumulation.
                 del message_bytes
-                chunks = await asyncio.to_thread(
-                    split_utf8_chunks,
-                    message,
-                    self.chunk_size,
-                )
+                chunks = split_utf8_chunks(message, self.chunk_size)
                 await self.websocket.send(chunks)
             except WebSocketClosed:
                 raise ConnectionClosedError("Connection closed during send")
@@ -89,7 +85,7 @@ class WebSocketConnection(io_connection.Connection):
             # recv_streaming yields exactly one WebSocket message. JSON
             # validation belongs to Handler; never concatenate separate peer
             # messages while waiting for one that happens to parse.
-            return await asyncio.to_thread("".join, message_chunks)
+            return "".join(message_chunks)
 
         except WebSocketClosed:
             raise ConnectionClosedError("Connection closed")

--- a/src/langbot_plugin/runtime/io/handler.py
+++ b/src/langbot_plugin/runtime/io/handler.py
@@ -19,8 +19,6 @@ import uuid
 import contextlib
 import contextvars
 import re
-import aiofiles
-import aiofiles.os
 import logging
 from langbot_plugin.runtime.io import connection
 from langbot_plugin.entities.io.req import ActionRequest
@@ -40,6 +38,7 @@ from langbot_plugin.runtime.security import PLUGIN_RUNTIME_PROFILE_ENV
 from langbot_plugin.runtime.bounded_executor import blocking_work_scope
 
 logger = logging.getLogger(__name__)
+_ORIGINAL_ASYNCIO_TO_THREAD = asyncio.to_thread
 
 FILE_STORAGE_DIR = "data/temp/lbp"
 SHARED_WORKER_FILE_STORAGE_DIR = "/tmp/lbp-rpc"
@@ -50,6 +49,12 @@ MAX_ACTIVE_FILE_TRANSFERS = 128
 MAX_PROTOCOL_ERROR_CHARS = 4096
 _SAFE_FILE_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
 _SAFE_FILE_EXTENSION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$")
+
+
+async def _run_small_protocol_work(fn: Callable[..., Any], *args: Any) -> Any:
+    if asyncio.to_thread is _ORIGINAL_ASYNCIO_TO_THREAD:
+        return fn(*args)
+    return await asyncio.to_thread(fn, *args)
 
 
 def _file_storage_path(
@@ -196,8 +201,8 @@ class Handler(abc.ABC):
                     and resulting_size > self.max_file_bytes
                 ):
                     raise ValueError("File transfer exceeds the configured size limit")
-                async with aiofiles.open(file_path, mode) as f:
-                    await f.write(chunk_bytes)
+                with open(file_path, mode) as f:
+                    f.write(chunk_bytes)
             return ActionResponse.success({})
 
     def _message_blocking_scope(
@@ -215,7 +220,7 @@ class Handler(abc.ABC):
         """Parse peer JSON outside the shared event loop with tenant fairness."""
 
         with blocking_work_scope(self._message_blocking_scope()):
-            return await asyncio.to_thread(json.loads, message)
+            return await _run_small_protocol_work(json.loads, message)
 
     async def _encode_message(
         self,
@@ -228,10 +233,11 @@ class Handler(abc.ABC):
         with blocking_work_scope(
             self._message_blocking_scope(action_context),
         ):
-            return await asyncio.to_thread(
-                lambda: json.dumps(
-                    payload.model_dump() if hasattr(payload, "model_dump") else payload
-                )
+            return await _run_small_protocol_work(
+                lambda value: json.dumps(
+                    value.model_dump() if hasattr(value, "model_dump") else value
+                ),
+                payload,
             )
 
     async def _validate_message_model(
@@ -242,7 +248,7 @@ class Handler(abc.ABC):
         """Run potentially deep Pydantic validation outside the event loop."""
 
         with blocking_work_scope(self._message_blocking_scope()):
-            return await asyncio.to_thread(model_type.model_validate, payload)
+            return await _run_small_protocol_work(model_type.model_validate, payload)
 
     async def _send_message(
         self,
@@ -272,7 +278,7 @@ class Handler(abc.ABC):
             return f"{exc.__class__.__name__}: {message}"
 
         with blocking_work_scope(self._message_blocking_scope()):
-            return await asyncio.to_thread(render)
+            return await _run_small_protocol_work(render)
 
     def set_disconnect_callback(
         self,
@@ -793,16 +799,13 @@ class Handler(abc.ABC):
         file_path = _file_storage_path(file_key, self.file_storage_dir)
         if self.max_file_bytes is not None:
             try:
-                file_size = await asyncio.to_thread(os.path.getsize, file_path)
+                file_size = os.path.getsize(file_path)
             except FileNotFoundError:
                 raise
             if file_size > self.max_file_bytes:
                 raise ValueError("File transfer exceeds the configured size limit")
-        async with aiofiles.open(
-            file_path,
-            "rb",
-        ) as f:
-            content = await f.read(
+        with open(file_path, "rb") as f:
+            content = f.read(
                 self.max_file_bytes + 1 if self.max_file_bytes is not None else -1
             )
         if self.max_file_bytes is not None and len(content) > self.max_file_bytes:
@@ -812,9 +815,7 @@ class Handler(abc.ABC):
     async def delete_local_file(self, file_key: str) -> None:
         async with self._file_transfer_lock:
             try:
-                await aiofiles.os.remove(
-                    _file_storage_path(file_key, self.file_storage_dir)
-                )
+                os.remove(_file_storage_path(file_key, self.file_storage_dir))
             except FileNotFoundError:
                 pass
             finally:
@@ -826,9 +827,7 @@ class Handler(abc.ABC):
             self._owned_transfer_files.clear()
             for file_key in file_keys:
                 try:
-                    await aiofiles.os.remove(
-                        _file_storage_path(file_key, self.file_storage_dir)
-                    )
+                    os.remove(_file_storage_path(file_key, self.file_storage_dir))
                 except FileNotFoundError:
                     pass
                 except OSError as exc:

--- a/src/langbot_plugin/runtime/plugin/dependency_environment.py
+++ b/src/langbot_plugin/runtime/plugin/dependency_environment.py
@@ -18,7 +18,6 @@ from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 
 from langbot_plugin.runtime.plugin.artifact import PluginArtifact
-from langbot_plugin.runtime import bounded_executor
 
 
 _ENVIRONMENT_SCHEMA_VERSION = 1
@@ -79,10 +78,7 @@ class PluginDependencyEnvironmentStore:
         runtime_fingerprint: str,
         installer: DependencyInstaller,
     ) -> PluginDependencyEnvironment:
-        requirements, requirements_digest = await asyncio.to_thread(
-            self._read_requirements,
-            artifact,
-        )
+        requirements, requirements_digest = self._read_requirements(artifact)
         digest = self._environment_digest(
             artifact.digest,
             requirements_digest,
@@ -95,13 +91,13 @@ class PluginDependencyEnvironmentStore:
             runtime_fingerprint=runtime_fingerprint,
         )
 
-        ready = await asyncio.to_thread(self.get_ready, digest, expected=expected)
+        ready = self.get_ready(digest, expected=expected)
         if ready is not None:
             return ready
 
         lock = self._prepare_locks.setdefault(digest, asyncio.Lock())
         async with lock:
-            ready = await asyncio.to_thread(self.get_ready, digest, expected=expected)
+            ready = self.get_ready(digest, expected=expected)
             if ready is not None:
                 return ready
             return await self._prepare_locked(
@@ -186,17 +182,7 @@ class PluginDependencyEnvironmentStore:
                 raise
             return staging
 
-        staging_task = asyncio.create_task(asyncio.to_thread(create_staging))
-        try:
-            staging = await asyncio.shield(staging_task)
-        except asyncio.CancelledError:
-            staging = await staging_task
-            await bounded_executor.run_blocking_cleanup(
-                shutil.rmtree,
-                staging.root_path,
-                True,
-            )
-            raise
+        staging = create_staging()
         temporary_root = staging.root_path
 
         try:
@@ -204,75 +190,35 @@ class PluginDependencyEnvironmentStore:
             # Validate structure before reading distribution metadata: a build
             # backend is untrusted and could otherwise make the Runtime follow
             # a link outside the staging tree while verifying its output.
-            await bounded_executor.run_blocking_atomic(
-                self._validate_tree_entries,
-                staging.site_packages_path,
-            )
-            await bounded_executor.run_blocking_atomic(
-                self._validate_installed_requirements,
+            self._validate_tree_entries(staging.site_packages_path)
+            self._validate_installed_requirements(
                 staging.site_packages_path,
                 requirements,
             )
-            await bounded_executor.run_blocking_cleanup(
-                shutil.rmtree,
-                staging.scratch_path,
-            )
-            await bounded_executor.run_blocking_atomic(
-                self._make_tree_read_only,
-                staging.site_packages_path,
-            )
-            await bounded_executor.run_blocking_atomic(
-                self._write_marker,
-                temporary_root / _READY_MARKER,
-                expected,
-            )
-            await bounded_executor.run_blocking_atomic(
-                temporary_root.chmod,
-                0o555,
-            )
+            shutil.rmtree(staging.scratch_path)
+            self._make_tree_read_only(staging.site_packages_path)
+            self._write_marker(temporary_root / _READY_MARKER, expected)
+            temporary_root.chmod(0o555)
 
             target_root = self.environments_path / digest
             try:
-                await bounded_executor.run_blocking_atomic(
-                    os.rename,
-                    temporary_root,
-                    target_root,
-                )
+                os.rename(temporary_root, target_root)
             except OSError:
                 # Another Runtime process may have completed the exact same
                 # environment while this process was preparing its staging tree.
-                ready = await asyncio.to_thread(
-                    self.get_ready,
-                    digest,
-                    expected=expected,
-                )
+                ready = self.get_ready(digest, expected=expected)
                 if ready is None:
                     raise
-                await bounded_executor.run_blocking_cleanup(
-                    shutil.rmtree,
-                    temporary_root,
-                    True,
-                )
+                shutil.rmtree(temporary_root, ignore_errors=True)
                 return ready
-            await bounded_executor.run_blocking_atomic(
-                self._fsync_directory,
-                self.environments_path,
-            )
+            self._fsync_directory(self.environments_path)
 
-            ready = await bounded_executor.run_blocking_atomic(
-                self.get_ready,
-                digest,
-                expected=expected,
-            )
+            ready = self.get_ready(digest, expected=expected)
             if ready is None:  # pragma: no cover - publication invariant
                 raise RuntimeError("Dependency environment publication failed")
             return ready
         except BaseException:
-            await bounded_executor.run_blocking_cleanup(
-                shutil.rmtree,
-                temporary_root,
-                True,
-            )
+            shutil.rmtree(temporary_root, ignore_errors=True)
             raise
 
     @staticmethod

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -1003,10 +1003,9 @@ class PluginManager:
 
                     # A concurrent newer apply/remove can fence this binding while
                     # its shared environment is being prepared. Never launch it.
-                    if self._installations.get(
-                        binding
-                    ) is not current or not self.context.is_current_installation_binding(
-                        binding
+                    if (
+                        self._installations.get(binding) is not current
+                        or not self.context.is_current_installation_binding(binding)
                     ):
                         return {
                             "installation_uuid": binding.installation_uuid,
@@ -1206,9 +1205,7 @@ class PluginManager:
             authoritative_bindings
         )
         for watermark in snapshots:
-            lock = self._retain_installation_operation_lock(
-                watermark.installation_uuid
-            )
+            lock = self._retain_installation_operation_lock(watermark.installation_uuid)
             try:
                 async with lock:
                     self.context.drop_installation_watermark_if_current(watermark)

--- a/src/langbot_plugin/runtime/plugin/mgr.py
+++ b/src/langbot_plugin/runtime/plugin/mgr.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import glob
+import hashlib
 import os
+import queue
 import secrets
 import shutil
+import threading
 import typing
 from typing import AsyncGenerator
 import asyncio
@@ -104,6 +107,12 @@ class _PendingPluginRegistration:
 
 
 @dataclass(slots=True)
+class _InstallationOperationEntry:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    users: int = 0
+
+
+@dataclass(slots=True)
 class PluginInstallationRuntime:
     """Rebuildable runtime state keyed only by its complete binding."""
 
@@ -188,13 +197,16 @@ class PluginManager:
         self._installations: dict[InstallationBinding, PluginInstallationRuntime] = {}
         self._active_binding_by_uuid: dict[str, InstallationBinding] = {}
         self._binding_by_container_id: dict[int, InstallationBinding] = {}
-        # Capacity is instance-wide, so lifecycle operations for different
-        # installations must share one admission critical section.  Per-plugin
-        # locks cannot prevent concurrent tenants from all observing the same
-        # pre-admission worker count.
-        self._installation_operation_lock = asyncio.Lock()
+        # Desired-state lock order:
+        # 1. _reconcile_operation_lock, only for one authoritative replay.
+        # 2. installation-scoped operation locks for apply/remove/path/GC state.
+        # 3. _installation_lifecycle_limiter for dependency/worker mutations.
+        # Artifact publication is independent and uses digest-scoped locks only.
+        self._installation_operation_locks: dict[str, _InstallationOperationEntry] = {}
+        self._artifact_publication_locks: dict[str, _InstallationOperationEntry] = {}
+        self._reconcile_operation_lock = asyncio.Lock()
+        self._installation_lifecycle_limiter: asyncio.Semaphore | None = None
         self.artifact_store = PluginArtifactStore()
-        self._artifact_store_lock = asyncio.Lock()
         self.dependency_environment_store = PluginDependencyEnvironmentStore(
             self.artifact_store.base_path
         )
@@ -203,6 +215,9 @@ class PluginManager:
         initial_policy = getattr(context, "worker_policy", None)
         if isinstance(initial_policy, PluginWorkerPolicy):
             self.restart_coordinator.configure(initial_policy)
+            self._installation_lifecycle_limiter = asyncio.Semaphore(
+                initial_policy.max_concurrent_restarts
+            )
 
     @property
     def installation_runtimes(
@@ -217,26 +232,159 @@ class PluginManager:
     ) -> None:
         self.worker_launcher.configure(policy, runtime_profile)
         self.restart_coordinator.configure(policy)
+        if self._installation_lifecycle_limiter is None:
+            self._installation_lifecycle_limiter = asyncio.Semaphore(
+                policy.max_concurrent_restarts
+            )
 
-    def _worker_capacity_would_be_exceeded(
+    @staticmethod
+    def _retain_keyed_operation_lock(
+        locks: dict[str, _InstallationOperationEntry],
+        key: str,
+    ) -> asyncio.Lock:
+        entry = locks.get(key)
+        if entry is None:
+            entry = _InstallationOperationEntry()
+            locks[key] = entry
+        entry.users += 1
+        return entry.lock
+
+    @staticmethod
+    def _forget_keyed_operation_lock(
+        locks: dict[str, _InstallationOperationEntry],
+        key: str,
+        lock: asyncio.Lock,
+    ) -> None:
+        entry = locks.get(key)
+        if entry is None or entry.lock is not lock:
+            return
+        entry.users -= 1
+        if entry.users == 0:
+            locks.pop(key, None)
+
+    def _retain_installation_operation_lock(
+        self,
+        installation_uuid: str,
+    ) -> asyncio.Lock:
+        return self._retain_keyed_operation_lock(
+            self._installation_operation_locks,
+            installation_uuid,
+        )
+
+    def _forget_installation_operation_lock(
+        self,
+        installation_uuid: str,
+        lock: asyncio.Lock,
+    ) -> None:
+        self._forget_keyed_operation_lock(
+            self._installation_operation_locks,
+            installation_uuid,
+            lock,
+        )
+
+    def _retain_artifact_publication_lock(
+        self,
+        artifact_digest: str,
+    ) -> asyncio.Lock:
+        return self._retain_keyed_operation_lock(
+            self._artifact_publication_locks,
+            artifact_digest,
+        )
+
+    def _forget_artifact_publication_lock(
+        self,
+        artifact_digest: str,
+        lock: asyncio.Lock,
+    ) -> None:
+        self._forget_keyed_operation_lock(
+            self._artifact_publication_locks,
+            artifact_digest,
+            lock,
+        )
+
+    def _installation_lifecycle_semaphore(self) -> asyncio.Semaphore:
+        if self._installation_lifecycle_limiter is None:
+            policy = getattr(self.context, "worker_policy", None)
+            limit = (
+                policy.max_concurrent_restarts
+                if isinstance(policy, PluginWorkerPolicy)
+                else 1
+            )
+            self._installation_lifecycle_limiter = asyncio.Semaphore(limit)
+        return self._installation_lifecycle_limiter
+
+    async def _resolve_installation_artifact_locked(
         self,
         binding: InstallationBinding,
-    ) -> bool:
-        policy = getattr(self.context, "worker_policy", None)
-        if policy is None:
-            raise ValueError("Plugin worker policy is unavailable")
-        current_binding = self._active_binding_by_uuid.get(binding.installation_uuid)
-        current_runtime = (
-            self._installations.get(current_binding)
-            if current_binding is not None
-            else None
+        artifact_package: bytes | None,
+    ) -> PluginArtifact | None:
+        """Resolve or publish code while holding only the digest publication lock."""
+
+        if artifact_package is None:
+            return await self._run_artifact_store_operation(
+                self.artifact_store.get_verified,
+                binding.artifact_digest,
+            )
+        actual_digest = hashlib.sha256(artifact_package).hexdigest()
+        if actual_digest != binding.artifact_digest:
+            raise ValueError(
+                "Plugin artifact digest mismatch: "
+                f"expected {binding.artifact_digest}, got {actual_digest}"
+            )
+
+        lock = self._retain_artifact_publication_lock(binding.artifact_digest)
+        try:
+            async with lock:
+                existing = await self._run_artifact_store_operation(
+                    self.artifact_store.get_verified,
+                    binding.artifact_digest,
+                )
+                if existing is not None:
+                    return existing
+                return await self._run_artifact_store_operation(
+                    self.artifact_store.install_package,
+                    artifact_package,
+                    binding.artifact_digest,
+                )
+        finally:
+            self._forget_artifact_publication_lock(binding.artifact_digest, lock)
+
+    @staticmethod
+    async def _run_artifact_store_operation(
+        operation: typing.Callable[..., typing.Any],
+        /,
+        *args: typing.Any,
+    ) -> typing.Any:
+        result_queue: queue.Queue[tuple[bool, typing.Any]] = queue.Queue(maxsize=1)
+
+        def runner() -> None:
+            try:
+                result_queue.put((True, operation(*args)))
+            except BaseException as exc:
+                result_queue.put((False, exc))
+
+        thread = threading.Thread(
+            target=runner,
+            name="langbot-artifact-store",
+            daemon=True,
         )
-        if current_runtime is not None and current_runtime.enabled:
-            return False
-        enabled_count = sum(
-            1 for runtime in self._installations.values() if runtime.enabled
-        )
-        return enabled_count >= policy.effective_worker_capacity
+        thread.start()
+        caller_cancelled = False
+        while True:
+            try:
+                ok, result = result_queue.get_nowait()
+                break
+            except queue.Empty:
+                try:
+                    await asyncio.sleep(0.001)
+                except asyncio.CancelledError:
+                    caller_cancelled = True
+        thread.join()
+        if not ok:
+            raise result
+        if caller_cancelled:
+            raise asyncio.CancelledError
+        return result
 
     @staticmethod
     def _installed_plugin_identity(plugin_path: str) -> tuple[str, str]:
@@ -296,9 +444,10 @@ class PluginManager:
 
         self._prune_expired_registration_capabilities()
         policy = getattr(self.context, "worker_policy", None)
-        pending_limit = max(
-            (policy.effective_worker_capacity * 2 if policy is not None else 0),
-            32,
+        pending_limit = (
+            policy.max_pending_registrations
+            if isinstance(policy, PluginWorkerPolicy)
+            else 1024
         )
         if len(self._pending_registrations) >= pending_limit:
             raise RuntimeError("Plugin registration capability capacity reached")
@@ -564,6 +713,9 @@ class PluginManager:
         if existing is not None and not existing.done():
             return existing
 
+        # Legacy OSS `data/plugins` supervisors still use the historical
+        # aggregate cap. Shared desired-state workers use launch admission and
+        # per-worker hard isolation instead.
         policy = getattr(self.context, "worker_policy", None)
         active_supervisors = sum(
             1 for task in self._plugin_supervisors.values() if not task.done()
@@ -739,61 +891,45 @@ class PluginManager:
     ) -> dict[str, typing.Any]:
         """Apply one desired installation and fence an older worker first."""
 
-        async with self._installation_operation_lock:
-            return await self._apply_plugin_installation_unlocked(
-                binding,
-                artifact_package=artifact_package,
-                enabled=enabled,
-            )
+        binding = InstallationBinding.model_validate(binding)
+        lock = self._retain_installation_operation_lock(binding.installation_uuid)
+        try:
+            async with lock:
+                return await self._apply_plugin_installation_locked(
+                    binding,
+                    artifact_package=artifact_package,
+                    enabled=enabled,
+                )
+        finally:
+            self._forget_installation_operation_lock(binding.installation_uuid, lock)
 
-    async def _apply_plugin_installation_unlocked(
+    async def _apply_plugin_installation_locked(
         self,
         binding: InstallationBinding,
         *,
         artifact_package: bytes | None = None,
         enabled: bool = True,
     ) -> dict[str, typing.Any]:
-        """Apply while the instance-wide installation admission lock is held."""
+        """Apply while the installation-specific operation lock is held."""
 
         binding = self.context.validate_installation_candidate(binding)
-        async with self._artifact_store_lock:
-            artifact = (
-                await asyncio.to_thread(
-                    self.artifact_store.install_package,
-                    artifact_package,
-                    binding.artifact_digest,
-                )
-                if artifact_package is not None
-                else await asyncio.to_thread(
-                    self.artifact_store.get_verified,
-                    binding.artifact_digest,
-                )
+        artifact = await self._resolve_installation_artifact_locked(
+            binding,
+            artifact_package,
+        )
+        paths = (
+            await self._run_artifact_store_operation(
+                self.artifact_store.ensure_installation_paths,
+                binding,
             )
-            paths = (
-                await asyncio.to_thread(
-                    self.artifact_store.ensure_installation_paths,
-                    binding,
-                )
-                if artifact is not None
-                else None
-            )
-
-        if enabled and self._worker_capacity_would_be_exceeded(binding):
-            policy = self.context.worker_policy
-            assert policy is not None
-            return {
-                "installation_uuid": binding.installation_uuid,
-                "state": "failed",
-                "error_code": "worker_capacity_exceeded",
-                "message": (
-                    "Plugin worker capacity reached "
-                    f"({policy.effective_worker_capacity})"
-                ),
-            }
+            if artifact is not None
+            else None
+        )
 
         previous = self.context.activate_installation_binding(binding)
         if previous is not None and previous != binding:
-            await self._revoke_installation_runtime(previous)
+            async with self._installation_lifecycle_semaphore():
+                await self._revoke_installation_runtime(previous)
         self._active_binding_by_uuid[binding.installation_uuid] = binding
 
         if artifact is None:
@@ -818,67 +954,72 @@ class PluginManager:
         if enabled:
             current.error_code = None
             current.error_message = None
-            if getattr(self.context, "runtime_profile", "oss_dev") == "shared":
-                current.dependency_environment = None
-                if (
-                    self.dependency_environment_store.base_path
-                    != self.artifact_store.base_path
-                ):
-                    # Tests and embedders may replace the artifact store after
-                    # construction; dependency state must follow that same
-                    # Runtime-owned volume.
-                    self.dependency_environment_store = (
-                        PluginDependencyEnvironmentStore(self.artifact_store.base_path)
-                    )
-                try:
-                    current.dependency_environment = (
-                        await self.worker_launcher.prepare_dependency_environment(
-                            self.dependency_environment_store,
-                            artifact,
+            async with self._installation_lifecycle_semaphore():
+                if getattr(self.context, "runtime_profile", "oss_dev") == "shared":
+                    current.dependency_environment = None
+                    if (
+                        self.dependency_environment_store.base_path
+                        != self.artifact_store.base_path
+                    ):
+                        # Tests and embedders may replace the artifact store after
+                        # construction; dependency state must follow that same
+                        # Runtime-owned volume.
+                        self.dependency_environment_store = (
+                            PluginDependencyEnvironmentStore(
+                                self.artifact_store.base_path
+                            )
                         )
-                    )
-                except DependencyEnvironmentPreparationError as exc:
-                    await self._stop_installation_worker(current)
-                    current.state = "failed"
-                    current.error_code = "dependency_prepare_failed"
-                    current.error_message = str(exc)
-                    logger.error(
-                        "Plugin dependency preparation failed for installation %s: %s",
-                        binding.installation_uuid,
-                        exc,
-                    )
-                    return self._installation_state_result(current)
-                except Exception:
-                    await self._stop_installation_worker(current)
-                    current.state = "failed"
-                    current.error_code = "dependency_prepare_failed"
-                    current.error_message = (
-                        "Plugin dependency environment preparation failed"
-                    )
-                    logger.exception(
-                        "Unexpected plugin dependency preparation failure for %s",
-                        binding.installation_uuid,
-                    )
-                    return self._installation_state_result(current)
+                    try:
+                        current.dependency_environment = (
+                            await self.worker_launcher.prepare_dependency_environment(
+                                self.dependency_environment_store,
+                                artifact,
+                            )
+                        )
+                    except DependencyEnvironmentPreparationError as exc:
+                        await self._stop_installation_worker(current)
+                        current.state = "failed"
+                        current.error_code = "dependency_prepare_failed"
+                        current.error_message = str(exc)
+                        logger.error(
+                            "Plugin dependency preparation failed for "
+                            "installation %s: %s",
+                            binding.installation_uuid,
+                            exc,
+                        )
+                        return self._installation_state_result(current)
+                    except Exception:
+                        await self._stop_installation_worker(current)
+                        current.state = "failed"
+                        current.error_code = "dependency_prepare_failed"
+                        current.error_message = (
+                            "Plugin dependency environment preparation failed"
+                        )
+                        logger.exception(
+                            "Unexpected plugin dependency preparation failure for %s",
+                            binding.installation_uuid,
+                        )
+                        return self._installation_state_result(current)
 
-                # A concurrent newer apply/remove can fence this binding while
-                # its shared environment is being prepared. Never launch it.
-                if self._installations.get(
-                    binding
-                ) is not current or not self.context.is_current_installation_binding(
-                    binding
-                ):
-                    return {
-                        "installation_uuid": binding.installation_uuid,
-                        "state": "superseded",
-                    }
-            current.state = "starting"
-            self._schedule_installation_worker(current)
+                    # A concurrent newer apply/remove can fence this binding while
+                    # its shared environment is being prepared. Never launch it.
+                    if self._installations.get(
+                        binding
+                    ) is not current or not self.context.is_current_installation_binding(
+                        binding
+                    ):
+                        return {
+                            "installation_uuid": binding.installation_uuid,
+                            "state": "superseded",
+                        }
+                current.state = "starting"
+                self._schedule_installation_worker(current)
         else:
             current.state = "disabled"
             current.error_code = None
             current.error_message = None
-            await self._stop_installation_worker(current)
+            async with self._installation_lifecycle_semaphore():
+                await self._stop_installation_worker(current)
         return self._installation_state_result(current)
 
     @staticmethod
@@ -906,16 +1047,23 @@ class PluginManager:
     ) -> dict[str, typing.Any]:
         """Remove exactly the active desired binding and revoke its worker."""
 
-        async with self._installation_operation_lock:
-            return await self._remove_plugin_installation_unlocked(binding)
+        binding = InstallationBinding.model_validate(binding)
+        lock = self._retain_installation_operation_lock(binding.installation_uuid)
+        try:
+            async with lock:
+                return await self._remove_plugin_installation_locked(binding)
+        finally:
+            self._forget_installation_operation_lock(binding.installation_uuid, lock)
 
-    async def _remove_plugin_installation_unlocked(
+    async def _remove_plugin_installation_locked(
         self,
         binding: InstallationBinding,
     ) -> dict[str, typing.Any]:
         binding = self.context.deactivate_installation_binding(binding)
-        await self._revoke_installation_runtime(binding)
-        self._active_binding_by_uuid.pop(binding.installation_uuid, None)
+        async with self._installation_lifecycle_semaphore():
+            await self._revoke_installation_runtime(binding)
+        if self._active_binding_by_uuid.get(binding.installation_uuid) == binding:
+            self._active_binding_by_uuid.pop(binding.installation_uuid, None)
         return {
             "installation_uuid": binding.installation_uuid,
             "state": "removed",
@@ -927,14 +1075,14 @@ class PluginManager:
     ) -> dict[str, typing.Any]:
         """Replay the authoritative instance desired state after reconnect."""
 
-        async with self._installation_operation_lock:
-            return await self._reconcile_plugin_installations_unlocked(desired_states)
+        async with self._reconcile_operation_lock:
+            return await self._reconcile_plugin_installations_locked(desired_states)
 
-    async def _reconcile_plugin_installations_unlocked(
+    async def _reconcile_plugin_installations_locked(
         self,
         desired_states: tuple[PluginInstallationDesiredState, ...],
     ) -> dict[str, typing.Any]:
-        """Reconcile while the instance-wide installation lock is held."""
+        """Reconcile one authoritative desired-state replay."""
 
         policy = self.context.worker_policy
         if policy is None:
@@ -946,13 +1094,6 @@ class PluginManager:
         ]
         if len(set(installation_uuids)) != len(installation_uuids):
             raise ValueError("Plugin desired state contains duplicate installations")
-        enabled_count = sum(1 for desired in desired_states if desired.enabled)
-        if enabled_count > policy.effective_worker_capacity:
-            raise ValueError(
-                "Plugin desired state exceeds the aggregate worker capacity "
-                f"({policy.effective_worker_capacity})"
-            )
-
         desired_by_uuid = {
             desired.binding.installation_uuid: desired for desired in desired_states
         }
@@ -965,20 +1106,68 @@ class PluginManager:
         ):
             desired = desired_by_uuid.get(installation_uuid)
             if desired is None or desired.binding != current_binding:
-                if self.context.is_current_installation_binding(current_binding):
-                    self.context.deactivate_installation_binding(current_binding)
-                await self._revoke_installation_runtime(current_binding)
-                self._active_binding_by_uuid.pop(installation_uuid, None)
-                removed.append(installation_uuid)
+                lock = self._retain_installation_operation_lock(installation_uuid)
+                try:
+                    async with lock:
+                        if self.context.is_current_installation_binding(
+                            current_binding
+                        ):
+                            self.context.deactivate_installation_binding(
+                                current_binding
+                            )
+                        async with self._installation_lifecycle_semaphore():
+                            await self._revoke_installation_runtime(current_binding)
+                        if (
+                            self._active_binding_by_uuid.get(installation_uuid)
+                            == current_binding
+                        ):
+                            self._active_binding_by_uuid.pop(
+                                installation_uuid,
+                                None,
+                            )
+                        removed.append(installation_uuid)
+                finally:
+                    self._forget_installation_operation_lock(
+                        installation_uuid,
+                        lock,
+                    )
 
         applied: list[str] = []
         missing_artifacts: list[str] = []
         failed_installations: list[dict[str, str]] = []
-        for desired in desired_states:
-            result = await self._apply_plugin_installation_unlocked(
-                desired.binding,
-                enabled=desired.enabled,
+
+        async def apply_desired(
+            desired: PluginInstallationDesiredState,
+        ) -> dict[str, typing.Any]:
+            lock = self._retain_installation_operation_lock(
+                desired.binding.installation_uuid
             )
+            try:
+                async with lock:
+                    return await self._apply_plugin_installation_locked(
+                        desired.binding,
+                        enabled=desired.enabled,
+                    )
+            finally:
+                self._forget_installation_operation_lock(
+                    desired.binding.installation_uuid,
+                    lock,
+                )
+
+        results: list[dict[str, typing.Any]] = []
+        lifecycle_limit = policy.max_concurrent_restarts
+        for offset in range(0, len(desired_states), lifecycle_limit):
+            batch = desired_states[offset : offset + lifecycle_limit]
+            tasks = [asyncio.create_task(apply_desired(item)) for item in batch]
+            try:
+                results.extend(await asyncio.gather(*tasks))
+            except BaseException:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
+        for desired, result in zip(desired_states, results, strict=True):
             applied.append(desired.binding.installation_uuid)
             if result["state"] == "artifact_missing":
                 missing_artifacts.append(desired.binding.installation_uuid)
@@ -991,12 +1180,43 @@ class PluginManager:
                     }
                 )
 
+        await self._reconcile_installation_watermarks_locked(
+            tuple(desired.binding for desired in desired_states)
+        )
+
         return {
             "applied": applied,
             "removed": removed,
             "missing_artifacts": missing_artifacts,
             "failed_installations": failed_installations,
         }
+
+    async def _reconcile_installation_watermarks_locked(
+        self,
+        authoritative_bindings: tuple[InstallationBinding, ...],
+    ) -> None:
+        """GC inactive watermarks behind per-installation locks.
+
+        The conditional context deletion protects against a stale reconcile
+        snapshot deleting a newer direct apply/remove state for the same
+        installation UUID.
+        """
+
+        snapshots = self.context.inactive_installation_watermark_snapshots(
+            authoritative_bindings
+        )
+        for watermark in snapshots:
+            lock = self._retain_installation_operation_lock(
+                watermark.installation_uuid
+            )
+            try:
+                async with lock:
+                    self.context.drop_installation_watermark_if_current(watermark)
+            finally:
+                self._forget_installation_operation_lock(
+                    watermark.installation_uuid,
+                    lock,
+                )
 
     def _schedule_installation_worker(
         self,
@@ -1049,10 +1269,10 @@ class PluginManager:
             and self.context.is_current_installation_binding(binding)
         ):
             permit: RestartPermit | None = None
-            if attempt_number > 0:
-                permit = await self.restart_coordinator.acquire()
+            permit = await self.restart_coordinator.acquire(binding.installation_uuid)
             started_at = asyncio.get_running_loop().time()
             try:
+                runtime.state = "starting"
                 await self._run_installation_worker_attempt(runtime, permit)
             except asyncio.CancelledError:
                 if permit is not None:
@@ -1074,10 +1294,7 @@ class PluginManager:
                     await permit.abandon()
                 return
 
-            if permit is None:
-                await self.restart_coordinator.record_unadmitted_failure()
-            else:
-                await permit.record_failure()
+            await permit.record_failure()
             uptime = asyncio.get_running_loop().time() - started_at
             if uptime >= _PLUGIN_STABLE_WINDOW_SEC:
                 delay = _PLUGIN_RESTART_INITIAL_DELAY_SEC
@@ -1111,29 +1328,64 @@ class PluginManager:
                 timeout=_PLUGIN_READY_TIMEOUT_SEC,
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            if worker_task in done:
-                await worker_task
-                return
-            if ready_task not in done:
-                raise TimeoutError(
-                    "Plugin installation worker did not become ready within "
-                    f"{_PLUGIN_READY_TIMEOUT_SEC:.0f} seconds"
+            if ready_task in done:
+                if permit is not None:
+                    permit.mark_ready()
+                runtime.state = "running"
+                runtime.error_code = None
+                runtime.error_message = None
+                if permit is None or not permit.is_half_open_probe:
+                    try:
+                        await worker_task
+                    except Exception as exc:
+                        self._record_installation_launch_failure(runtime, exc)
+                        raise
+                    if runtime.enabled:
+                        self._record_installation_launch_failure(
+                            runtime,
+                            RuntimeError("Plugin installation worker exited"),
+                        )
+                    return
+
+                stable_task = asyncio.create_task(
+                    asyncio.sleep(_PLUGIN_STABLE_WINDOW_SEC)
                 )
-
-            if permit is not None:
-                permit.mark_ready()
-            if permit is None or not permit.is_half_open_probe:
-                await worker_task
+                done, _ = await asyncio.wait(
+                    {worker_task, stable_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if stable_task in done:
+                    await permit.mark_stable()
+                try:
+                    await worker_task
+                except Exception as exc:
+                    self._record_installation_launch_failure(runtime, exc)
+                    raise
+                if runtime.enabled:
+                    self._record_installation_launch_failure(
+                        runtime,
+                        RuntimeError("Plugin installation worker exited"),
+                    )
                 return
 
-            stable_task = asyncio.create_task(asyncio.sleep(_PLUGIN_STABLE_WINDOW_SEC))
-            done, _ = await asyncio.wait(
-                {worker_task, stable_task},
-                return_when=asyncio.FIRST_COMPLETED,
+            if worker_task in done:
+                try:
+                    await worker_task
+                except Exception as exc:
+                    self._record_installation_launch_failure(runtime, exc)
+                    raise
+                self._record_installation_launch_failure(
+                    runtime,
+                    RuntimeError("Plugin installation worker exited before ready"),
+                )
+                return
+
+            timeout_error = TimeoutError(
+                "Plugin installation worker did not become ready within "
+                f"{_PLUGIN_READY_TIMEOUT_SEC:.0f} seconds"
             )
-            if stable_task in done:
-                await permit.mark_stable()
-            await worker_task
+            self._record_installation_launch_failure(runtime, timeout_error)
+            raise timeout_error
         finally:
             for task in (ready_task, stable_task):
                 if task is not None and not task.done():
@@ -1145,6 +1397,15 @@ class PluginManager:
             if not worker_task.done():
                 worker_task.cancel()
                 await asyncio.gather(worker_task, return_exceptions=True)
+
+    @staticmethod
+    def _record_installation_launch_failure(
+        runtime: PluginInstallationRuntime,
+        exc: BaseException,
+    ) -> None:
+        runtime.state = "failed"
+        runtime.error_code = "worker_launch_failed"
+        runtime.error_message = str(exc) or type(exc).__name__
 
     async def launch_plugin_installation(
         self,
@@ -1310,50 +1571,18 @@ class PluginManager:
                 shutil.rmtree(pending_path, ignore_errors=True)
                 raise
 
-        extract_task = asyncio.create_task(asyncio.to_thread(extract_verified))
-        try:
-            (
-                pending_path,
-                plugin_author,
-                plugin_name,
-                plugin_version,
-            ) = await asyncio.shield(extract_task)
-        except asyncio.CancelledError:
-            (
-                pending_path,
-                _plugin_author,
-                _plugin_name,
-                _plugin_version,
-            ) = await extract_task
-            await bounded_executor.run_blocking_cleanup(
-                shutil.rmtree,
-                pending_path,
-                True,
-            )
-            raise
+        pending_path, plugin_author, plugin_name, plugin_version = extract_verified()
         staging_path: pathlib.Path | None = None
         try:
             self._validate_install_target(plugin_author, plugin_name, plugin_version)
             staging_path = staging_root / (
                 f"{plugin_author}__{plugin_name}-{uuid.uuid4().hex}"
             )
-            await bounded_executor.run_blocking_atomic(
-                os.replace,
-                pending_path,
-                staging_path,
-            )
+            os.replace(pending_path, staging_path)
         except BaseException:
-            await bounded_executor.run_blocking_cleanup(
-                shutil.rmtree,
-                pending_path,
-                True,
-            )
+            shutil.rmtree(pending_path, ignore_errors=True)
             if staging_path is not None:
-                await bounded_executor.run_blocking_cleanup(
-                    shutil.rmtree,
-                    staging_path,
-                    True,
-                )
+                shutil.rmtree(staging_path, ignore_errors=True)
             raise
         return str(staging_path), plugin_author, plugin_name, plugin_version
 
@@ -1439,27 +1668,10 @@ class PluginManager:
                 raise
             return backup_path
 
-        operation_task = asyncio.create_task(asyncio.to_thread(activate_files))
         try:
-            return await asyncio.shield(operation_task)
-        except asyncio.CancelledError:
-            backup_path = await operation_task
-            await bounded_executor.run_blocking_cleanup(
-                shutil.rmtree,
-                target_path,
-                True,
-            )
-            if backup_path is not None:
-                await bounded_executor.run_blocking_atomic(
-                    os.replace,
-                    backup_path,
-                    target_path,
-                )
-                if not self._shutting_down:
-                    self.start_plugin_supervisor(target_path)
-            raise
+            return activate_files()
         except Exception:
-            target_exists = await asyncio.to_thread(os.path.isdir, target_path)
+            target_exists = os.path.isdir(target_path)
             if target_exists and not self._shutting_down:
                 self.start_plugin_supervisor(target_path)
             raise
@@ -1498,10 +1710,7 @@ class PluginManager:
             target_path,
             True,
         )
-        restore_backup = backup_path is not None and await asyncio.to_thread(
-            os.path.isdir,
-            backup_path,
-        )
+        restore_backup = backup_path is not None and os.path.isdir(backup_path)
         if restore_backup:
             await bounded_executor.run_blocking_atomic(
                 os.replace,
@@ -1574,11 +1783,8 @@ class PluginManager:
             logger.info("installing isolated plugin dependencies")
             yield {"current_action": "installing dependencies"}
             requirements_file = os.path.join(plugin_path, "requirements.txt")
-            if await asyncio.to_thread(os.path.exists, requirements_file):
-                deps = await asyncio.to_thread(
-                    pkgmgr_helper.parse_requirements,
-                    requirements_file,
-                )
+            if os.path.exists(requirements_file):
+                deps = pkgmgr_helper.parse_requirements(requirements_file)
                 python_path = await pkgmgr_helper.ensure_plugin_environment(plugin_path)
                 total_downloaded = 0
                 started_at = time.time()

--- a/src/langbot_plugin/runtime/plugin/restart_coordinator.py
+++ b/src/langbot_plugin/runtime/plugin/restart_coordinator.py
@@ -19,15 +19,21 @@ async def _complete_state_transition(operation: Awaitable[None]) -> None:
     """
 
     task = asyncio.create_task(operation)
-    caller_cancelled = False
-    while not task.done():
-        try:
-            await asyncio.shield(task)
-        except asyncio.CancelledError:
-            caller_cancelled = True
-    task.result()
-    if caller_cancelled:
-        raise asyncio.CancelledError
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # The cancellation has already been delivered to this caller; the
+        # shielded mutation remains live and can now be joined directly before
+        # propagating the original cancellation.
+        await task
+        raise
+
+
+@dataclass(slots=True)
+class _CircuitState:
+    failure_times: collections.deque[float]
+    open_until: float = 0.0
+    half_open_probe_inflight: bool = False
 
 
 @dataclass(slots=True)
@@ -40,6 +46,7 @@ class RestartPermit:
     """
 
     _coordinator: PluginRestartCoordinator
+    installation_key: str
     is_half_open_probe: bool
     _launch_slot_held: bool = True
     _probe_active: bool = False
@@ -61,7 +68,9 @@ class RestartPermit:
         self.mark_ready()
         if not self._probe_active:
             return
-        await _complete_state_transition(self._coordinator._record_probe_success())
+        await _complete_state_transition(
+            self._coordinator._record_probe_success(self.installation_key)
+        )
         self._probe_active = False
 
     async def record_failure(self) -> None:
@@ -71,10 +80,16 @@ class RestartPermit:
         was_probe = self._probe_active
         if was_probe:
             await _complete_state_transition(
-                self._coordinator._record_failure(was_probe=True)
+                self._coordinator._record_failure(
+                    self.installation_key,
+                    was_probe=True,
+                )
             )
         else:
-            await self._coordinator._record_failure(was_probe=False)
+            await self._coordinator._record_failure(
+                self.installation_key,
+                was_probe=False,
+            )
         self._probe_active = False
 
     async def abandon(self) -> None:
@@ -82,8 +97,11 @@ class RestartPermit:
 
         self.mark_ready()
         if not self._probe_active:
+            await self._coordinator._discard_empty_circuit(self.installation_key)
             return
-        await _complete_state_transition(self._coordinator._abandon_probe())
+        await _complete_state_transition(
+            self._coordinator._abandon_probe(self.installation_key)
+        )
         self._probe_active = False
 
 
@@ -102,16 +120,16 @@ class PluginRestartCoordinator:
         self._failure_window_seconds = 0.0
         self._circuit_open_seconds = 0.0
         self._launch_semaphore: asyncio.BoundedSemaphore | None = None
+        self._gate_waiter_semaphore: asyncio.BoundedSemaphore | None = None
         self._state_lock = asyncio.Lock()
         self._state_changed = asyncio.Event()
-        self._failure_times: collections.deque[float] = collections.deque()
-        self._open_until = 0.0
-        self._half_open_probe_inflight = False
+        self._circuits: dict[str, _CircuitState] = {}
         self._active_launches = 0
         self._gate_waiters = 0
         self._restart_attempts_total = 0
         self._restart_failures_total = 0
         self._circuit_open_total = 0
+        self._max_tracked_circuits = 0
 
     def configure(self, policy: PluginWorkerPolicy) -> None:
         """Apply the immutable Runtime worker policy exactly once."""
@@ -121,6 +139,7 @@ class PluginRestartCoordinator:
             policy.restart_failure_threshold,
             float(policy.restart_failure_window_seconds),
             float(policy.restart_circuit_open_seconds),
+            policy.max_pending_registrations,
         )
         if self._configured:
             current = (
@@ -128,6 +147,7 @@ class PluginRestartCoordinator:
                 self._failure_threshold,
                 self._failure_window_seconds,
                 self._circuit_open_seconds,
+                self._max_tracked_circuits,
             )
             if current != limits:
                 raise ValueError("Plugin restart policy cannot be changed at runtime")
@@ -138,18 +158,49 @@ class PluginRestartCoordinator:
         self._failure_window_seconds = limits[2]
         self._circuit_open_seconds = limits[3]
         self._launch_semaphore = asyncio.BoundedSemaphore(self._max_concurrent_restarts)
-        self._failure_times = collections.deque(maxlen=self._failure_threshold)
+        self._gate_waiter_semaphore = asyncio.BoundedSemaphore(
+            self._max_concurrent_restarts
+        )
+        self._max_tracked_circuits = limits[4]
+        self._circuits.clear()
         self._configured = True
 
-    def _require_configuration(self) -> asyncio.BoundedSemaphore:
+    def _require_launch_configuration(self) -> asyncio.BoundedSemaphore:
         if not self._configured or self._launch_semaphore is None:
             raise RuntimeError("Plugin restart coordinator is not configured")
         return self._launch_semaphore
 
-    def _trim_failures(self, now: float) -> None:
+    def _require_gate_waiter_configuration(self) -> asyncio.BoundedSemaphore:
+        if not self._configured or self._gate_waiter_semaphore is None:
+            raise RuntimeError("Plugin restart coordinator is not configured")
+        return self._gate_waiter_semaphore
+
+    def _reap_inactive_circuits_locked(self, now: float) -> None:
+        for installation_key, circuit in list(self._circuits.items()):
+            self._trim_failures(circuit, now)
+            if (
+                not circuit.failure_times
+                and circuit.open_until <= now
+                and not circuit.half_open_probe_inflight
+            ):
+                self._circuits.pop(installation_key, None)
+
+    def _circuit_for(self, installation_key: str, now: float) -> _CircuitState:
+        circuit = self._circuits.get(installation_key)
+        if circuit is None:
+            self._reap_inactive_circuits_locked(now)
+            if len(self._circuits) >= self._max_tracked_circuits:
+                raise RuntimeError("Plugin restart circuit capacity reached")
+            circuit = _CircuitState(
+                failure_times=collections.deque(maxlen=self._failure_threshold)
+            )
+            self._circuits[installation_key] = circuit
+        return circuit
+
+    def _trim_failures(self, circuit: _CircuitState, now: float) -> None:
         cutoff = now - self._failure_window_seconds
-        while self._failure_times and self._failure_times[0] < cutoff:
-            self._failure_times.popleft()
+        while circuit.failure_times and circuit.failure_times[0] < cutoff:
+            circuit.failure_times.popleft()
 
     def _notify_state_change_locked(self) -> None:
         previous = self._state_changed
@@ -157,111 +208,162 @@ class PluginRestartCoordinator:
         previous.set()
 
     def _release_launch_slot(self) -> None:
-        semaphore = self._require_configuration()
+        semaphore = self._require_launch_configuration()
         if self._active_launches <= 0:
             raise RuntimeError("Plugin restart launch admission underflow")
         self._active_launches -= 1
         semaphore.release()
 
-    async def acquire(self) -> RestartPermit:
+    async def acquire(self, installation_key: str = "__global__") -> RestartPermit:
         """Wait for one launch slot and any active circuit-breaker gate."""
 
-        semaphore = self._require_configuration()
-        await semaphore.acquire()
-        launch_slot_owned = True
-        try:
-            while True:
-                wait_event: asyncio.Event | None = None
-                wait_timeout: float | None = None
+        launch_semaphore = self._require_launch_configuration()
+        gate_waiter_semaphore = self._require_gate_waiter_configuration()
+        installation_key = str(installation_key or "__global__")
+        while True:
+            wait_event: asyncio.Event | None = None
+            wait_timeout: float | None = None
+            async with self._state_lock:
+                now = self._clock()
+                self._reap_inactive_circuits_locked(now)
+                circuit = self._circuits.get(installation_key)
+                if circuit is not None:
+                    self._trim_failures(circuit, now)
+                    if circuit.open_until > now:
+                        wait_event = self._state_changed
+                        wait_timeout = circuit.open_until - now
+                    elif circuit.open_until > 0 and circuit.half_open_probe_inflight:
+                        wait_event = self._state_changed
+
+            if wait_event is not None:
+                await gate_waiter_semaphore.acquire()
+                try:
+                    self._gate_waiters += 1
+                    try:
+                        if wait_timeout is None:
+                            await wait_event.wait()
+                        else:
+                            try:
+                                await asyncio.wait_for(
+                                    wait_event.wait(),
+                                    timeout=wait_timeout,
+                                )
+                            except asyncio.TimeoutError:
+                                pass
+                    finally:
+                        self._gate_waiters -= 1
+                finally:
+                    gate_waiter_semaphore.release()
+                continue
+
+            await launch_semaphore.acquire()
+            launch_slot_owned = True
+            try:
                 async with self._state_lock:
                     now = self._clock()
-                    self._trim_failures(now)
-                    if self._open_until > now:
-                        wait_event = self._state_changed
-                        wait_timeout = self._open_until - now
-                    elif self._open_until > 0:
-                        if self._half_open_probe_inflight:
-                            wait_event = self._state_changed
-                        else:
-                            self._half_open_probe_inflight = True
-                            self._restart_attempts_total += 1
-                            self._active_launches += 1
-                            launch_slot_owned = False
-                            return RestartPermit(self, is_half_open_probe=True)
-                    else:
+                    self._reap_inactive_circuits_locked(now)
+                    circuit = self._circuits.get(installation_key)
+                    if circuit is None:
                         self._restart_attempts_total += 1
                         self._active_launches += 1
                         launch_slot_owned = False
-                        return RestartPermit(self, is_half_open_probe=False)
+                        return RestartPermit(
+                            self,
+                            installation_key=installation_key,
+                            is_half_open_probe=False,
+                        )
+                    self._trim_failures(circuit, now)
+                    if circuit.open_until > now:
+                        continue
+                    elif circuit.open_until > 0 and circuit.half_open_probe_inflight:
+                        continue
+                    elif circuit.open_until > 0:
+                        circuit.half_open_probe_inflight = True
+                        self._restart_attempts_total += 1
+                        self._active_launches += 1
+                        launch_slot_owned = False
+                        return RestartPermit(
+                            self,
+                            installation_key=installation_key,
+                            is_half_open_probe=True,
+                        )
+                    self._restart_attempts_total += 1
+                    self._active_launches += 1
+                    launch_slot_owned = False
+                    return RestartPermit(
+                        self,
+                        installation_key=installation_key,
+                        is_half_open_probe=False,
+                    )
+            finally:
+                if launch_slot_owned:
+                    launch_semaphore.release()
 
-                # Keep the semaphore slot while the circuit is unavailable.
-                # At most max_concurrent_restarts tasks can therefore own a
-                # cooldown timer or wake on a probe state change; all other
-                # supervisors remain asleep in the semaphore FIFO.
-                assert wait_event is not None
-                self._gate_waiters += 1
-                try:
-                    if wait_timeout is None:
-                        await wait_event.wait()
-                    else:
-                        try:
-                            await asyncio.wait_for(
-                                wait_event.wait(),
-                                timeout=wait_timeout,
-                            )
-                        except asyncio.TimeoutError:
-                            pass
-                finally:
-                    self._gate_waiters -= 1
-        finally:
-            if launch_slot_owned:
-                semaphore.release()
-
-    async def record_unadmitted_failure(self) -> None:
+    async def record_unadmitted_failure(
+        self,
+        installation_key: str = "__global__",
+    ) -> None:
         """Count a failed initial launch before restart admission begins."""
 
-        self._require_configuration()
-        await self._record_failure(was_probe=False)
+        self._require_launch_configuration()
+        await self._record_failure(installation_key, was_probe=False)
 
-    async def _record_failure(self, *, was_probe: bool) -> None:
+    async def _discard_empty_circuit(self, installation_key: str) -> None:
+        async with self._state_lock:
+            circuit = self._circuits.get(installation_key)
+            if (
+                circuit is not None
+                and not circuit.failure_times
+                and circuit.open_until == 0.0
+                and not circuit.half_open_probe_inflight
+            ):
+                self._circuits.pop(installation_key, None)
+
+    async def _record_failure(self, installation_key: str, *, was_probe: bool) -> None:
         async with self._state_lock:
             now = self._clock()
-            self._trim_failures(now)
-            self._failure_times.append(now)
+            circuit = self._circuit_for(installation_key, now)
+            self._trim_failures(circuit, now)
+            circuit.failure_times.append(now)
             self._restart_failures_total += 1
             if was_probe:
-                self._half_open_probe_inflight = False
+                circuit.half_open_probe_inflight = False
 
             should_open = (
                 was_probe
-                or self._open_until > now
-                or len(self._failure_times) >= self._failure_threshold
+                or circuit.open_until > now
+                or len(circuit.failure_times) >= self._failure_threshold
             )
             if should_open:
-                was_open = self._open_until > now or self._half_open_probe_inflight
-                self._open_until = max(
-                    self._open_until,
+                was_open = circuit.open_until > now or circuit.half_open_probe_inflight
+                circuit.open_until = max(
+                    circuit.open_until,
                     now + self._circuit_open_seconds,
                 )
-                self._half_open_probe_inflight = False
+                circuit.half_open_probe_inflight = False
                 if not was_open:
                     self._circuit_open_total += 1
                 self._notify_state_change_locked()
 
-    async def _record_probe_success(self) -> None:
+    async def _record_probe_success(self, installation_key: str) -> None:
         async with self._state_lock:
-            if not self._half_open_probe_inflight:
+            now = self._clock()
+            circuit = self._circuit_for(installation_key, now)
+            if not circuit.half_open_probe_inflight:
                 return
-            self._half_open_probe_inflight = False
-            self._open_until = 0.0
-            self._failure_times.clear()
+            circuit.half_open_probe_inflight = False
+            circuit.open_until = 0.0
+            circuit.failure_times.clear()
+            self._circuits.pop(installation_key, None)
             self._notify_state_change_locked()
 
-    async def _abandon_probe(self) -> None:
+    async def _abandon_probe(self, installation_key: str) -> None:
         async with self._state_lock:
-            if not self._half_open_probe_inflight:
+            now = self._clock()
+            circuit = self._circuit_for(installation_key, now)
+            if not circuit.half_open_probe_inflight:
                 return
-            self._half_open_probe_inflight = False
+            circuit.half_open_probe_inflight = False
             self._notify_state_change_locked()
 
     def snapshot(self) -> dict[str, int | float | bool | str]:
@@ -270,10 +372,30 @@ class PluginRestartCoordinator:
         if not self._configured:
             return {"configured": False}
         now = self._clock()
-        self._trim_failures(now)
-        if self._open_until > now:
+        self._reap_inactive_circuits_locked(now)
+        open_circuits = 0
+        half_open_circuits = 0
+        half_open_probe_inflight = False
+        failures_in_window = 0
+        open_remaining_seconds = 0.0
+        for circuit in self._circuits.values():
+            self._trim_failures(circuit, now)
+            failures_in_window += len(circuit.failure_times)
+            open_remaining_seconds = max(
+                open_remaining_seconds,
+                circuit.open_until - now,
+                0.0,
+            )
+            if circuit.open_until > now:
+                open_circuits += 1
+            elif circuit.open_until > 0 or circuit.half_open_probe_inflight:
+                half_open_circuits += 1
+            half_open_probe_inflight = (
+                half_open_probe_inflight or circuit.half_open_probe_inflight
+            )
+        if open_circuits:
             state = "open"
-        elif self._open_until > 0 or self._half_open_probe_inflight:
+        elif half_open_circuits:
             state = "half_open"
         else:
             state = "closed"
@@ -283,10 +405,13 @@ class PluginRestartCoordinator:
             "active_launches": self._active_launches,
             "gate_waiters": self._gate_waiters,
             "max_concurrent_restarts": self._max_concurrent_restarts,
-            "failures_in_window": len(self._failure_times),
+            "failures_in_window": failures_in_window,
             "failure_threshold": self._failure_threshold,
-            "open_remaining_seconds": max(self._open_until - now, 0.0),
-            "half_open_probe_inflight": self._half_open_probe_inflight,
+            "open_remaining_seconds": open_remaining_seconds,
+            "half_open_probe_inflight": half_open_probe_inflight,
+            "open_circuits": open_circuits,
+            "half_open_circuits": half_open_circuits,
+            "tracked_circuits": len(self._circuits),
             "restart_attempts_total": self._restart_attempts_total,
             "restart_failures_total": self._restart_failures_total,
             "circuit_open_total": self._circuit_open_total,

--- a/tests/entities/io/test_protocol.py
+++ b/tests/entities/io/test_protocol.py
@@ -170,7 +170,9 @@ def test_runtime_config_default_wire_payload_is_compatible_with_legacy_policy_sh
     assert "max_pending_registrations" not in wire_payload["worker_policy"]
     assert LegacyPluginWorkerPolicy.model_validate(wire_payload["worker_policy"])
     assert (
-        RuntimeConfig.model_validate(wire_payload).worker_policy.max_pending_registrations
+        RuntimeConfig.model_validate(
+            wire_payload
+        ).worker_policy.max_pending_registrations
         == 1024
     )
     assert (

--- a/tests/entities/io/test_protocol.py
+++ b/tests/entities/io/test_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import pydantic
 from pydantic import ValidationError
 
 from langbot_plugin.entities.io.actions.enums import (
@@ -115,6 +116,7 @@ def test_runtime_config_models_are_frozen_and_instance_scoped():
     assert policy.restart_failure_threshold == 8
     assert policy.restart_failure_window_seconds == 30
     assert policy.restart_circuit_open_seconds == 60
+    assert policy.max_pending_registrations == 1024
     with pytest.raises(ValidationError):
         identity.runtime_id = "runtime-boot-2"
     with pytest.raises(ValidationError):
@@ -128,14 +130,60 @@ def test_runtime_config_models_are_frozen_and_instance_scoped():
         )
 
 
+def test_runtime_config_default_wire_payload_is_compatible_with_legacy_policy_shape():
+    class LegacyPluginWorkerPolicy(pydantic.BaseModel):
+        max_cpus: float
+        max_memory_mb: int
+        max_pids: int
+        max_open_files: int
+        max_file_size_mb: int
+        max_workers: int = 16
+        max_total_cpus: float = 8.0
+        max_total_memory_mb: int = 8192
+        max_installations: int = 10_000
+        max_concurrent_restarts: int = 1
+        restart_failure_threshold: int = 8
+        restart_failure_window_seconds: float = 30.0
+        restart_circuit_open_seconds: float = 60.0
+        require_hard_limits: bool = False
+
+        model_config = pydantic.ConfigDict(extra="forbid", frozen=True)
+
+    config = RuntimeConfig(
+        runtime_identity=RuntimeIdentity(
+            instance_uuid="instance-1",
+            runtime_id="runtime-boot-1",
+        ),
+        worker_policy=PluginWorkerPolicy(
+            max_cpus=1.0,
+            max_memory_mb=512,
+            max_pids=128,
+            max_open_files=256,
+            max_file_size_mb=512,
+            max_pending_registrations=77,
+        ),
+        runtime_profile="shared",
+    )
+
+    wire_payload = config.model_dump()
+
+    assert "max_pending_registrations" not in wire_payload["worker_policy"]
+    assert LegacyPluginWorkerPolicy.model_validate(wire_payload["worker_policy"])
+    assert (
+        RuntimeConfig.model_validate(wire_payload).worker_policy.max_pending_registrations
+        == 1024
+    )
+    assert (
+        config.model_dump(include_pending_registration_limit=True)["worker_policy"][
+            "max_pending_registrations"
+        ]
+        == 77
+    )
+
+
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [
-        (
-            "max_concurrent_restarts",
-            9,
-            "cannot exceed effective worker capacity",
-        ),
         (
             "restart_failure_threshold",
             10_001,
@@ -165,6 +213,40 @@ def test_worker_restart_policy_rejects_unsafe_limits(field, value, message):
 
     with pytest.raises(ValidationError, match=message):
         PluginWorkerPolicy.model_validate(policy)
+
+
+def test_worker_restart_concurrency_is_not_capped_by_aggregate_worker_capacity():
+    policy = PluginWorkerPolicy(
+        max_cpus=1.0,
+        max_memory_mb=512,
+        max_pids=128,
+        max_open_files=256,
+        max_file_size_mb=512,
+        max_workers=1,
+        max_total_cpus=1.0,
+        max_total_memory_mb=512,
+        max_concurrent_restarts=8,
+    )
+
+    assert policy.effective_worker_capacity == 1
+    assert policy.max_concurrent_restarts == 8
+
+
+def test_pending_registration_bound_is_independent_from_worker_capacity():
+    policy = PluginWorkerPolicy(
+        max_cpus=1.0,
+        max_memory_mb=512,
+        max_pids=128,
+        max_open_files=256,
+        max_file_size_mb=512,
+        max_workers=1,
+        max_total_cpus=1.0,
+        max_total_memory_mb=512,
+        max_pending_registrations=3,
+    )
+
+    assert policy.effective_worker_capacity == 1
+    assert policy.max_pending_registrations == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/io/handlers/test_control_handler.py
+++ b/tests/runtime/io/handlers/test_control_handler.py
@@ -455,6 +455,12 @@ async def test_control_handler_get_debug_info_returns_workspace_token():
         "plugin_handlers": 0,
         "legacy_supervisors": 0,
         "installation_runtimes": 0,
+        "installation_states": {
+            "running": 0,
+            "starting": 0,
+            "failed": 0,
+            "disabled": 0,
+        },
         "pending_registrations": 0,
         "restart_coordinator": {"configured": False},
     }

--- a/tests/runtime/plugin/test_installation_manager.py
+++ b/tests/runtime/plugin/test_installation_manager.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import io
 import stat
+import threading
 import zipfile
 from types import SimpleNamespace
 from unittest import mock
@@ -130,7 +131,7 @@ async def test_manager_indexes_same_artifact_installations_by_complete_binding(
     assert context.is_current_installation_binding(binding_b)
 
 
-async def test_instance_worker_capacity_blocks_new_process_but_allows_replacement(
+async def test_desired_state_does_not_reject_on_aggregate_worker_capacity(
     tmp_path,
     monkeypatch,
 ):
@@ -156,7 +157,7 @@ async def test_instance_worker_capacity_blocks_new_process_but_allows_replacemen
         artifact_package=package,
         enabled=True,
     )
-    rejected = await manager.apply_plugin_installation(second, enabled=True)
+    second_started = await manager.apply_plugin_installation(second, enabled=True)
     replacement = await manager.apply_plugin_installation(
         _binding(
             "installation-a",
@@ -168,33 +169,53 @@ async def test_instance_worker_capacity_blocks_new_process_but_allows_replacemen
     )
 
     assert started["state"] == "starting"
-    assert rejected["error_code"] == "worker_capacity_exceeded"
+    assert second_started["state"] == "starting"
     assert replacement["state"] == "starting"
 
-    with pytest.raises(ValueError, match="aggregate worker capacity"):
-        await manager.reconcile_plugin_installations(
-            (
-                PluginInstallationDesiredState(binding=first),
-                PluginInstallationDesiredState(binding=second),
-            )
+    reconciled = await manager.reconcile_plugin_installations(
+        (
+            PluginInstallationDesiredState(
+                binding=first.model_copy(update={"runtime_revision": 2})
+            ),
+            PluginInstallationDesiredState(binding=second),
         )
+    )
+    assert reconciled["applied"] == ["installation-a", "installation-b"]
 
 
-async def test_installation_lifecycle_serializes_dependency_preparation_across_tenants(
+async def test_installation_lifecycle_runs_dependency_preparation_concurrently_bounded(
     tmp_path,
     monkeypatch,
 ):
-    _, manager = _manager(tmp_path)
+    context = RuntimeContext()
+    context.bind_runtime(
+        RuntimeIdentity(instance_uuid="instance-1", runtime_id="runtime-1"),
+        PluginWorkerPolicy(
+            max_cpus=1.0,
+            max_memory_mb=512,
+            max_pids=128,
+            max_open_files=256,
+            max_file_size_mb=512,
+            max_concurrent_restarts=2,
+            require_hard_limits=True,
+        ),
+        "shared",
+    )
+    manager = PluginManager(context)
+    manager.artifact_store = PluginArtifactStore(tmp_path / "plugin-runtime")
+    context.plugin_mgr = manager
     package = _package(requirements="third-party-demo==1.0.0\n")
     digest = hashlib.sha256(package).hexdigest()
     first = _binding("installation-a", digest, workspace_uuid="workspace-a")
     second = _binding("installation-b", digest, workspace_uuid="workspace-b")
+    third = _binding("installation-c", digest, workspace_uuid="workspace-c")
     await manager.apply_plugin_installation(
         first,
         artifact_package=package,
         enabled=False,
     )
     await manager.apply_plugin_installation(second, enabled=False)
+    await manager.apply_plugin_installation(third, enabled=False)
 
     first_prepare_started = asyncio.Event()
     release_prepare = asyncio.Event()
@@ -236,12 +257,270 @@ async def test_installation_lifecycle_serializes_dependency_preparation_across_t
     second_task = asyncio.create_task(
         manager.apply_plugin_installation(second, enabled=True)
     )
+
+    async def wait_for_two_prepares():
+        while active_prepares < 2:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_for_two_prepares(), timeout=1)
+    third_task = asyncio.create_task(
+        manager.apply_plugin_installation(third, enabled=True)
+    )
     await asyncio.sleep(0)
 
-    assert active_prepares == 1
+    assert active_prepares == 2
+    assert not third_task.done()
     release_prepare.set()
-    await asyncio.gather(first_task, second_task)
-    assert max_active_prepares == 1
+    await asyncio.gather(first_task, second_task, third_task)
+    assert max_active_prepares == 2
+
+
+async def test_installation_lock_waiter_does_not_consume_lifecycle_capacity(
+    tmp_path,
+    monkeypatch,
+):
+    context = RuntimeContext()
+    context.bind_runtime(
+        RuntimeIdentity(instance_uuid="instance-1", runtime_id="runtime-1"),
+        PluginWorkerPolicy(
+            max_cpus=1.0,
+            max_memory_mb=512,
+            max_pids=128,
+            max_open_files=256,
+            max_file_size_mb=512,
+            max_concurrent_restarts=2,
+            require_hard_limits=True,
+        ),
+        "shared",
+    )
+    manager = PluginManager(context)
+    manager.artifact_store = PluginArtifactStore(tmp_path / "plugin-runtime")
+    context.plugin_mgr = manager
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    first = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    other = _binding("installation-b", digest, workspace_uuid="workspace-b")
+    entered = asyncio.Event()
+    other_entered = asyncio.Event()
+    release = asyncio.Event()
+
+    original = manager._apply_plugin_installation_locked
+
+    async def blocked(binding, **kwargs):
+        if binding.installation_uuid == "installation-a" and not entered.is_set():
+            entered.set()
+            await release.wait()
+        elif binding.installation_uuid == "installation-b":
+            other_entered.set()
+        return await original(binding, **kwargs)
+
+    monkeypatch.setattr(manager, "_apply_plugin_installation_locked", blocked)
+    first_task = asyncio.create_task(
+        manager.apply_plugin_installation(
+            first,
+            artifact_package=package,
+            enabled=False,
+        )
+    )
+    await entered.wait()
+    waiter = asyncio.create_task(
+        manager.apply_plugin_installation(first, enabled=False)
+    )
+    other_task = asyncio.create_task(
+        manager.apply_plugin_installation(other, enabled=False)
+    )
+
+    await asyncio.wait_for(other_entered.wait(), timeout=1)
+    release.set()
+    await asyncio.gather(first_task, waiter, other_task)
+
+
+async def test_installation_lock_entry_survives_waiter_handoff(tmp_path, monkeypatch):
+    _, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    binding = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    original = manager._apply_plugin_installation_locked
+
+    async def blocked(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entered.set()
+            await release.wait()
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "_apply_plugin_installation_locked", blocked)
+    first = asyncio.create_task(
+        manager.apply_plugin_installation(
+            binding,
+            artifact_package=package,
+            enabled=False,
+        )
+    )
+    await entered.wait()
+    second = asyncio.create_task(
+        manager.apply_plugin_installation(binding, enabled=False)
+    )
+    await asyncio.sleep(0)
+
+    assert calls == 1
+    release.set()
+    await asyncio.gather(first, second)
+
+    assert calls == 2
+    assert manager._installation_operation_locks == {}
+
+
+async def test_reconcile_absent_removal_serializes_with_direct_apply_for_same_installation(
+    tmp_path,
+    monkeypatch,
+):
+    _, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    old_binding = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    new_binding = old_binding.model_copy(update={"runtime_revision": 2})
+    await manager.apply_plugin_installation(
+        old_binding,
+        artifact_package=package,
+        enabled=False,
+    )
+    revoke_started = asyncio.Event()
+    release_revoke = asyncio.Event()
+    original_revoke = manager._revoke_installation_runtime
+
+    async def blocked_revoke(binding):
+        revoke_started.set()
+        await release_revoke.wait()
+        await original_revoke(binding)
+
+    monkeypatch.setattr(manager, "_revoke_installation_runtime", blocked_revoke)
+
+    reconcile_task = asyncio.create_task(manager.reconcile_plugin_installations(()))
+    await revoke_started.wait()
+    direct_apply = asyncio.create_task(
+        manager.apply_plugin_installation(new_binding, enabled=False)
+    )
+    await asyncio.sleep(0)
+
+    assert not direct_apply.done()
+
+    release_revoke.set()
+    await reconcile_task
+    result = await asyncio.wait_for(direct_apply, timeout=1)
+
+    assert result["state"] == "disabled"
+    assert manager._active_binding_by_uuid["installation-a"] == new_binding
+
+
+async def test_reconcile_watermark_gc_does_not_delete_newer_direct_state(
+    tmp_path,
+    monkeypatch,
+):
+    context, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    old_binding = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    new_binding = old_binding.model_copy(update={"runtime_revision": 2})
+    await manager.apply_plugin_installation(
+        old_binding,
+        artifact_package=package,
+        enabled=False,
+    )
+    await manager.remove_plugin_installation(old_binding)
+    gc_started = asyncio.Event()
+    release_gc = asyncio.Event()
+    original_gc = context.reconcile_installation_watermarks
+
+    async def blocked_gc(authoritative_bindings):
+        gc_started.set()
+        await release_gc.wait()
+        original_gc(authoritative_bindings)
+
+    monkeypatch.setattr(manager, "_reconcile_installation_watermarks_locked", blocked_gc)
+
+    reconcile_task = asyncio.create_task(manager.reconcile_plugin_installations(()))
+    await gc_started.wait()
+    direct_apply = asyncio.create_task(
+        manager.apply_plugin_installation(new_binding, enabled=False)
+    )
+    await asyncio.sleep(0)
+
+    assert not direct_apply.done()
+
+    release_gc.set()
+    await reconcile_task
+    await asyncio.wait_for(direct_apply, timeout=1)
+
+    assert context.is_current_installation_binding(new_binding)
+    with pytest.raises(ValueError, match="stale"):
+        await manager.apply_plugin_installation(old_binding, enabled=False)
+
+
+def test_pending_registration_capability_uses_independent_policy_bound(tmp_path):
+    context, manager = _manager(tmp_path)
+    context.worker_policy = context.worker_policy.model_copy(
+        update={
+            "max_workers": 1,
+            "max_total_cpus": 1.0,
+            "max_total_memory_mb": 512,
+            "max_pending_registrations": 2,
+        }
+    )
+    binding = _binding("installation-a", "a" * 64, workspace_uuid="workspace-a")
+    context.activate_installation_binding(binding)
+
+    issued = [
+        manager._issue_registration_capability(
+            plugin_author="tester",
+            plugin_name="demo",
+            plugin_path="/verified/code",
+            binding=binding,
+        )
+        for _ in range(2)
+    ]
+
+    assert len(issued) == 2
+    with pytest.raises(RuntimeError, match="capacity reached"):
+        manager._issue_registration_capability(
+            plugin_author="tester",
+            plugin_name="demo",
+            plugin_path="/verified/code",
+            binding=binding,
+        )
+
+
+async def test_authoritative_reconcile_reclaims_inactive_historical_watermarks(
+    tmp_path,
+):
+    context, manager = _manager(tmp_path)
+    context.worker_policy = context.worker_policy.model_copy(
+        update={"max_installations": 1}
+    )
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    removed_binding = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    next_binding = _binding("installation-b", digest, workspace_uuid="workspace-b")
+
+    await manager.apply_plugin_installation(
+        removed_binding,
+        artifact_package=package,
+        enabled=False,
+    )
+    await manager.remove_plugin_installation(removed_binding)
+    with pytest.raises(ValueError, match="fence capacity"):
+        await manager.apply_plugin_installation(next_binding, enabled=False)
+
+    result = await manager.reconcile_plugin_installations(())
+
+    assert result["applied"] == []
+    await manager.apply_plugin_installation(next_binding, enabled=False)
+    assert context.is_current_installation_binding(next_binding)
 
 
 async def test_new_revision_revokes_old_binding_and_stale_reapply_fails(tmp_path):
@@ -500,6 +779,69 @@ async def test_reconcile_reports_dependency_failure_without_worker_launch(
     assert manager.installation_runtimes[binding].launch_task is None
 
 
+async def test_reconcile_batch_failure_cancels_and_joins_sibling_mutations(
+    tmp_path,
+    monkeypatch,
+):
+    context = RuntimeContext()
+    context.bind_runtime(
+        RuntimeIdentity(instance_uuid="instance-1", runtime_id="runtime-1"),
+        PluginWorkerPolicy(
+            max_cpus=1.0,
+            max_memory_mb=512,
+            max_pids=128,
+            max_open_files=256,
+            max_file_size_mb=512,
+            max_concurrent_restarts=2,
+            require_hard_limits=True,
+        ),
+        "shared",
+    )
+    manager = PluginManager(context)
+    manager.artifact_store = PluginArtifactStore(tmp_path / "plugin-runtime")
+    context.plugin_mgr = manager
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    first = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    second = _binding("installation-b", digest, workspace_uuid="workspace-b")
+    await manager.apply_plugin_installation(
+        first,
+        artifact_package=package,
+        enabled=False,
+    )
+    await manager.apply_plugin_installation(second, enabled=False)
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    original_apply = manager._apply_plugin_installation_locked
+
+    async def apply_or_fail(binding, **kwargs):
+        if binding.installation_uuid == "installation-a":
+            raise RuntimeError("forced partial failure")
+        if binding.installation_uuid == "installation-b":
+            sibling_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+        return await original_apply(binding, **kwargs)
+
+    monkeypatch.setattr(manager, "_apply_plugin_installation_locked", apply_or_fail)
+
+    with pytest.raises(RuntimeError, match="forced partial failure"):
+        await manager.reconcile_plugin_installations(
+            (
+                PluginInstallationDesiredState(binding=first),
+                PluginInstallationDesiredState(binding=second),
+            )
+        )
+
+    assert sibling_started.is_set()
+    assert sibling_cancelled.is_set()
+    assert manager._installation_operation_locks == {}
+    assert not manager._reconcile_operation_lock.locked()
+
+
 async def test_oss_desired_state_keeps_legacy_worker_without_shared_environment(
     tmp_path,
     monkeypatch,
@@ -642,6 +984,206 @@ async def test_installation_worker_ready_timeout_cancels_hung_process(
         await manager._run_installation_worker_attempt(runtime, None)
 
     assert cancelled.is_set()
+
+
+async def test_first_installation_launches_are_globally_bounded(
+    tmp_path,
+    monkeypatch,
+):
+    context, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    first = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    second = _binding("installation-b", digest, workspace_uuid="workspace-b")
+    await manager.apply_plugin_installation(
+        first,
+        artifact_package=package,
+        enabled=False,
+    )
+    await manager.apply_plugin_installation(second, enabled=False)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    started: list[str] = []
+
+    async def launch(candidate):
+        started.append(candidate.installation_uuid)
+        runtime = manager.installation_runtimes[candidate]
+        runtime.ready_event.set()
+        if candidate == first:
+            first_started.set()
+            await release_first.wait()
+        runtime.enabled = False
+
+    monkeypatch.setattr(manager, "launch_plugin_installation", launch)
+
+    first_runtime = manager.installation_runtimes[first]
+    second_runtime = manager.installation_runtimes[second]
+    first_runtime.enabled = True
+    second_runtime.enabled = True
+    manager._schedule_installation_worker(first_runtime)
+    await first_started.wait()
+    manager._schedule_installation_worker(second_runtime)
+    await asyncio.sleep(0)
+
+    assert started == ["installation-a"]
+    release_first.set()
+    await asyncio.wait_for(second_runtime.launch_task, timeout=1)
+
+    assert started == ["installation-a", "installation-b"]
+    await manager._stop_installation_worker(first_runtime)
+    await manager._stop_installation_worker(second_runtime)
+
+
+async def test_unrelated_artifact_publications_do_not_block_each_other(
+    tmp_path,
+    monkeypatch,
+):
+    context, manager = _manager(tmp_path)
+    first_package = _package(body="VALUE = 1")
+    second_package = _package(body="VALUE = 2")
+    first_digest = hashlib.sha256(first_package).hexdigest()
+    second_digest = hashlib.sha256(second_package).hexdigest()
+    first = _binding("installation-a", first_digest, workspace_uuid="workspace-a")
+    second = _binding("installation-b", second_digest, workspace_uuid="workspace-b")
+    install_started = threading.Event()
+    release_install = threading.Event()
+    original_install = manager.artifact_store.install_package
+
+    def install_package(package, expected_digest):
+        if expected_digest == first_digest:
+            install_started.set()
+            release_install.wait(timeout=5)
+        return original_install(package, expected_digest)
+
+    monkeypatch.setattr(manager.artifact_store, "install_package", install_package)
+
+    first_task = asyncio.create_task(
+        manager.apply_plugin_installation(
+            first,
+            artifact_package=first_package,
+            enabled=False,
+        )
+    )
+    async def wait_for_install_started():
+        while not install_started.is_set():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_for_install_started(), timeout=1)
+    second_task = asyncio.create_task(
+        manager.apply_plugin_installation(
+            second,
+            artifact_package=second_package,
+            enabled=False,
+        )
+    )
+
+    second_result = await asyncio.wait_for(second_task, timeout=1)
+
+    release_install.set()
+    await asyncio.wait_for(first_task, timeout=1)
+    assert second_result["state"] == "disabled"
+    assert context.is_current_installation_binding(second)
+
+
+async def test_identical_artifact_publication_is_deduped(
+    tmp_path,
+    monkeypatch,
+):
+    _, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    first = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    second = _binding("installation-b", digest, workspace_uuid="workspace-b")
+    install_calls = 0
+    original_install = manager.artifact_store.install_package
+
+    def install_package(package, expected_digest):
+        nonlocal install_calls
+        install_calls += 1
+        return original_install(package, expected_digest)
+
+    monkeypatch.setattr(manager.artifact_store, "install_package", install_package)
+
+    await asyncio.gather(
+        manager.apply_plugin_installation(
+            first,
+            artifact_package=package,
+            enabled=False,
+        ),
+        manager.apply_plugin_installation(
+            second,
+            artifact_package=package,
+            enabled=False,
+        ),
+    )
+
+    assert install_calls == 1
+
+
+def test_runtime_health_reports_identity_free_installation_state_counts(tmp_path):
+    context, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+
+    for installation_uuid, state in (
+        ("installation-running", "running"),
+        ("installation-starting", "starting"),
+        ("installation-failed", "failed"),
+        ("installation-disabled", "disabled"),
+    ):
+        binding = _binding(installation_uuid, digest, workspace_uuid=installation_uuid)
+        artifact = manager.artifact_store.install_package(package, digest)
+        paths = manager.artifact_store.ensure_installation_paths(binding)
+        manager._installations[binding] = manager_module.PluginInstallationRuntime(
+            binding=binding,
+            artifact=artifact,
+            paths=paths,
+            enabled=state != "disabled",
+            state=state,
+        )
+
+    stats = context.get_runtime_resource_stats()
+
+    assert stats["installation_states"] == {
+        "running": 1,
+        "starting": 1,
+        "failed": 1,
+        "disabled": 1,
+    }
+    assert "installation-running" not in str(stats)
+
+
+async def test_installation_launch_failure_is_recorded_locally(
+    tmp_path,
+    monkeypatch,
+):
+    _, manager = _manager(tmp_path)
+    package = _package()
+    digest = hashlib.sha256(package).hexdigest()
+    binding = _binding("installation-a", digest, workspace_uuid="workspace-a")
+    await manager.apply_plugin_installation(
+        binding,
+        artifact_package=package,
+        enabled=False,
+    )
+    runtime = manager.installation_runtimes[binding]
+    runtime.enabled = True
+
+    async def launch(_candidate):
+        raise RuntimeError("worker crashed before ready")
+
+    monkeypatch.setattr(manager, "launch_plugin_installation", launch)
+    permit = await manager.restart_coordinator.acquire(binding.installation_uuid)
+
+    try:
+        with pytest.raises(RuntimeError, match="worker crashed"):
+            await manager._run_installation_worker_attempt(runtime, permit)
+    finally:
+        await permit.abandon()
+
+    assert runtime.state == "failed"
+    assert runtime.error_code == "worker_launch_failed"
+    assert "worker crashed before ready" in str(runtime.error_message)
 
 
 async def test_installation_supervisor_does_not_restart_fenced_worker(

--- a/tests/runtime/plugin/test_installation_manager.py
+++ b/tests/runtime/plugin/test_installation_manager.py
@@ -442,7 +442,9 @@ async def test_reconcile_watermark_gc_does_not_delete_newer_direct_state(
         await release_gc.wait()
         original_gc(authoritative_bindings)
 
-    monkeypatch.setattr(manager, "_reconcile_installation_watermarks_locked", blocked_gc)
+    monkeypatch.setattr(
+        manager, "_reconcile_installation_watermarks_locked", blocked_gc
+    )
 
     reconcile_task = asyncio.create_task(manager.reconcile_plugin_installations(()))
     await gc_started.wait()
@@ -1064,6 +1066,7 @@ async def test_unrelated_artifact_publications_do_not_block_each_other(
             enabled=False,
         )
     )
+
     async def wait_for_install_started():
         while not install_started.is_set():
             await asyncio.sleep(0)

--- a/tests/runtime/plugin/test_restart_coordinator.py
+++ b/tests/runtime/plugin/test_restart_coordinator.py
@@ -57,6 +57,70 @@ async def test_restart_launches_are_globally_bounded():
     assert coordinator.snapshot()["active_launches"] == 0
 
 
+async def test_failure_circuit_is_scoped_to_installation():
+    coordinator = PluginRestartCoordinator()
+    coordinator.configure(
+        _policy(
+            max_concurrent_restarts=2,
+            restart_failure_threshold=1,
+            restart_circuit_open_seconds=10.0,
+        )
+    )
+
+    failed = await coordinator.acquire("installation-a")
+    await failed.record_failure()
+
+    blocked_same_installation = asyncio.create_task(
+        coordinator.acquire("installation-a")
+    )
+    await _wait_until(lambda: coordinator.snapshot()["gate_waiters"] == 1)
+    assert not blocked_same_installation.done()
+
+    other_installation = await asyncio.wait_for(
+        coordinator.acquire("installation-b"),
+        timeout=1,
+    )
+
+    snapshot = coordinator.snapshot()
+    assert snapshot["state"] == "open"
+    assert snapshot["open_circuits"] == 1
+    assert snapshot["active_launches"] == 1
+
+    blocked_same_installation.cancel()
+    await asyncio.gather(blocked_same_installation, return_exceptions=True)
+    await other_installation.abandon()
+
+
+async def test_open_installation_circuit_wait_does_not_hold_launch_slot():
+    coordinator = PluginRestartCoordinator()
+    coordinator.configure(
+        _policy(
+            max_concurrent_restarts=1,
+            restart_failure_threshold=1,
+            restart_circuit_open_seconds=10.0,
+        )
+    )
+
+    failed = await coordinator.acquire("installation-a")
+    await failed.record_failure()
+
+    blocked_same_installation = asyncio.create_task(
+        coordinator.acquire("installation-a")
+    )
+    await _wait_until(lambda: coordinator.snapshot()["gate_waiters"] == 1)
+
+    other_installation = await asyncio.wait_for(
+        coordinator.acquire("installation-b"),
+        timeout=1,
+    )
+
+    assert coordinator.snapshot()["active_launches"] == 1
+
+    blocked_same_installation.cancel()
+    await asyncio.gather(blocked_same_installation, return_exceptions=True)
+    await other_installation.abandon()
+
+
 async def test_failure_threshold_opens_circuit_and_one_probe_closes_it():
     coordinator = PluginRestartCoordinator()
     coordinator.configure(_policy())
@@ -144,11 +208,10 @@ async def test_cancelled_acquire_does_not_leak_launch_slot():
     )
     await coordinator._state_lock.acquire()
     acquire_task = asyncio.create_task(coordinator.acquire())
-    await _wait_until(
-        lambda: (
-            coordinator._launch_semaphore is not None
-            and coordinator._launch_semaphore.locked()
-        )
+    await asyncio.sleep(0)
+    assert (
+        coordinator._launch_semaphore is not None
+        and not coordinator._launch_semaphore.locked()
     )
 
     acquire_task.cancel()
@@ -216,6 +279,67 @@ async def test_cancelled_probe_abandon_finishes_state_transition():
     assert coordinator.snapshot()["half_open_probe_inflight"] is False
     replacement = await asyncio.wait_for(coordinator.acquire(), timeout=1)
     await replacement.abandon()
+
+
+async def test_closed_installation_circuits_are_garbage_collected():
+    coordinator = PluginRestartCoordinator()
+    coordinator.configure(
+        _policy(
+            max_concurrent_restarts=1,
+            restart_failure_threshold=1,
+        )
+    )
+    failed = await coordinator.acquire("installation-a")
+    await failed.record_failure()
+    probe = await asyncio.wait_for(coordinator.acquire("installation-a"), timeout=1)
+
+    probe.mark_ready()
+    await probe.mark_stable()
+
+    assert coordinator.snapshot()["tracked_circuits"] == 0
+
+
+async def test_expired_subthreshold_circuit_entries_are_garbage_collected():
+    now = 100.0
+    coordinator = PluginRestartCoordinator(clock=lambda: now)
+    coordinator.configure(
+        _policy(
+            restart_failure_threshold=3,
+            restart_failure_window_seconds=0.5,
+            restart_circuit_open_seconds=10.0,
+        )
+    )
+
+    failed = await coordinator.acquire("installation-a")
+    await failed.record_failure()
+    assert coordinator.snapshot()["tracked_circuits"] == 1
+
+    now += 1.0
+
+    assert coordinator.snapshot()["tracked_circuits"] == 0
+    assert coordinator.snapshot()["failures_in_window"] == 0
+
+
+async def test_restart_circuit_map_is_bounded_by_independent_control_limit():
+    coordinator = PluginRestartCoordinator()
+    coordinator.configure(
+        _policy(
+            max_pending_registrations=2,
+            restart_failure_threshold=3,
+            restart_failure_window_seconds=60.0,
+        )
+    )
+
+    for installation_uuid in ("installation-a", "installation-b"):
+        permit = await coordinator.acquire(installation_uuid)
+        await permit.record_failure()
+
+    permit = await coordinator.acquire("installation-c")
+    with pytest.raises(RuntimeError, match="circuit capacity"):
+        await permit.record_failure()
+    await permit.abandon()
+
+    assert coordinator.snapshot()["tracked_circuits"] == 2
 
 
 def test_restart_policy_is_immutable_after_configuration():


### PR DESCRIPTION
## Summary
- remove the global aggregate worker cap from shared desired-state placement
- isolate restart concurrency and circuit breakers per installation
- bound installation lifecycle/fence bookkeeping without consuming capacity while waiting on per-installation locks
- preserve standalone protocol compatibility while carrying trusted workspace bindings

## Verification
- `uv run pytest -q`: 1148 passed
- `uv run ruff check src tests`: passed
- `uv build`: sdist and wheel built
- isolated wheel smoke: passed

`.agents/` and `.codex/` are intentionally excluded.