### PR TITLE
fix(runtime): pass absolute worker RPC storage path

### DIFF
--- a/src/langbot_plugin/runtime/plugin/worker_launcher.py
+++ b/src/langbot_plugin/runtime/plugin/worker_launcher.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from typing import Literal
 
 from langbot_plugin.entities.io.context import InstallationBinding, PluginWorkerPolicy
+from langbot_plugin.runtime import bounded_executor
+from langbot_plugin.runtime.helper import pkgmgr as pkgmgr_helper
 from langbot_plugin.runtime.io.controllers.stdio import (
     client as stdio_client_controller,
 )
@@ -25,15 +27,12 @@ from langbot_plugin.runtime.plugin.dependency_environment import (
     PluginDependencyEnvironment,
     PluginDependencyEnvironmentStore,
 )
-from langbot_plugin.runtime.helper import pkgmgr as pkgmgr_helper
-from langbot_plugin.runtime import bounded_executor
 from langbot_plugin.runtime.security import (
     PLUGIN_FILE_STORAGE_DIR_ENV,
     PLUGIN_REGISTRATION_CAPABILITY_ENV,
     PLUGIN_RUNTIME_PROFILE_ENV,
 )
 from langbot_plugin.utils.platform import get_platform
-
 
 _READONLY_SYSTEM_MOUNTS = (
     "/bin",
@@ -142,7 +141,7 @@ class PluginWorkerLauncher:
             ],
             env={
                 PLUGIN_FILE_STORAGE_DIR_ENV: str(
-                    launch_spec.paths.root_path / "rpc-transfer"
+                    (launch_spec.paths.root_path / "rpc-transfer").resolve()
                 ),
                 PLUGIN_REGISTRATION_CAPABILITY_ENV: (
                     launch_spec.registration_capability

--- a/tests/runtime/plugin/test_worker_launcher.py
+++ b/tests/runtime/plugin/test_worker_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import hashlib
 import io
 import pathlib
@@ -11,15 +12,15 @@ import pytest
 
 from langbot_plugin.cli.commands.runplugin import should_load_artifact_dotenv
 from langbot_plugin.entities.io.context import InstallationBinding, PluginWorkerPolicy
-from langbot_plugin.runtime.plugin.artifact import PluginArtifactStore
+from langbot_plugin.runtime.plugin import worker_launcher as worker_launcher_module
+from langbot_plugin.runtime.plugin.artifact import PluginArtifact, PluginArtifactStore
 from langbot_plugin.runtime.plugin.dependency_environment import (
     DependencyEnvironmentStaging,
     PluginDependencyEnvironment,
 )
-from langbot_plugin.runtime.plugin import worker_launcher as worker_launcher_module
 from langbot_plugin.runtime.plugin.worker_launcher import (
-    PluginWorkerLaunchSpec,
     PluginWorkerLauncher,
+    PluginWorkerLaunchSpec,
 )
 from langbot_plugin.runtime.security import (
     PLUGIN_FILE_STORAGE_DIR_ENV,
@@ -332,6 +333,50 @@ def test_launcher_builds_profile_specific_controllers(tmp_path):
         PLUGIN_REGISTRATION_CAPABILITY_ENV: "capability-value",
         PLUGIN_RUNTIME_PROFILE_ENV: "oss_dev",
     }
+
+
+def test_oss_launcher_passes_absolute_rpc_storage_when_store_base_is_relative(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    store = PluginArtifactStore()
+    binding = InstallationBinding(
+        instance_uuid="instance-1",
+        runtime_revision=1,
+        artifact_digest="0" * 64,
+        installation_uuid="installation-1",
+        workspace_uuid="workspace-1",
+        placement_generation=1,
+    )
+    paths = store.ensure_installation_paths(binding)
+    artifact_code = tmp_path / "data/plugin-runtime/artifacts/sha256/digest/code"
+    artifact_code.mkdir(parents=True)
+    artifact = PluginArtifact(
+        digest="0" * 64,
+        root_path=artifact_code.parent,
+        code_path=artifact_code,
+        plugin_author="author",
+        plugin_name="plugin",
+        plugin_version="1.0.0",
+    )
+    launch_spec = dataclasses.replace(
+        _launch_spec(tmp_path),
+        artifact=artifact,
+        paths=paths,
+    )
+    launcher = PluginWorkerLauncher(
+        nsjail_path="",
+        cgroup_v2_available=False,
+        platform="linux",
+    )
+    launcher.configure(_policy(require_hard_limits=False), "oss_dev")
+
+    controller = launcher.create_controller(launch_spec)
+    storage_path = pathlib.Path(controller.env[PLUGIN_FILE_STORAGE_DIR_ENV])
+
+    assert storage_path.is_absolute()
+    assert storage_path == (paths.root_path / "rpc-transfer").resolve()
 
 
 async def test_prepare_dependency_environment_delegates_only_in_shared_profile(


### PR DESCRIPTION
## Summary

- resolve installation-private RPC transfer storage to an absolute path before crossing into the worker process
- prevent the worker CWD from rebasing a relative default store path beneath the immutable artifact tree
- add a regression using the default relative artifact-store base and a distinct artifact CWD

## Verification

- RED: new regression failed because the launcher emitted `data/plugin-runtime/installations/.../rpc-transfer`
- GREEN: focused launcher tests passed
- full SDK suite: 1153 passed
- Ruff and `git diff --check` passed

Follow-up to #117.